### PR TITLE
shelf dashboard: adding override option for shelf field

### DIFF
--- a/grafana/prometheus/harvest_dashboard_shelf.json
+++ b/grafana/prometheus/harvest_dashboard_shelf.json
@@ -486,6 +486,18 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "shelf"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "json-view"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "op_status"
             },
             "properties": [


### PR DESCRIPTION
Adding override option to show values as JSON values.
So that it will show 1.10, 1.20 to 1.1, 1.2 which is the actual values.