### PR TITLE
Pass through all container arguments exactly as specified

### DIFF
--- a/docker/allPollerInOneContainer/Dockerfile
+++ b/docker/allPollerInOneContainer/Dockerfile
@@ -39,4 +39,4 @@ VOLUME     [ "/opt/harvest" ]
 VOLUME     [ "/var/log/harvest" ]
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--", "./docker-entrypoint.sh"]
-CMD ["start", "--config harvest.yml"]
+CMD ["start", "--config", "harvest.yml"]

--- a/docker/allPollerInOneContainer/docker-entrypoint.sh
+++ b/docker/allPollerInOneContainer/docker-entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-bin/harvest $1 $2
+bin/harvest "$@"
 `exec "sh"`


### PR DESCRIPTION
Previously the entrypoint wrapper took exactly two arguments, and passed them along
unquoted, to harvest meaning any spaces made the given arguments split into additional
passed arguments. This is confusing, because there's no way to know without reading
the entrypoint code why that's happening, and it's unlike any other software out
there. Any additional arguments given to the entrypoint were _silently_ ignored.
    
This commit changes the entrypoint to pass _all_ arguments through unmodified.
This is more intuitive and consistent with other applications, including the
harvest application itself.
    
**Compatibility break**
    
Where users have previously customised container arguments as:
    
```
'start' '--config /opt/harvest.yml ...'
```
    
These instead need to be passed as:

```
'start' '--config' '/opt/harvest.yml' ...
```
    
Fixes #163