### PR TITLE
feat: harvest version checks for latest release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ ifneq (, $(shell which go))
 FOUND_GO_VERSION := $(shell go version | cut -d" " -f3 | cut -d"o" -f 2)
 CORRECT_GO_VERSION := $(shell expr `go version | cut -d" " -f3 | cut -d"o" -f 2` \>= ${REQUIRED_GO_VERSION})
 endif
-RELEASE      ?= $(shell git describe --tags --abbrev=0)
+TAG_COMMIT   ?= $(shell git rev-list --tags --max-count=1)
+RELEASE      ?= $(shell git describe --tags $(TAG_COMMIT))
 VERSION      ?= $(shell expr `date +%Y.%m.%d%H | cut -c 3-`)
 COMMIT       := $(shell git rev-parse --short HEAD)
 BUILD_DATE   := `date +%FT%T%z`

--- a/cmd/harvest/harvest.go
+++ b/cmd/harvest/harvest.go
@@ -560,6 +560,7 @@ func init() {
 	rootCmd.AddCommand(config.ConfigCmd, zapi.Cmd, rest.Cmd, grafana.GrafanaCmd, stub.NewCmd)
 	rootCmd.AddCommand(generate.Cmd)
 	rootCmd.AddCommand(doctor.Cmd)
+	rootCmd.AddCommand(version.Cmd())
 
 	rootCmd.PersistentFlags().StringVar(&opts.config, "config", "./harvest.yml", "harvest config file path")
 	rootCmd.Version = version.String()

--- a/cmd/harvest/version/version.go
+++ b/cmd/harvest/version/version.go
@@ -1,11 +1,23 @@
 /*
  * Copyright NetApp Inc, 2021 All rights reserved
  */
+
 package version
 
 import (
 	"fmt"
+	"github.com/hashicorp/go-version"
+	"github.com/spf13/cobra"
+	"net/http"
+	"net/url"
 	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	githubReleases = "https://github.com/NetApp/harvest/releases/latest"
+	youHaveLatest  = "you have the latest ✓"
 )
 
 var (
@@ -24,4 +36,90 @@ func String() string {
 		runtime.GOOS,
 		runtime.GOARCH,
 	)
+}
+
+func Cmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Show application version and check for latest",
+		Long:  "Show application version and check for latest",
+		Run:   doVersion,
+	}
+}
+
+func doVersion(cmd *cobra.Command, _ []string) {
+	fmt.Printf(cmd.Root().Version)
+	checkLatest()
+}
+
+func checkLatest() {
+	//goland:noinspection GoBoolExpressions
+	if Commit == "HEAD" {
+		return
+	}
+	fmt.Printf("checking GitHub for latest...")
+	latest, err := latestRelease()
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return
+	}
+	available, err := isNewerAvailable(Release, latest)
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return
+	}
+	if available {
+		fmt.Printf(" newer version %s available at %s\n", latest, githubReleases)
+	} else {
+		fmt.Printf(" %s\n", youHaveLatest)
+	}
+}
+
+func isNewerAvailable(current string, remote string) (bool, error) {
+	//fmt.Printf("isNewerAvail cur=%s remote=%s ", current, remote)
+	if remote == current {
+		return false, nil
+	} else {
+		remoteVersion, err := version.NewVersion(remote)
+		if err != nil {
+			return false, err
+		}
+		currentVersion, err := version.NewVersion(current)
+		if err != nil {
+			return false, err
+		}
+		if currentVersion.GreaterThanOrEqual(remoteVersion) {
+			return false, nil
+		} else {
+			return true, nil
+		}
+	}
+}
+
+func latestRelease() (string, error) {
+	client := &http.Client{
+		Transport: &http.Transport{},
+		Timeout:   5 * time.Second,
+	}
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return fmt.Errorf("redirect")
+	}
+	resp, err := client.Get(githubReleases)
+	// check if we got a redirect to the latest release
+	if err != nil {
+		var location *url.URL
+		if resp == nil {
+			return "", fmt.Errorf(" error checking GitHub %s", err)
+		}
+		if resp.StatusCode == http.StatusFound {
+			location, err = resp.Location()
+			if err != nil {
+				return "", err
+			}
+			// returns like https://github.com/NetApp/harvest/releases/tag/v21.05.3
+			lastSlash := strings.LastIndex(location.String(), "/")
+			return location.String()[lastSlash+1:], nil
+		}
+	}
+	return "", fmt.Errorf(" error checking GitHub")
 }

--- a/cmd/harvest/version/version_test.go
+++ b/cmd/harvest/version/version_test.go
@@ -1,0 +1,30 @@
+package version
+
+import "testing"
+
+func Test_isNewerAvailable(t *testing.T) {
+	type test struct {
+		name          string
+		curVersion    string
+		remoteVersion string
+		shouldUpgrade bool
+	}
+	tests := []test{
+		{name: "do not upgrade 21.05.1 to same", curVersion: "v21.05.1", remoteVersion: "v21.05.1", shouldUpgrade: false},
+		{name: "upgrade 21.05.1 to 21.05.2", curVersion: "v21.05.1", remoteVersion: "v21.05.2", shouldUpgrade: true},
+		{name: "upgrade 21.05.1 to 21.11.1", curVersion: "v21.05.1", remoteVersion: "v21.11.1", shouldUpgrade: true},
+		{name: "upgrade 21.05.1 to 22.02.1", curVersion: "v21.05.1", remoteVersion: "v22.02.1", shouldUpgrade: true},
+		{name: "do not upgrade 21.07.2017 to v21.05.1", curVersion: "21.07.2017", remoteVersion: "v21.05.1", shouldUpgrade: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			available, err := isNewerAvailable(tt.curVersion, tt.remoteVersion)
+			if err != nil {
+				panic(err)
+			}
+			if available != tt.shouldUpgrade {
+				t.Errorf("expected %t got %t for %+v", tt.shouldUpgrade, available, tt)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #323 

We usually tag the release branch with the release tag instead of the main branch. That caused our Makefile to embed the wrong RELEASE string when building locally. Jenkins works fine because we explicitly pass the RELEASE string. 

I changed the Makefile to pick the latest tagged commit across all branches instead of the latest tag on the current branch. That way local builds include the most recent tag too.

Local Build with version check (the release is `v21.05.3` instead of `v21.05.0`)
```
make build

bin/harvest version
harvest version 21.07.2020-v21.05.3 (commit 5836229) (build date 2021-07-20T20:26:39-0400) darwin/amd64
checking GitHub for latest... you have the latest ✓
```


Build a version of Harvest from the past

```
RELEASE=17.05.1 make build

bin/harvest version
harvest version 21.07.2020-17.05.1 (commit 2e261b7) (build date 2021-07-20T20:46:35-0400) darwin/amd64
checking GitHub for latest... newer version v21.05.3 available at https://github.com/NetApp/harvest/releases/latest
```

You can skip the version check by using the arg version instead of the subcommand version.

```
bin/harvest --version
harvest version 21.07.2020-17.05.1 (commit 2e261b7) (build date 2021-07-20T20:46:35-0400) darwin/amd64
```