### PR TITLE
feat: zapi tool should print xml

### DIFF
--- a/cmd/tools/zapi/show.go
+++ b/cmd/tools/zapi/show.go
@@ -13,19 +13,19 @@ import (
 func show(n *node.Node, args *Args) {
 	switch args.Item {
 	case "system":
-		showSystem(n, args)
+		showSystem(n)
 	case "apis":
-		showApis(n, args)
+		showApis(n)
 	case "objects":
-		showObjects(n, args)
+		showObjects(n)
 	case "attrs":
-		showAttrs(n, args)
+		showAttrs(n)
 	case "counters":
-		showCounters(n, args)
+		showCounters(n)
 	case "counter":
-		showCounter(n, args)
+		showCounter(n)
 	case "instances":
-		showInstances(n, args)
+		showInstances(n)
 	case "data":
 		showData(n, args)
 	default:
@@ -33,15 +33,15 @@ func show(n *node.Node, args *Args) {
 	}
 }
 
-func showSystem(n *node.Node, args *Args) {
+func showSystem(n *node.Node) {
 	n.Print(0)
 }
 
-func showApis(n *node.Node, args *Args) {
+func showApis(n *node.Node) {
 	n.Print(0)
 }
 
-func showObjects(item *node.Node, args *Args) {
+func showObjects(item *node.Node) {
 
 	for _, o := range item.GetChildren() {
 
@@ -53,22 +53,29 @@ func showObjects(item *node.Node, args *Args) {
 	}
 }
 
-func showAttrs(n *node.Node, args *Args) {
+func showAttrs(n *node.Node) {
 	n.Print(0)
 }
 
-func showCounters(n *node.Node, args *Args) {
+func showCounters(n *node.Node) {
 	n.Print(0)
 }
 
-func showCounter(n *node.Node, args *Args) {
+func showCounter(n *node.Node) {
 	n.Print(0)
 }
 
-func showInstances(n *node.Node, args *Args) {
+func showInstances(n *node.Node) {
 	n.Print(0)
 }
 
-func showData(n *node.Node, args *Args) {
-	n.Print(0)
+func showData(n *node.Node, a *Args) {
+	if a.OutputFormat == "xml" {
+		// the root node was stripped earlier, add back here
+		fmt.Println("<root>")
+		fmt.Println(string(n.Content))
+		fmt.Println("</root>")
+	} else {
+		n.Print(0)
+	}
 }

--- a/cmd/tools/zapi/zapi.go
+++ b/cmd/tools/zapi/zapi.go
@@ -26,6 +26,7 @@ var (
 	maxSearchDepth  = 1
 	validShowArgs   = []string{"data", "apis", "attrs", "objects", "instances", "counters", "counter", "system"}
 	validExportArgs = []string{"attrs", "counters"}
+	outputFormats   = []string{"xml", "color"}
 )
 
 type Args struct {
@@ -52,8 +53,9 @@ type Args struct {
 	// ??
 	MaxRecords int
 	// additional parameters to add to the ZAPI request, in "key:value" format
-	Parameters []string
-	Config     string // filepath of Harvest config (defaults to "harvest.yml") can be relative or absolute path
+	Parameters   []string
+	Config       string // filepath of Harvest config (defaults to "harvest.yml") can be relative or absolute path
+	OutputFormat string
 }
 
 var Cmd = &cobra.Command{
@@ -149,7 +151,8 @@ func doCmd(cmd string) {
 		os.Exit(1)
 	}
 
-	fmt.Printf("connected to %s%s%s (%s)\n", color.Bold, connection.Name(), color.End, connection.Release())
+	color.DetectConsole("")
+	_, _ = fmt.Fprintf(os.Stderr, "connected to %s%s%s (%s)\n", color.Bold, connection.Name(), color.End, connection.Release())
 
 	// get requested item
 	if item, err = get(connection, args); err != nil {
@@ -329,6 +332,8 @@ func init() {
 	flags.StringVarP(&args.Poller, "poller", "p", "", "name of poller (cluster), as defined in your harvest config")
 	_ = Cmd.MarkPersistentFlagRequired("poller")
 
+	flags.StringVarP(&args.OutputFormat, "write", "w", "xml",
+		fmt.Sprintf("Output format to use: one of %s", outputFormats))
 	flags.StringVarP(&args.Api, "api", "a", "", "ZAPI query to show")
 	flags.StringVarP(&args.Attr, "attr", "t", "", "ZAPI attribute to show")
 	flags.StringVarP(&args.Object, "object", "o", "", "ZapiPerf object to show")


### PR DESCRIPTION
Original printing is still supported with new flag (`--write color`). Default flag is `xml`.

This change makes post-processing zapi responses much easier - for example to convert xml to json
```
bin/zapi --poller infinity show data --api storage-disk-get-iter | dasel -r xml -w json

...
          "disk-stats-info": {
            "average-latency": "0",
            "bytes-per-sector": "520",
            "disk-io-kbps": "197",
            "disk-iops": "6",
            "disk-uid": "5002538B:08448840:00000000:00000000:00000000:00000000:00000000:00000000:00000000:00000000",
            "path-error-count": "0",
            "power-on-time-interval": "86994000",
            "sectors-read": "8448345263",
            "sectors-written": "638497917"
          },
          "disk-uid": "5002538B:08448840:00000000:00000000:00000000:00000000:00000000:00000000:00000000:00000000"
        }
      ]
    },
    "num-records": "24"
  }

```