### PR TITLE
fix: false negatives by prefix matcher

### DIFF
--- a/cmd/tools/grafana/grafana.go
+++ b/cmd/tools/grafana/grafana.go
@@ -354,7 +354,7 @@ func addPrefixToMetricNames(expr, prefix string) string {
 
 	// variable queries
 	if strings.HasPrefix(expr, "label_values(") {
-		if isMatch, err = regexp.MatchString(`^label_values\(([a-zA-Z_])+({.+?})?,\s?[a-zA-Z_]+\)$`, expr); err != nil {
+		if isMatch, err = regexp.MatchString(`^label_values\s?\(([a-zA-Z_])+(\s?{.+?})?,\s?[a-zA-Z_]+\)$`, expr); err != nil {
 			fmt.Printf("Regex error: %v\n", err)
 			return expr
 		} else if isMatch {
@@ -366,7 +366,7 @@ func addPrefixToMetricNames(expr, prefix string) string {
 	}
 
 	// everything else is for graph queries
-	regex = regexp.MustCompile(`([a-zA-Z_+]+){.+?}`)
+	regex = regexp.MustCompile(`([a-zA-Z_+]+)\s?{.+?}`)
 	match = regex.FindAllStringSubmatch(expr, -1)
 
 	for _, m := range match {

--- a/cmd/tools/grafana/grafana.go
+++ b/cmd/tools/grafana/grafana.go
@@ -274,12 +274,7 @@ func addGlobalPrefix(db map[string]interface{}, prefix string) {
 		p, t                                       interface{}
 		queryString, definition, expr              string
 		ok, has                                    bool
-		//regex                                      *regexp.Regexp
 	)
-
-	// regex we will use to match metric names
-	// used in addPrefixToMatricNames, but better to initialize it once
-	//regex = regexp.MustCompile(`([a-zA-Z_+]+){.+?}`)
 
 	// make sure prefix ends with _
 	if !strings.HasSuffix(prefix, "_") {
@@ -341,9 +336,10 @@ func addGlobalPrefix(db map[string]interface{}, prefix string) {
 	}
 }
 
-// addPrefixToMetricNames adds prefix to metric names in expr. Note that
-// this function will only work with the Prometheus-dashboards of Harvest.
-// It will recognize a number of ways in which metrics are used as queries.
+// addPrefixToMetricNames adds prefix to metric names in expr or leaves it
+// unchanged if no metric names are identified.
+// Note that this function will only work with the Prometheus-dashboards of Harvest.
+// It will use a number of patterns in which metrics might be used in queries.
 // (E.g. a single metric, multiple metrics used in addition, etc -- for examples
 // see the test). If we change queries of our dashboards, we have to review
 // this function as well (or come up with a better solution).

--- a/cmd/tools/grafana/grafana_test.go
+++ b/cmd/tools/grafana/grafana_test.go
@@ -56,11 +56,8 @@ func TestAddPrefixToMetricNames(t *testing.T) {
 	var (
 		examples, expected []string
 		prefix, result     string
-		//regex              *regexp.Regexp
-		i int
+		i                  int
 	)
-
-	//regex = regexp.MustCompile(`([a-zA-Z_+]+){.+?}`)
 
 	prefix = "xx_"
 

--- a/cmd/tools/grafana/grafana_test.go
+++ b/cmd/tools/grafana/grafana_test.go
@@ -70,6 +70,8 @@ func TestAddPrefixToMetricNames(t *testing.T) {
 		`label_values(poller_status, datacenter)`,
 		`label_values(datacenter)`,
 		`label_values(node_uptime{datacenter="$Datacenter"},cluster)`,
+		`label_values (node_uptime{datacenter="$Datacenter"},cluster)`,
+		`label_values(node_uptime {datacenter="$Datacenter"},cluster)`,
 	}
 
 	expected = []string{
@@ -81,6 +83,8 @@ func TestAddPrefixToMetricNames(t *testing.T) {
 		`label_values(xx_poller_status, datacenter)`,
 		`label_values(datacenter)`, // no metric name
 		`label_values(xx_node_uptime{datacenter="$Datacenter"},cluster)`,
+		`label_values (xx_node_uptime{datacenter="$Datacenter"},cluster)`,
+		`label_values(xx_node_uptime {datacenter="$Datacenter"},cluster)`,
 	}
 
 	for i = range examples {

--- a/cmd/tools/grafana/grafana_test.go
+++ b/cmd/tools/grafana/grafana_test.go
@@ -1,7 +1,6 @@
 package grafana
 
 import (
-	"regexp"
 	"testing"
 )
 
@@ -55,17 +54,17 @@ func TestHttpsAddr(t *testing.T) {
 func TestAddPrefixToMetricNames(t *testing.T) {
 
 	var (
-		examples, expected [7]string
+		examples, expected []string
 		prefix, result     string
-		regex              *regexp.Regexp
-		i                  int
+		//regex              *regexp.Regexp
+		i int
 	)
 
-	regex = regexp.MustCompile(`([a-zA-Z_+]+){.+?}`)
+	//regex = regexp.MustCompile(`([a-zA-Z_+]+){.+?}`)
 
 	prefix = "xx_"
 
-	examples = [7]string{
+	examples = []string{
 		`sum(volume_read_data{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"}) by (cluster) + sum(volume_write_data{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"}) by(cluster)`,
 		`sum(topk($TopResources, volume_total_ops{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"}))`,
 		`volume_size_used_percent{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"}`,
@@ -73,9 +72,10 @@ func TestAddPrefixToMetricNames(t *testing.T) {
 		`label_values(metadata_component_status{type="collector",poller=~"$Poller"}, name)`,
 		`label_values(poller_status, datacenter)`,
 		`label_values(datacenter)`,
+		`label_values(node_uptime{datacenter="$Datacenter"},cluster)`,
 	}
 
-	expected = [7]string{
+	expected = []string{
 		`sum(xx_volume_read_data{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"}) by (cluster) + sum(xx_volume_write_data{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"}) by(cluster)`,
 		`sum(topk($TopResources, xx_volume_total_ops{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"}))`,
 		`xx_volume_size_used_percent{datacenter=\"$Datacenter\",cluster=\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"}`,
@@ -83,10 +83,11 @@ func TestAddPrefixToMetricNames(t *testing.T) {
 		`label_values(xx_metadata_component_status{type="collector",poller=~"$Poller"}, name)`,
 		`label_values(xx_poller_status, datacenter)`,
 		`label_values(datacenter)`, // no metric name
+		`label_values(xx_node_uptime{datacenter="$Datacenter"},cluster)`,
 	}
 
 	for i = range examples {
-		result = addPrefixToMetricNames(examples[i], prefix, regex)
+		result = addPrefixToMetricNames(examples[i], prefix)
 		if result != expected[i] {
 			t.Errorf("\nExpected: [%s]\n     Got: [%s]", expected[i], result)
 		}

--- a/grafana/prometheus/harvest_dashboard_metadata.json
+++ b/grafana/prometheus/harvest_dashboard_metadata.json
@@ -136,7 +136,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "count (count by (datacenter) (poller_status))",
+          "expr": "count (count by (datacenter) (poller_status{hostname=~\"$Hostname\"}))",
           "format": "time_series",
           "hide": false,
           "instant": false,


### PR DESCRIPTION
fixes #332

For the first query, I couldn't find a better solution than just change the query in the dashboard. (Trying to match this with another regex, seems likely to produce false positives).

For the second query, a more precise regexp is used. Tests are updated as well.