### PR TITLE
Volume dashboard select option

### DIFF
--- a/grafana/prometheus/harvest_dashboard_volume.json
+++ b/grafana/prometheus/harvest_dashboard_volume.json
@@ -120,7 +120,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "avg(topk($TopResources, volume_avg_latency{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\"}))",
+          "expr": "avg(topk($TopResources, volume_avg_latency{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"}))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -175,7 +175,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "sum(topk($TopResources, volume_write_data+volume_read_data{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\"}))",
+          "expr": "sum(topk($TopResources, volume_write_data+volume_read_data{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"}))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -230,7 +230,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "sum(topk($TopResources, volume_total_ops{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\"}))",
+          "expr": "sum(topk($TopResources, volume_total_ops{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"}))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -294,7 +294,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk($TopResources, volume_avg_latency{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\"})",
+          "expr": "topk($TopResources, volume_avg_latency{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"})",
           "interval": "",
           "legendFormat": "{{svm}} - {{volume}}",
           "refId": "A"
@@ -397,7 +397,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk($TopResources, volume_write_data+volume_read_data{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\"})",
+          "expr": "topk($TopResources, volume_write_data+volume_read_data{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"})",
           "interval": "",
           "legendFormat": "{{svm}} - {{volume}}",
           "refId": "A"
@@ -500,7 +500,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk($TopResources, volume_total_ops{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\"})",
+          "expr": "topk($TopResources, volume_total_ops{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"})",
           "interval": "",
           "legendFormat": "{{svm}} - {{volume}}",
           "refId": "A"
@@ -725,7 +725,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "volume_labels{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\"}",
+          "expr": "volume_labels{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -734,7 +734,7 @@
           "refId": "B"
         },
         {
-          "expr": "volume_status{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\"}",
+          "expr": "volume_status{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -744,7 +744,7 @@
           "refId": "A"
         },
         {
-          "expr": "volume_size_total{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\"}",
+          "expr": "volume_size_total{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -754,7 +754,7 @@
           "refId": "C"
         },
         {
-          "expr": "volume_size_used_percent{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\"}",
+          "expr": "volume_size_used_percent{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1547,7 +1547,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(volume_labels{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",svm=~\"$SVM\"}, volume)",
+        "definition": "label_values(volume_labels{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\"}, volume)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1557,7 +1557,7 @@
         "name": "Volume",
         "options": [],
         "query": {
-          "query": "label_values(volume_labels{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",svm=~\"$SVM\"}, volume)",
+          "query": "label_values(volume_labels{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\"}, volume)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/grafana/prometheus/harvest_dashboard_volume.json
+++ b/grafana/prometheus/harvest_dashboard_volume.json
@@ -1312,7 +1312,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Read Throughput",
+      "title": "Write Throughput",
       "tooltip": {
         "shared": true,
         "sort": 2,


### PR DESCRIPTION
supporting filter based on the chosen volume in volume dashboard.

Graphs:
These are the current numbers/graphs which supports volume filter:
- Average latency [number]
- Throughput [number]
- Total iops [number]
- Average latency [graph]
- Total average throughput [graph]
- Total iops [graph]
- volumes in cluster [table]

These are cluster scope graphs and not supporting filter on svm and volume: NO CHANGE HERE
- read latency
- read throughput
- read iops
- write latency
- write throughput
- write iops


Also, there is typo in write throughput graph [changed form read to write].


Grafana: http://10.249.24.71:3000/d/mRFX09Rnk/netapp-detail-volume?orgId=1&refresh=1m&var-Datacenter=DC-03&var-Cluster=F8080-32-25&var-SVM=All&var-Volume=MDV_CRS_d33421f0984011eb814a00a0986abd71_B&var-TopResources=5
