### PR TITLE
fix: disk dashboard status column

### DIFF
--- a/grafana/dashboards/harvest_dashboard_disk.json
+++ b/grafana/dashboards/harvest_dashboard_disk.json
@@ -840,7 +840,7 @@
       "yaxes": [
         {
           "$$hashKey": "object:234",
-          "format": "percentunit",
+          "format": "percent",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1158,13 +1158,12 @@
                 "id": "mappings",
                 "value": [
                   {
-                    "type": "value",
-                    "options": {
-                      " ": {
-                        "text": "Ok",
-                        "index": 0
-                      }
-                    }
+                    "id": 1,
+                    "type": 1,
+                    "from": "",
+                    "to": "",
+                    "text": "Ok",
+                    "value": " "
                   }
                 ]
               }


### PR DESCRIPTION
local testing grafana: http://10.249.28.157:3000/.  [used grafana version for testing: 7.5.10]

Covered these:
1. status column issue
2. disk utilization percentage

I don't think we have issue with 'Disk and Take Drives Throughput' as metric values are in µs and it should be.