### PR TITLE
fix: supporting diskstatus(outage info) for all cases in disk dashboard

### DIFF
--- a/grafana/dashboards/harvest_dashboard_disk.json
+++ b/grafana/dashboards/harvest_dashboard_disk.json
@@ -1003,22 +1003,6 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "outage"
-            },
-            "properties": [
-              {
-                "id": "noValue",
-                "value": "Ok"
-              },
-              {
-                "id": "displayName",
-                "value": "Status"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
               "options": "disk"
             },
             "properties": [
@@ -1163,6 +1147,32 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "diskStatus"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Status"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      " ": {
+                        "text": "Ok",
+                        "index": 0
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "shelf_bay"
             },
             "properties": [
@@ -1235,7 +1245,7 @@
           "refId": "C"
         },
         {
-          "expr": "disk_labels{datacenter=\"$Datacenter\",cluster=\"$Cluster\"}",
+          "expr": "label_join(disk_labels{datacenter=\"$Datacenter\",cluster=\"$Cluster\"}, \"diskStatus\", \" \",\"NonSupportedField\", \"outage\")",
           "legendFormat": "",
           "interval": "",
           "exemplar": true,
@@ -1269,7 +1279,8 @@
               "owner_node": true,
               "shared": true,
               "shelf": true,
-              "Value #E": true
+              "Value #E": true,
+              "outage": true
             },
             "indexByName": {
               "Time": 0,
@@ -1283,8 +1294,7 @@
               "serial_number": 5,
               "shelf": 1,
               "shelf_bay": 2,
-              "type": 4,
-              "outage": 12
+              "type": 4
             },
             "renameByName": {}
           }


### PR DESCRIPTION
Result of the query: label_join(disk_labels{datacenter="DC-03",cluster="F8080-32-25"}, "diskStatus", " ","NonSupportedField", "outage")

1. When no outage info available in disk_labels:


disk_labels{aggr="aggr0_F8080_32_25_01", cluster="F8080-32-25", datacenter="DC-03", disk="1.0.12", diskStatus=" ", failed="false", instance="localhost:12991", job="prometheus1", model="X446_1625200MCSG", node="F8080-32-25-01", owner_node="F8080-32-25-01", serial_number="S142NEAG200663", shared="true", shelf="0", shelf_bay="12", type="SSD"} | 1
-- | --

2. When outage info available in disk_labels:


disk_labels{cluster="F8080-32-25", datacenter="DC-03", disk="1.10.4", diskStatus=" unknown", failed="false", instance="localhost:12991", job="prometheus1", model="X446_1625200MCSG", node="F8080-32-22-01", outage="unknown", owner_node="F8080-32-22-01", serial_number="S142NEAG102094", shared="true", shelf="10", shelf_bay="4", type="SSD"} | 1
-- | --



DC-03:
![image](https://user-images.githubusercontent.com/83282894/127985644-28884717-a71f-4f83-b7e2-56002047a0c5.png)

DC-02:
![image](https://user-images.githubusercontent.com/83282894/127985684-662db30b-1d41-4a41-8add-c14b05d324b9.png)


