### PR TITLE
fix: typo in nfsv4 template causes mislabeling

### DIFF
--- a/conf/zapiperf/cdot/9.8.0/nfsv4.yaml
+++ b/conf/zapiperf/cdot/9.8.0/nfsv4.yaml
@@ -3,7 +3,7 @@ name:                     NFSv4
 query:                    nfsv4
 object:                   svm_nfs
 
-global_label:
+global_labels:
   - nfsv: v4
 
 counters:


### PR DESCRIPTION
Thanks to Jeff Asher for reporting this