### PR TITLE
fix: first autosupport runs after delay

### DIFF
--- a/cmd/poller/poller.go
+++ b/cmd/poller/poller.go
@@ -313,7 +313,9 @@ func (p *Poller) Init() error {
 			if err = p.schedule.NewTaskString("asup", asupSchedule, p.startAsup, p.options.Asup, "asup_"+p.name); err != nil {
 				return err
 			}
-			logger.Debug().Msgf("Autosupport scheduled with %s frequency", asupSchedule)
+			logger.Info().
+				Str("asupSchedule", asupSchedule).
+				Msg("Autosupport scheduled.")
 		} else {
 			logger.Info().
 				Str("poller", p.name).
@@ -383,7 +385,7 @@ func (p *Poller) Start() {
 // report metadata and do some housekeeping
 func (p *Poller) Run() {
 
-	// poller schedule has just one task
+	// poller schedule has the poller and asup task (when enabled)
 	task := p.schedule.GetTask("poller")
 	asuptask := p.schedule.GetTask("asup")
 

--- a/cmd/poller/schedule/schedule.go
+++ b/cmd/poller/schedule/schedule.go
@@ -159,7 +159,7 @@ func (s *Schedule) NewTask(n string, i time.Duration, f func() (*matrix.Matrix, 
 			if runNow {
 				t.timer = time.Now().Add(-i) // set to run immediately
 			} else {
-				t.timer = time.Now().Add(i) // run after interval
+				t.timer = time.Now().Add(0) // run after interval has elapsed
 			}
 			s.tasks = append(s.tasks, t)
 			return nil


### PR DESCRIPTION
If the schedule is once a week, the first time autosupport runs, it instead runs after two weeks.

```
time |---X----f----y----|
         ^    ^               
         |    |                 
   now --     ---- future                 
```

That's because when a task is created and added to the schedule at X, a time in the future is calculated (current time + 1 week), at f.
 
Later, when a go routine checks if the future task is due to run, it determines that by calculating: one week - time.Since(f), but since f is already a week in the future. The task won't run until y, which is two weeks after X was scheduled.

The fix: when the task is scheduled, schedule it at the current time instead of current time + 1 week.