### PR TITLE
feat: log zapi request/response

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ All pollers are defined in `harvest.yml`, the main configuration file of Harvest
 | `use_insecure_tls`     | optional, bool |  If true, disable TLS verification when connecting to ONTAP cluster  | false         |
 | `log_max_bytes`        |  | Maximum size of the log file before it will be rotated | `10000000` (10 mb) |
 | `log_max_files`        |  | Number of rotated log files to keep | `10` |
-| |  | | |
+| `log`                  | optional, list of collector names              | matching collectors log their ZAPI request/response                                                                                                                                                                                                                                                                                                                         |                    |
 
 ## Defaults
 This section is optional. If there are parameters identical for all your pollers (e.g. datacenter, authentication method, login preferences), they can be grouped under this section. The poller section will be checked first and if the values aren't found there, the defaults will be consulted.

--- a/cmd/collectors/zapi/collector/zapi.go
+++ b/cmd/collectors/zapi/collector/zapi.go
@@ -81,7 +81,7 @@ func (me *Zapi) InitVars() error {
 	if me.Client, err = client.New(me.Params); err != nil { // convert to connection error, so poller aborts
 		return errors.New(errors.ERR_CONNECTION, err.Error())
 	}
-
+	me.Client.TraceLogSet(me.Name, me.Params)
 	if err = me.Client.Init(5); err != nil { // 5 retries before giving up to connect
 		return errors.New(errors.ERR_CONNECTION, err.Error())
 	}

--- a/harvest.cue
+++ b/harvest.cue
@@ -38,4 +38,5 @@ Pollers: [Name=_]: #Poller
 	log_max_files?: int
 	collectors: [...string]
 	exporters: [...string]
+	log: [...string]
 }

--- a/pkg/api/ontapi/zapi/client.go
+++ b/pkg/api/ontapi/zapi/client.go
@@ -16,6 +16,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -32,6 +33,7 @@ type Client struct {
 	apiVersion string
 	vfiler     string
 	Logger     *logging.Logger // logger used for logging
+	logZapi    bool            // used to log ZAPI request/response
 }
 
 func New(config *node.Node) (*Client, error) {
@@ -362,6 +364,13 @@ func (c *Client) invoke(withTimers bool) (*node.Node, time.Duration, time.Durati
 	if withTimers {
 		start = time.Now()
 	}
+
+	// ZAPI request needs to be saved before calling client.Do because client.Do will zero out the buffer
+	zapiReq := ""
+	if c.logZapi {
+		zapiReq = c.buffer.String()
+	}
+
 	if response, err = c.client.Do(c.request); err != nil {
 		return result, responseT, parseT, errors.New(errors.ERR_CONNECTION, err.Error())
 	}
@@ -379,6 +388,7 @@ func (c *Client) invoke(withTimers bool) (*node.Node, time.Duration, time.Durati
 	if body, err = ioutil.ReadAll(response.Body); err != nil {
 		return result, responseT, parseT, err
 	}
+	defer c.printRequestAndResponse(zapiReq, body)
 
 	// parse xml
 	if withTimers {
@@ -410,4 +420,28 @@ func (c *Client) invoke(withTimers bool) (*node.Node, time.Duration, time.Durati
 	}
 
 	return result, responseT, parseT, nil
+}
+
+func (c *Client) TraceLogSet(collectorName string, config *node.Node) {
+	// check for log sets and enable zapi request logging if collectorName is in the set
+	if llogs := config.GetChildS("log"); llogs != nil {
+		for _, log := range llogs.GetAllChildContentS() {
+			if strings.EqualFold(log, collectorName) {
+				c.logZapi = true
+			}
+		}
+	}
+}
+
+func (c *Client) printRequestAndResponse(req string, response []byte) {
+	res := "<nil>"
+	if response != nil {
+		res = string(response)
+	}
+	if req != "" {
+		c.Logger.Info().
+			Str("Request", req).
+			Str("Response", res).
+			Msg("")
+	}
 }

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -414,6 +414,7 @@ type Poller struct {
 	IsKfs          *bool     `yaml:"is_kfs,omitempty"`
 	PollerSchedule *string   `yaml:"poller_schedule,omitempty"`
 	ClientTimeout  *string   `yaml:"client_timeout,omitempty"`
+	LogSet         *[]string `yaml:"log,omitempty"`
 }
 
 func (p *Poller) Union(defaults *Poller) {


### PR DESCRIPTION
when a `poller` includes a `log` section, the matching collector will log that collector's zapi request/response

e.g.

```
Pollers:
  infinity:
    datacenter: ctl
    addr: 10.10.10.10
    log:
      - Zapi                <==== the Zapi collector should log each ZAPI's request/response
      - ZapiPerf         <==== the ZapiPerf collector should do the same
```