### PR TITLE
fix: consuming node status from diagnosis-config-get-iter zapi for 7mode

### DIFF
--- a/conf/zapi/7mode/8.6.0/status_7.yaml
+++ b/conf/zapi/7mode/8.6.0/status_7.yaml
@@ -1,0 +1,24 @@
+# API provides over system health of a cluster
+
+name:       Status_7mode
+query:      diagnosis-config-get-iter
+object:     node
+
+counters:
+  diagnosis-config-info:
+    - ^health                       => health
+    - ^^monitor                     => monitor
+    - mon-version                   => monitor_version
+
+collect_only_labels: true
+
+plugins:
+  - LabelAgent:
+    value_mapping: 7mode_status health ok `1`
+    # metric label zapi_value rest_value `default_value`
+    value_to_num: 7mode_new_status health ok todo `0`
+
+export_options:
+  instance_keys:
+    - monitor
+    - health

--- a/conf/zapi/7mode/8.6.0/status_7.yaml
+++ b/conf/zapi/7mode/8.6.0/status_7.yaml
@@ -14,9 +14,8 @@ collect_only_labels: true
 
 plugins:
   - LabelAgent:
-    value_mapping: 7mode_status health ok `1`
     # metric label zapi_value rest_value `default_value`
-    value_to_num: 7mode_new_status health ok todo `0`
+    value_to_num: 7mode_status health ok todo `0`
 
 export_options:
   instance_keys:

--- a/conf/zapi/default.yaml
+++ b/conf/zapi/default.yaml
@@ -16,3 +16,4 @@ objects:
   Status:           status.yaml
   Subsystem:        subsystem.yaml
   Lun:              lun.yaml
+  Status_7mode:     status_7.yaml

--- a/grafana/dashboards/7mode/harvest_dashboard_cluster7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_cluster7.json
@@ -236,7 +236,7 @@
         },
         {
           "exemplar": false,
-          "expr": "cluster_new_status{datacenter=\"$Datacenter\",cluster=\"$Cluster\"}",
+          "expr": "node_7mode_new_status{datacenter=\"$Datacenter\",cluster=\"$Cluster\",monitor=\"node-connect\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -406,7 +406,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^status$/",
+          "fields": "/^health$/",
           "values": false
         },
         "text": {},
@@ -418,7 +418,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "cluster_new_status{datacenter=~\"$Datacenter\",cluster=\"$Cluster\"}",
+          "expr": "node_7mode_new_status{datacenter=\"$Datacenter\",cluster=\"$Cluster\", monitor=\"node-connect\"}",
           "instant": true,
           "interval": "",
           "legendFormat": "",

--- a/grafana/dashboards/7mode/harvest_dashboard_cluster7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_cluster7.json
@@ -236,7 +236,7 @@
         },
         {
           "exemplar": false,
-          "expr": "node_7mode_new_status{datacenter=\"$Datacenter\",cluster=\"$Cluster\",monitor=\"node-connect\"}",
+          "expr": "node_7mode_status{datacenter=\"$Datacenter\",cluster=\"$Cluster\",monitor=\"node-connect\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -418,7 +418,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "node_7mode_new_status{datacenter=\"$Datacenter\",cluster=\"$Cluster\", monitor=\"node-connect\"}",
+          "expr": "node_7mode_status{datacenter=\"$Datacenter\",cluster=\"$Cluster\", monitor=\"node-connect\"}",
           "instant": true,
           "interval": "",
           "legendFormat": "",


### PR DESCRIPTION
using diagnosis-config-get-iter zapi to get node status with monitor type as node-connect

![image](https://user-images.githubusercontent.com/83282894/132662189-d0869afa-1499-43d8-8f54-2e0280653ccb.png)
