### PR TITLE
fix: FCP send, receive charts with units

### DIFF
--- a/grafana/dashboards/harvest_dashboard_network.json
+++ b/grafana/dashboards/harvest_dashboard_network.json
@@ -217,26 +217,6 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "mappings": [
-            {
-              "from": "",
-              "id": 0,
-              "operator": "",
-              "text": "UP",
-              "to": "",
-              "type": 1,
-              "value": "0"
-            },
-            {
-              "from": "",
-              "id": 1,
-              "operator": "",
-              "text": "DOWN",
-              "to": "",
-              "type": 1,
-              "value": "1"
-            }
-          ],
           "noValue": "n/a",
           "thresholds": {
             "mode": "absolute",
@@ -293,26 +273,6 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "mappings": [
-            {
-              "from": "",
-              "id": 0,
-              "operator": "",
-              "text": "UP",
-              "to": "",
-              "type": 1,
-              "value": "0"
-            },
-            {
-              "from": "",
-              "id": 1,
-              "operator": "",
-              "text": "DOWN",
-              "to": "",
-              "type": 1,
-              "value": "1"
-            }
-          ],
           "noValue": "n/a",
           "thresholds": {
             "mode": "absolute",


### PR DESCRIPTION
FCP send and receive should show like Ethernet send and receive. currently, fcp_write_data and fcp_read_data metric value is 0, that's why graph is horizontal line with 0 B/s.

![image](https://user-images.githubusercontent.com/83282894/130812206-12c84bcb-e633-496e-9009-f47da3727e89.png)
