### PR TITLE
docs: remove references to deprecated addr

### DIFF
--- a/cmd/exporters/prometheus/README.md
+++ b/cmd/exporters/prometheus/README.md
@@ -49,7 +49,6 @@ A few examples:
 Exporters:
   prom-prod:
     exporter: Prometheus
-    addr: 0.0.0.0
     port_range: 2000-2030
 Pollers:
   cluster-01:

--- a/cmd/tools/doctor/testdata/testConfig.yml
+++ b/cmd/tools/doctor/testdata/testConfig.yml
@@ -5,11 +5,10 @@ Tools:
 Exporters:
   prometheusrange:
     exporter: Prometheus
-    addr: 0.0.0.0
     port_range: 2000-2000
   prometheus:
     exporter: Prometheus
-    addr: 0.0.0.0
+    local_http_addr: 0.0.0.0
     port: 12990
     allow_addrs_regex:
       - ^192.168.0.\d+$
@@ -19,7 +18,7 @@ Exporters:
     port: 12990
   pluto: # name of your exporter, can be any valid yaml string
     exporter: PrometheusConsul
-    addr: 1.2.3.4          # ip or hostname of Consul cluster
+    local_http_addr: 1.2.3.4          # ip or hostname of Consul cluster
     service_name: monitor  # all pollers exporting to pluto will be registered with the service name of 'monitor'
     tags:
       - netapp             # each of the pollers exporting to pluto will be tagged with two tags: 'netapp' and 'harvest'

--- a/harvest.cue
+++ b/harvest.cue
@@ -1,20 +1,14 @@
 package harvest
 
-Exporters: [Name=_]: #Prom | #Influx | #PromConsul
+Exporters: [Name=_]: #Prom | #Influx
 
 #Prom: {
-	addr: string
+	local_http_addr: "0.0.0.0" | "localhost" | "127.0.0.1"
+	addr: string // deprecated
 	exporter:    "Prometheus"
 	port?:       int
 	port_range?: string
 	allow_addrs_regex?: [...string]
-}
-
-#PromConsul: {
-	addr: string
-	exporter:    "PrometheusConsul"
-    service_name: string
-    tags: [...string]
 }
 
 #Influx: {

--- a/harvest.yml
+++ b/harvest.yml
@@ -5,11 +5,10 @@ Tools:
 Exporters:
   prometheus:
     exporter: Prometheus
-    addr: 0.0.0.0
+    local_http_addr: 0.0.0.0
     port: 12990
   prometheus1:
     exporter: Prometheus
-    addr: 0.0.0.0
     port: 12991
 
 Defaults:


### PR DESCRIPTION
Prometheus `addr` is deprecated. Use [local_http_addr](https://github.com/NetApp/harvest/tree/main/cmd/exporters/prometheus#parameters) instead or omit entirely if you want to use `0.0.0.0`.