### PR TITLE
Store reason as a label for disk.yaml so

### DIFF
--- a/conf/zapi/cdot/9.8.0/disk.yaml
+++ b/conf/zapi/cdot/9.8.0/disk.yaml
@@ -29,7 +29,7 @@ counters:
       - sectors-written
     - disk-raid-info:
       - disk-outage-info:
-        - reason                => outage
+        - ^reason                => outage
 
 plugins:
   - LabelAgent:


### PR DESCRIPTION
that disk status is correctly reported

Fixes #182