### PR TITLE
Infinite sleep without needing a TTY or side effects

### DIFF
--- a/docker/allPollerInOneContainer/docker-entrypoint.sh
+++ b/docker/allPollerInOneContainer/docker-entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 bin/harvest $1 $2
-`exec "sh"`
+`exec /bin/sleep infinity`


### PR DESCRIPTION
Infinite sleep without needing a TTY or side effects
    
This commit changes the means by which the container keeps itself
alive from running a `sh` process, to an explicit infinite sleep.
    
Using a shell means the container does not continue to run after
poller startup if run in detached mode, since stdin is closed the
shell process immediately exits. When run in attached mode,
use of shell will interpret any stdin as commands to be run within
the container, which is potentially dangerous, and certainly unexpected.
    
Fixes #164
