### PR TITLE
fix: certificate auth should honor path in harvest.yml

### DIFF
--- a/cmd/poller/poller.go
+++ b/cmd/poller/poller.go
@@ -193,7 +193,7 @@ func (p *Poller) Init() error {
 	// check optional parameter auth_style
 	// if certificates are missing use default paths
 	if p.params.AuthStyle != nil && *p.params.AuthStyle == "certificate_auth" {
-		if p.params.SslCert != nil {
+		if p.params.SslCert == nil {
 			fp := path.Join(p.options.HomePath, "cert/", p.options.Hostname+".pem")
 			p.params.SslCert = &fp
 			logger.Debug().Msgf("using default [ssl_cert] path: [%s]", fp)
@@ -202,7 +202,7 @@ func (p *Poller) Init() error {
 				return errors.New(errors.MISSING_PARAM, "ssl_cert: "+err.Error())
 			}
 		}
-		if p.params.SslKey != nil {
+		if p.params.SslKey == nil {
 			fp := path.Join(p.options.HomePath, "cert/", p.options.Hostname+".key")
 			p.params.SslKey = &fp
 			logger.Debug().Msgf("using default [ssl_key] path: [%s]", fp)


### PR DESCRIPTION
The cert and key values specified in harvest.yml were ignored because of an incorrect nil check.

With this fix, a relative or absolute path can be specified for
```
 ssl_cert: path/to/cbg-inf.pem # absolute
 ssl_key: cbg-inf.key          # relative to Harvest home
```