### PR TITLE
fix issue when label is treated as a metric

### DIFF
--- a/cmd/collectors/zapi/collector/zapi.go
+++ b/cmd/collectors/zapi/collector/zapi.go
@@ -286,11 +286,11 @@ func (me *Zapi) PollData() (*matrix.Matrix, error) {
 					count += 1
 				}
 			} else {
-				me.Logger.Debug().Msgf("%sskipped (%s) with value (%s): not in metric or label cache%s", color.Blue, key, value, color.End)
+				me.Logger.Debug().Msgf(" > %sskipped (%s) with value (%s): not in metric or label cache%s", color.Blue, key, value, color.End)
 				skipped += 1
 			}
 		} else {
-			logger.Trace(me.Prefix, "%sskippped (%s) with no value%s", color.Cyan, key, color.End)
+			me.Logger.Debug().Msgf(" > %sskippped (%s) with no value%s", color.Cyan, key, color.End)
 			skipped += 1
 		}
 


### PR DESCRIPTION
fix #66 

label disappears because the collector tries to store an incoming label value as a numeric metric (since both have the same name, e.g. "status" in the case reported).

currently a workaround, leaving a better solution for the future.