### PR TITLE
Handle special characters in passwords

### DIFF
--- a/cmd/tools/doctor/doctor_test.go
+++ b/cmd/tools/doctor/doctor_test.go
@@ -1,10 +1,7 @@
 package doctor
 
 import (
-	"fmt"
 	"goharvest2/pkg/conf"
-	"gopkg.in/yaml.v3"
-	"io/ioutil"
 	"strings"
 	"testing"
 )
@@ -31,34 +28,31 @@ func assertRedacted(t *testing.T, input, redacted string) {
 
 func TestConfigToStruct(t *testing.T) {
 	path := "testConfig.yml"
-	contents, err := ioutil.ReadFile(path)
+	err := conf.LoadHarvestConfig(path)
 	if err != nil {
-		fmt.Printf("error reading config file %+v\n", err)
 		return
 	}
-	harvestConfig := &conf.HarvestConfig{}
-	err = yaml.Unmarshal(contents, harvestConfig)
-	if err != nil {
-		fmt.Printf("error reading config file=[%s] %+v\n", path, err)
-		return
+	if conf.Config.Defaults.Password != "123#abc" {
+		t.Fatalf(`expected harvestConfig.Defaults.Password to be 123#abc, actual=[%+v]`,
+			conf.Config.Defaults.Addr)
 	}
 
-	if harvestConfig.Defaults.Addr != nil {
+	if conf.Config.Defaults.Addr != nil {
 		t.Fatalf(`expected harvestConfig.Defaults.Addr to be nil, actual=[%+v]`,
-			harvestConfig.Defaults.Addr)
+			conf.Config.Defaults.Addr)
 	}
-	if len(*harvestConfig.Defaults.Collectors) != 2 {
+	if len(*conf.Config.Defaults.Collectors) != 2 {
 		t.Fatalf(`expected two default collectors, actual=%+v`,
-			*harvestConfig.Defaults.Collectors)
+			*conf.Config.Defaults.Collectors)
 	}
 
-	allowedRegexes := (*harvestConfig.Exporters)["influxy"].AllowedAddrsRegex
+	allowedRegexes := (*conf.Config.Exporters)["influxy"].AllowedAddrsRegex
 	if (*allowedRegexes)[0] != "^192.168.0.\\d+$" {
 		t.Fatalf(`expected allow_addrs_regex to be ^192.168.0.\d+$ actual=%+v`,
 			(*allowedRegexes)[0])
 	}
 
-	collectors := (*harvestConfig.Pollers)["infinity2"].Collectors
+	collectors := (*conf.Config.Pollers)["infinity2"].Collectors
 	if (*collectors)[0] != "Zapi" {
 		t.Fatalf(`expected infinity2 collectors to contain Zapi actual=%+v`,
 			(*collectors)[0])

--- a/cmd/tools/doctor/testConfig.yml
+++ b/cmd/tools/doctor/testConfig.yml
@@ -31,7 +31,7 @@ Defaults:
     - ZapiPerf
   use_insecure_tls: false
   username: myuser
-  password: mypasw
+  password: 123#abc
 
 Pollers:
   # this is a special/optional poller that provides stats about harvest itself

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -9,12 +9,58 @@ import (
 	"goharvest2/pkg/errors"
 	"goharvest2/pkg/tree"
 	"goharvest2/pkg/tree/node"
+	"gopkg.in/yaml.v3"
+	"io/ioutil"
 	"os"
 	"path"
 )
 
-func LoadConfig(config_fp string) (*node.Node, error) {
-	return tree.Import("yaml", config_fp)
+// LoadConfig loads the config info from harvest.yml
+func LoadConfig(configPath string) (*node.Node, error) {
+	configNode, err := tree.Import("yaml", configPath)
+	if configNode != nil {
+		// Load HarvestConfig to rewrite passwords - eventually all the code will be refactored to use HarvestConfig.
+		// This is needed because the current yaml parser does not handle password with special characters.
+		// E.g abc#123, that's because the # is interpreted as the beginning of a comment. The code below overwrites
+		// the incorrect password with the correct one by using a better yaml parser for each Poller and Default section
+		_ = LoadHarvestConfig(configPath)
+		pollers := configNode.GetChildS("Pollers")
+		if pollers != nil {
+			for _, poller := range pollers.GetChildren() {
+				password := poller.GetChildContentS("password")
+				pollerStruct := (*Config.Pollers)[poller.GetNameS()]
+				if pollerStruct.Password != "" && pollerStruct.Password != password {
+					poller.SetChildContentS("password", pollerStruct.Password)
+				}
+			}
+		}
+		// Check Defaults also
+		defaultNode := configNode.GetChildS("Defaults")
+		if defaultNode != nil {
+			password := defaultNode.GetChildContentS("password")
+			defaultStruct := *Config.Defaults
+			if defaultStruct.Password != "" && defaultStruct.Password != password {
+				defaultNode.SetChildContentS("password", defaultStruct.Password)
+			}
+		}
+	}
+	return configNode, err
+}
+
+var Config = HarvestConfig{}
+
+func LoadHarvestConfig(configPath string) error {
+	contents, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		fmt.Printf("error reading config file=[%s] %+v\n", configPath, err)
+		return err
+	}
+	err = yaml.Unmarshal(contents, &Config)
+	if err != nil {
+		fmt.Printf("error unmarshalling config file=[%s] %+v\n", configPath, err)
+		return err
+	}
+	return nil
 }
 
 func SafeConfig(n *node.Node, fp string) error {
@@ -190,7 +236,7 @@ type Poller struct {
 	Addr           *string   `yaml:"addr,omitempty"`
 	AuthStyle      *string   `yaml:"auth_style,omitempty"`
 	Username       *string   `yaml:"username,omitempty"`
-	Password       *string   `yaml:"password,omitempty"`
+	Password       string    `yaml:"password,omitempty"`
 	UseInsecureTls *bool     `yaml:"use_insecure_tls,omitempty"`
 	SslCert        *string   `yaml:"ssl_cert,omitempty"`
 	SslKey         *string   `yaml:"ssl_key,omitempty"`


### PR DESCRIPTION
This change only addresses passwords in Pollers and Defaults. The bigger refactor is to use HarvestConfig through out the codebase, but that was too big a change at the moment. That change touches a lot more code.

When that change is made, the code in conf.LoadConfig can be removed.