### PR TITLE
enable stacktrace during errors

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -4,6 +4,7 @@
 package errors
 
 import (
+	"github.com/pkg/errors"
 	"strings"
 )
 
@@ -30,17 +31,8 @@ const (
 	GO_ROUTINE_PANIC = "goroutine panic"
 )
 
-type Error struct {
-	class string
-	msg   string
-}
-
-func (e Error) Error() string {
-	return e.class + " => " + e.msg
-}
-
-func New(class, msg string) Error {
-	return Error{class: class, msg: msg}
+func New(class, msg string) error {
+	return errors.New(class + " => " + msg)
 }
 
 func GetClass(err error) string {


### PR DESCRIPTION
Example below.

{"level":"error","Poller":"F2240-127-26","collector":"ZapiPerf:Volume","stack":[{"func":"New","line":"35","source":"errors.go"},{"func":"(*Client).invoke","line":"403","source":"client.go"},{"func":"(*Client).InvokeWithTimers","line":"317","source":"client.go"},{"func":"(*ZapiPerf).PollData","line":"206","source":"zapiperf.go"},{"func":"(*task).Run","line":"60","source":"schedule.go"},{"func":"(*AbstractCollector).Start","line":"269","source":"collector.go"},{"func":"goexit","line":"1371","source":"asm_amd64.s"}],"error":"api request rejected => Incorrect counter list: \"timestamp\", non-existent counters are not allowed.","caller":"/home/rahulg2/code/github/harvest/cmd/poller/collector/collector.go:303","time":"2021-06-06T08:55:07-04:00"}



