### PR TITLE
WIP Poller should use Harvest config

### DIFF
--- a/pkg/tree/node/node.go
+++ b/pkg/tree/node/node.go
@@ -1,6 +1,7 @@
 /*
  * Copyright NetApp Inc, 2021 All rights reserved
  */
+
 package node
 
 import (


### PR DESCRIPTION
struct instead of nodes
The methods suffixed with 2: `GetPollers2`, `GetPoller2`, etc. will replace the node based versions once we update all senders

Compare the two approaches to union in Poller.Union2 and Conf.Union