### PR TITLE
fix: don't log err when file is missing

### DIFF
--- a/cmd/poller/poller.go
+++ b/cmd/poller/poller.go
@@ -519,7 +519,7 @@ func (p *Poller) loadCollector(c conf.Collector, object string) error {
 		for _, t := range *c.Templates {
 			if subTemplate, err = collector.ImportTemplate(p.options.HomePath, t, class); err != nil {
 				logger.Warn().
-					Err(err).
+					Str("err", err.Error()).
 					Msg("Unable to load template.")
 				continue
 			}


### PR DESCRIPTION
Instead of logging error when custom.yaml is missing like this
```
1:47PM WRN command-line-arguments/poller.go:523 > Unable to load template. error="open conf/zapi/custom.yaml: no such file or directory" Poller=venkat
```

log was warning like this
```
1:50PM WRN command-line-arguments/poller.go:523 > Unable to load template. Poller=venkat err="open conf/zapi/custom.yaml: no such file or directory"
```

The first is in red while the second is a normal log msg