### PR TITLE
feat: add richer set of REST queries

### DIFF
--- a/cmd/harvest/harvest.go
+++ b/cmd/harvest/harvest.go
@@ -24,6 +24,7 @@ import (
 	"goharvest2/cmd/tools/doctor"
 	"goharvest2/cmd/tools/generate"
 	"goharvest2/cmd/tools/grafana"
+	"goharvest2/cmd/tools/rest"
 	"goharvest2/cmd/tools/zapi"
 	"goharvest2/pkg/conf"
 	"goharvest2/pkg/set"
@@ -556,7 +557,7 @@ func init() {
 	rootCmd.AddCommand(manageCmd("stop", true))
 	rootCmd.AddCommand(manageCmd("restart", true))
 	rootCmd.AddCommand(manageCmd("kill", true))
-	rootCmd.AddCommand(config.ConfigCmd, zapi.Cmd, grafana.GrafanaCmd, stub.NewCmd)
+	rootCmd.AddCommand(config.ConfigCmd, zapi.Cmd, rest.Cmd, grafana.GrafanaCmd, stub.NewCmd)
 	rootCmd.AddCommand(generate.Cmd)
 	rootCmd.AddCommand(doctor.Cmd)
 

--- a/cmd/tools/zapi/zapi.go
+++ b/cmd/tools/zapi/zapi.go
@@ -340,7 +340,7 @@ func init() {
 	showCmd.SetUsageTemplate("item to show should be one of: " + strings.Join(validShowArgs, ", "))
 
 	// Append usage examples
-	Cmd.SetUsageTemplate(Cmd.UsageString() + `
+	Cmd.SetUsageTemplate(Cmd.UsageTemplate() + `
 Examples:
   harvest zapi -p infinity show apis                                      Query cluster infinity for available APIs
   harvest zapi -p infinity show attrs --api volume-get-iter               Query cluster infinity for volume-get-iter metrics


### PR DESCRIPTION
Added
```
 -c, --cross string         Cross-field queries return rows where any field in a specified set of fields matches the query
      --field string         Query a field by value. If the value contains query characters (*|,!<>..), it must be quoted to avoid their special meaning
                                 *         wildcard
                                 < > <= >= comparisons
                                 3..10     range
                                 !water    negation
                                 3|5       matching value in a list
                                 {} and "" escape special characters

```