### PR TITLE
refactor: remove PrometheusConsul from test

### DIFF
--- a/cmd/tools/doctor/doctor.go
+++ b/cmd/tools/doctor/doctor.go
@@ -87,7 +87,7 @@ func checkExporterTypes(config conf.HarvestConfig) validation {
 			continue
 		}
 		switch *exporter.Type {
-		case "Prometheus", "InfluxDB", "PrometheusConsul":
+		case "Prometheus", "InfluxDB":
 			break
 		default:
 			invalidTypes[name] = *exporter.Type

--- a/cmd/tools/doctor/testdata/testConfig.yml
+++ b/cmd/tools/doctor/testdata/testConfig.yml
@@ -16,13 +16,6 @@ Exporters:
     exporter: Prometheus
     addr: 0.0.0.0
     port: 12990
-  pluto: # name of your exporter, can be any valid yaml string
-    exporter: PrometheusConsul
-    local_http_addr: 1.2.3.4          # ip or hostname of Consul cluster
-    service_name: monitor  # all pollers exporting to pluto will be registered with the service name of 'monitor'
-    tags:
-      - netapp             # each of the pollers exporting to pluto will be tagged with two tags: 'netapp' and 'harvest'
-      - harvest
   influxy:
     exporter: InfluxDB
     addr: localhost


### PR DESCRIPTION
Re-add when PrometheusConsul is implemented. Until then, it's confusing to include as an example