### PR TITLE
feat: collect qtree ops

### DIFF
--- a/conf/zapiperf/cdot/9.8.0/qtree.yaml
+++ b/conf/zapiperf/cdot/9.8.0/qtree.yaml
@@ -1,0 +1,22 @@
+name:                     Qtree
+query:                    qtree
+object:                   qtree
+instance_key:             uuid
+counters:
+  - instance_uuid
+  - instance_name         => qtreefull
+  - vserver_name          => svm
+  - node_name             => node
+  - parent_vol            => volume
+  - cifs_ops
+  - nfs_ops
+  - internal_ops
+  - total_ops
+plugins:
+  - LabelAgent:
+    split: qtreefull `/` ,qtree
+export_options:
+  instance_keys:
+    - qtree
+    - volume
+    - svm

--- a/conf/zapiperf/default.yaml
+++ b/conf/zapiperf/default.yaml
@@ -31,6 +31,7 @@ objects:
   NFSv3Node:              nfsv3_node.yaml
   NFSv4Node:              nfsv4_node.yaml
   NFSv41Node:             nfsv4_1_node.yaml
+  Qtree:                  qtree.yaml
 
   # SVM-level metrics
   Volume:                 volume.yaml


### PR DESCRIPTION
Thanks to Martin Möbius on Slack for contributing

```
curl -s 'http://127.0.0.1:13000/metrics' | rg "^qtree" | head
qtree_internal_ops{cluster="stiA400-7591614006449",datacenter="nane1",qtree="",volume="san_vs_4_vl_34",svm="san_vs_4"} 0
qtree_nfs_ops{cluster="stiA400-7591614006449",datacenter="nane1",qtree="",volume="san_vs_4_vl_34",svm="san_vs_4"} 0
qtree_total_ops{cluster="stiA400-7591614006449",datacenter="nane1",qtree="",volume="san_vs_4_vl_34",svm="san_vs_4"} 0
qtree_cifs_ops{cluster="stiA400-7591614006449",datacenter="nane1",qtree="",volume="san_vs_4_vl_34",svm="san_vs_4"} 0
qtree_cifs_ops{cluster="stiA400-7591614006449",datacenter="nane1",qtree="san_vs_3_vl_19_qtree_1",volume="san_vs_3_vl_19",svm="san_vs_3"} 0
qtree_internal_ops{cluster="stiA400-7591614006449",datacenter="nane1",qtree="san_vs_3_vl_19_qtree_1",volume="san_vs_3_vl_19",svm="san_vs_3"} 0
qtree_nfs_ops{cluster="stiA400-7591614006449",datacenter="nane1",qtree="san_vs_3_vl_19_qtree_1",volume="san_vs_3_vl_19",svm="san_vs_3"} 0
qtree_total_ops{cluster="stiA400-7591614006449",datacenter="nane1",qtree="san_vs_3_vl_19_qtree_1",volume="san_vs_3_vl_19",svm="san_vs_3"} 0
qtree_internal_ops{cluster="stiA400-7591614006449",datacenter="nane1",qtree="",volume="san_vs_4_vl_11",svm="san_vs_4"} 0
qtree_nfs_ops{cluster="stiA400-7591614006449",datacenter="nane1",qtree="",volume="san_vs_4_vl_11",svm="san_vs_4"} 0
```