### PR TITLE
Replace busybox wget with standalone package

### DIFF
--- a/docker/allPollerInOneContainer/Dockerfile
+++ b/docker/allPollerInOneContainer/Dockerfile
@@ -26,6 +26,9 @@ RUN cp -aR bin $BUILD_DIR/conf $BUILD_DIR/docs $BUILD_DIR/grafana $BUILD_DIR/doc
 
 FROM alpine:latest
 
+# Work around https://github.com/mirror/busybox/issues/21
+RUN apk add wget
+
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 && \
     chmod +x /usr/local/bin/dumb-init
 


### PR DESCRIPTION
Docker container cannot be built in corporate environments using
http proxies due to issue https://github.com/mirror/busybox/issues/21.
    
This change installs the wget package, so a fully-featured wget
is available for downloading artifacts during container build.
    
This change could be reverted once the wget issue is resolved.
    
Fixes #165
