### PR TITLE
fix: rpmbuild should ignore python errors

### DIFF
--- a/cmd/collectors/zapi/collector/zapi.go
+++ b/cmd/collectors/zapi/collector/zapi.go
@@ -81,7 +81,7 @@ func (me *Zapi) InitVars() error {
 	if me.Client, err = client.New(me.Params); err != nil { // convert to connection error, so poller aborts
 		return errors.New(errors.ERR_CONNECTION, err.Error())
 	}
-
+	me.Client.TraceLogSet(me.Name, me.Params)
 	if err = me.Client.Init(5); err != nil { // 5 retries before giving up to connect
 		return errors.New(errors.ERR_CONNECTION, err.Error())
 	}

--- a/harvest.cue
+++ b/harvest.cue
@@ -38,4 +38,5 @@ Pollers: [Name=_]: #Poller
 	log_max_files?: int
 	collectors: [...string]
 	exporters: [...string]
+	log: [...string]
 }

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -414,6 +414,7 @@ type Poller struct {
 	IsKfs          *bool     `yaml:"is_kfs,omitempty"`
 	PollerSchedule *string   `yaml:"poller_schedule,omitempty"`
 	ClientTimeout  *string   `yaml:"client_timeout,omitempty"`
+	LogSet         *[]string `yaml:"log,omitempty"`
 }
 
 func (p *Poller) Union(defaults *Poller) {

--- a/rpm/spec
+++ b/rpm/spec
@@ -1,6 +1,7 @@
 
 # version, release and arch will be pasted here
 %define name harvest
+%define _python_bytecompile_errors_terminate_build 0
 
 Name: %{name}
 Summary: Storage System Monitoring


### PR DESCRIPTION
Update rpm/spec to ignore python errors. Fix for issue #385 