### PR TITLE
Improve harvest start behavior

### DIFF
--- a/cmd/harvest/harvest.go
+++ b/cmd/harvest/harvest.go
@@ -187,10 +187,16 @@ func doManageCmd(cmd *cobra.Command, args []string) {
 
 		if opts.command == "start" || opts.command == "restart" {
 			// only start poller if confirmed that it's not running
-			if s.status == "not running" || s.status == "stopped" || s.status == "killed" {
+			// if it's running do nothing
+			switch s.status {
+			case "running":
+				// do nothing but print current status, idempotent
+				printStatus(opts.longStatus, c1, c2, datacenter, name, s.promPort, s)
+				break
+			case "not running", "stopped", "killed":
 				s = startPoller(name, promPort, opts)
 				printStatus(opts.longStatus, c1, c2, datacenter, name, s.promPort, s)
-			} else {
+			default:
 				fmt.Printf("can't verify status of [%s]: kill poller and try again\n", name)
 			}
 		}
@@ -244,8 +250,10 @@ func getStatus(pollerName string) *pollerStatus {
 	if err := proc.Signal(syscall.Signal(0)); err != nil {
 		if os.IsPermission(err) {
 			fmt.Println("Insufficient privileges to send signal to process")
+		} else {
+			// if not a permission issue, assume process is not running
+			s.status = "not running"
 		}
-		s.status = "unknown: " + err.Error()
 		return s
 		// process not running, but did not clean PID file
 		// maybe it just exited, so give it a chance to clean


### PR DESCRIPTION
Two cases are improved here:
1) Harvest detects when there is a stale pidfile and correctly restarts the poller process. A stale pidfile is when the pidfile exists in `/var/run/harvest` but there is no running process associated with that pid.

1) Harvest no longer suggests killing an already running poller when you try to start it. This is a a no-op.

Fixes #123