### PR TITLE
fix: Prometheus port_range-related issue 357

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ header:
 	@echo
 
 deps: header ## Check dependencies
-	@echo "checking Harvest dependencies"
+	@echo "Checking Harvest dependencies"
 ifeq (${GCC_EXISTS}, )
 	@echo
 	@echo "Harvest requires that you have gcc installed."

--- a/cmd/harvest/harvest.go
+++ b/cmd/harvest/harvest.go
@@ -241,7 +241,7 @@ func getStatus(pollerName string) *pollerStatus {
 	}
 	if len(pids) != 1 {
 		if len(pids) > 1 {
-			fmt.Printf("exepcted one pid for %s, instead pids=%+v\n", pollerName, pids)
+			fmt.Printf("expected one pid for %s, instead pids=%+v\n", pollerName, pids)
 		}
 		return s
 	}

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -256,6 +256,11 @@ func GetPrometheusExporterPorts(pollerName string) (int, error) {
 	if poller == nil {
 		return 0, errors.New(errors.ERR_CONFIG, "Poller does not exist "+pollerName)
 	}
+
+	if Config.Defaults != nil {
+		poller.Union(Config.Defaults) // exporter can be defined in Defaults
+	}
+
 	exporters := poller.Exporters
 	if exporters != nil && len(*exporters) > 0 {
 		for _, e := range *exporters {
@@ -313,7 +318,8 @@ func loadPrometheusExporterPortRangeMapping() {
 	for k, v := range exporters {
 		if v.Type != nil && *v.Type == "Prometheus" {
 			if v.PortRange != nil {
-				promPortRangeMapping[k] = PortMapFromRange(*v.Addr, v.PortRange)
+				// we only care about free ports on the localhost
+				promPortRangeMapping[k] = PortMapFromRange("localhost", v.PortRange)
 			}
 		}
 	}

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -257,10 +257,6 @@ func GetPrometheusExporterPorts(pollerName string) (int, error) {
 		return 0, errors.New(errors.ERR_CONFIG, "Poller does not exist "+pollerName)
 	}
 
-	if Config.Defaults != nil {
-		poller.Union(Config.Defaults) // exporter can be defined in Defaults
-	}
-
 	exporters := poller.Exporters
 	if exporters != nil && len(*exporters) > 0 {
 		for _, e := range *exporters {


### PR DESCRIPTION
This fixes issue #357

The underlying problems are:
- in [pkg/conf/conf.go:  loadPrometheusExporterPortRangeMapping()](https://github.com/NetApp/harvest/blob/664a8265788dedb4850c5f4ba3aa514005f5e11d/pkg/conf/conf.go#L316) we deference the `addr` parameter, which is not documented in the list of parameters of the Prometheus exporter. But it's also redundant, since we only care about free ports on the localhost.
- in pkg/conf/conf.go: GetPrometheusExporterPorts() we do not check for exporters in the Defaults section.

This PR fixes both issues.