### PR TITLE
Add test to ensure config path is not overwritten

### DIFF
--- a/cmd/poller/options/options_test.go
+++ b/cmd/poller/options/options_test.go
@@ -1,0 +1,15 @@
+package options
+
+import "testing"
+
+// Make sure that if --config is passed on the cmdline that it is not overwritten
+// See https://github.com/NetApp/harvest/issues/28
+func TestConfigPath(t *testing.T) {
+	want := "foo"
+	options := Options{Config: want}
+	SetPathsAndHostname(&options)
+
+	if options.Config != want {
+		t.Fatalf(`options.Config expected=[%q], actual was=[%q]`, want, options.Config)
+	}
+}


### PR DESCRIPTION
This test is in response to issue #28.

Reverted the [fix](https://github.com/NetApp/harvest/commit/abd1517e347f091d535ae71decfe8b84b211e0c1) and verified the test fails with the following output.

```
 --- FAIL: TestConfigPath (0.00s)
    options_test.go:13: options.Config expected=["foo"], actual was=["harvest.yml"]
```

Apply the fix and test passes.