### PR TITLE
fix: reset metadata for each task

### DIFF
--- a/cmd/poller/collector/collector.go
+++ b/cmd/poller/collector/collector.go
@@ -291,6 +291,9 @@ func (me *AbstractCollector) Start(wg *sync.WaitGroup) {
 				taskTime, pluginTime time.Duration
 			)
 
+			// reset task metadata
+			me.Metadata.ResetInstance(task.Name)
+
 			start = time.Now()
 			data, err := task.Run()
 			taskTime = time.Since(start)
@@ -365,16 +368,11 @@ func (me *AbstractCollector) Start(wg *sync.WaitGroup) {
 					pluginTime = time.Since(pluginStart)
 					me.Metadata.LazySetValueInt64("plugin_time", task.Name, pluginTime.Microseconds())
 				}
-
-				// update some metadata
-				me.Metadata.LazySetValueInt64("poll_time", task.Name, task.GetDuration().Microseconds())
-				me.Metadata.LazySetValueInt64("task_time", task.Name, taskTime.Microseconds())
-
-				if apiTime, ok := me.Metadata.LazyGetValueInt64("api_time", task.Name); ok && apiTime != 0 {
-					me.Metadata.LazySetValueFloat64("api_time_percent", task.Name, float64(apiTime)/float64(taskTime.Microseconds())*100)
-				}
-
 			}
+
+			// update task metadata
+			me.Metadata.LazySetValueInt64("poll_time", task.Name, task.GetDuration().Microseconds())
+			me.Metadata.LazySetValueInt64("task_time", task.Name, taskTime.Microseconds())
 		}
 
 		// pass results to exporters

--- a/cmd/poller/collector/collector.go
+++ b/cmd/poller/collector/collector.go
@@ -218,8 +218,6 @@ func Init(c Collector) error {
 	md.NewMetricInt64("parse_time")
 	md.NewMetricInt64("calc_time")
 	md.NewMetricInt64("plugin_time")
-	md.NewMetricInt64("content_length")
-	md.NewMetricFloat64("api_time_percent")
 	md.NewMetricUint64("count")
 	//md.AddLabel("task", "")
 	//md.AddLabel("interval", "")

--- a/pkg/matrix/matrix.go
+++ b/pkg/matrix/matrix.go
@@ -224,6 +224,14 @@ func (me *Matrix) NewInstance(key string) (*Instance, error) {
 	return instance, nil
 }
 
+func (me *Matrix) ResetInstance(key string) {
+	if instance, has := me.instances[key]; has {
+		for _, metric := range me.GetMetrics() {
+			metric.SetValueNAN(instance)
+		}
+	}
+}
+
 func (me *Matrix) RemoveInstance(key string) {
 	if instance, has := me.instances[key]; has {
 		// re-arrange columns in metrics


### PR DESCRIPTION
fix makes sure that metadata of each task is reset only when it's being executed.

other minor changes:
- remove dead metadata metrics: `content_length` and `api_time_percent`
- set the `poll_time` and `task_time` metrics for all tasks, not just `data`