### PR TITLE
refactor: remove dead HarvestTag code

### DIFF
--- a/cmd/harvest/harvest.go
+++ b/cmd/harvest/harvest.go
@@ -433,7 +433,6 @@ func startPoller(pollerName string, promPort int, opts *options) *pollerStatus {
 
 	if opts.foreground {
 		cmd := exec.Command(argv[0], argv[1:]...)
-		cmd.Env = append(os.Environ(), util.HarvestTag)
 		//fmt.Println(cmd.String())
 		fmt.Println("starting in foreground, enter CTRL+C or close terminal to stop poller")
 		_ = os.Stdout.Sync()
@@ -467,7 +466,6 @@ func startPoller(pollerName string, promPort int, opts *options) *pollerStatus {
 	}
 
 	cmd := exec.Command(path.Join(HarvestHomePath, "bin", "daemonize"), argv...)
-	cmd.Env = append(os.Environ(), util.HarvestTag)
 	//fmt.Println(cmd.String())
 	if err := cmd.Start(); err != nil {
 		fmt.Println(err)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -16,9 +16,6 @@ import (
 	"strings"
 )
 
-// HarvestTag is injected into a poller's environment to disambiguate the process
-const HarvestTag = "IS_HARVEST=TRUE"
-
 func MinLen(elements [][]string) int {
 	var min, i int
 	min = len(elements[0])


### PR DESCRIPTION
Injecting into a poller's environment to disambiguate the process doesn't work on Mac and on Unixes, non-root users can not read /proc