### PR TITLE
fix: zapi tool should limit perf-o-g-i to subset of counters

### DIFF
--- a/cmd/tools/zapi/zapi.go
+++ b/cmd/tools/zapi/zapi.go
@@ -312,6 +312,10 @@ func getData(c *client.Client, args *Args) (*node.Node, error) {
 		}
 	}
 
+	if args.Counter != "" {
+		counters := req.NewChildS("counters", "")
+		counters.NewChildS("counter", args.Counter)
+	}
 	return c.InvokeRequest(req)
 }
 
@@ -343,5 +347,7 @@ Examples:
                                                                           Typically APIs suffixed with 'get-iter' have interesting metrics 
   harvest zapi -p infinity show data --api volume-get-iter                Query cluster infinity and print attribute tree of volume-get-iter
   harvest zapi -p infinity show counters --object workload_detail_volume  Query cluster infinity and print performance counter metadata 
+  harvest zapi -p infinity show data --object qtree --counter nfs_ops     Query cluster infinity and print performance counters on the 
+                                                                          number of NFS operations per second on each qtree
 `)
 }


### PR DESCRIPTION
```
bin/zapi --config harvest.ved.yml --poller venkat show data --object qtree --counter nfs_ops

    [instance-data]                   -                                   *
      [aggregation]                   -                                   *
        [aggregation-data]            -                                   *
          [constituent-count]         -                                   1
          [result]                    -                complete_aggregation
      [counters]                      -                                   *
        [counter-data]                -                                   *
          [name]                      -                             nfs_ops
          [value]                     -                                   0
      [name]                          - san_vs_4:san_vs_4_vl_9/san_vs_4_vl_9_qtree_2
      [sort-id]                       -                                   0
      [uuid]                          - c2aa7dae-ba6e-11eb-947b-d039ea1fbe60:7230:2
    [instance-data]                   -                                   *
      [aggregation]                   -                                   *
        [aggregation-data]            -                                   *
          [constituent-count]         -                                   1
          [result]                    -                complete_aggregation
      [counters]                      -                                   *
        [counter-data]                -                                   *
          [name]                      -                             nfs_ops
          [value]                     -                                   0
      [name]                          -                san_vs_4:vendorvol8/
      [sort-id]                       -                                   0
      [uuid]                          - c2aa7dae-ba6e-11eb-947b-d039ea1fbe60:7284:0
  [timestamp]                         -                          1626204281
```