### PR TITLE
fix: escape whitespace in InfluxDB exporter

### DIFF
--- a/cmd/exporters/influxdb/influxdb.go
+++ b/cmd/exporters/influxdb/influxdb.go
@@ -10,6 +10,7 @@ import (
 	"goharvest2/pkg/color"
 	"goharvest2/pkg/errors"
 	"goharvest2/pkg/matrix"
+	"goharvest2/pkg/util"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -112,7 +113,8 @@ func (e *InfluxDB) Init() error {
 
 		urlToUSe := "http://" + *addr + ":" + strconv.Itoa(*port)
 		url = &urlToUSe
-		e.url = fmt.Sprintf("%s/api/v%s/write?org=%s&bucket=%s&precision=%s", *url, *version, *org, *bucket, *precision)
+		e.url = fmt.Sprintf("%s/api/v%s/write?org=%s&bucket=%s&precision=%s", *url, *version, util.EscapeUrl(*org),
+			util.EscapeUrl(*bucket), *precision)
 	} else {
 		e.url = *url
 	}

--- a/cmd/exporters/influxdb/influxdb.go
+++ b/cmd/exporters/influxdb/influxdb.go
@@ -1,6 +1,7 @@
 /*
  * Copyright NetApp Inc, 2021 All rights reserved
  */
+
 package influxdb
 
 import (
@@ -10,9 +11,9 @@ import (
 	"goharvest2/pkg/color"
 	"goharvest2/pkg/errors"
 	"goharvest2/pkg/matrix"
-	"goharvest2/pkg/util"
 	"io/ioutil"
 	"net/http"
+	url2 "net/url"
 	"strconv"
 	"time"
 )
@@ -113,8 +114,8 @@ func (e *InfluxDB) Init() error {
 
 		urlToUSe := "http://" + *addr + ":" + strconv.Itoa(*port)
 		url = &urlToUSe
-		e.url = fmt.Sprintf("%s/api/v%s/write?org=%s&bucket=%s&precision=%s", *url, *version, util.EscapeUrl(*org),
-			util.EscapeUrl(*bucket), *precision)
+		e.url = fmt.Sprintf("%s/api/v%s/write?org=%s&bucket=%s&precision=%s",
+			*url, *version, url2.PathEscape(*org), url2.PathEscape(*bucket), *precision)
 	} else {
 		e.url = *url
 	}

--- a/cmd/exporters/influxdb/influxdb_test.go
+++ b/cmd/exporters/influxdb/influxdb_test.go
@@ -111,6 +111,20 @@ func TestExportDebug(t *testing.T) {
 	}
 }
 
+// test that whitespace is escaped in the  parameters
+// are handled properly to construct server URL
+func TestWhiteSpaceInParameter(t *testing.T) {
+	expectedURL := "http://localhost:8086/api/v2/write?org=harvest%202&bucket=harvest%20%2009&precision=s"
+	exporterName := "influx-test-space"
+	influx := setupInfluxDB(exporterName, t)
+
+	if influx.url == expectedURL {
+		t.Logf("OK - url: [%s]", expectedURL)
+	} else {
+		t.Fatalf("FAIL - expected [%s]\n                             got [%s]", expectedURL, influx.url)
+	}
+}
+
 /* Uncomment to test against a running InfluxDB instance
    ! Edit the params values below
    ! Uncomment import "goharvest2/share/tree/node"

--- a/cmd/exporters/influxdb/influxdb_test.go
+++ b/cmd/exporters/influxdb/influxdb_test.go
@@ -118,9 +118,7 @@ func TestWhiteSpaceInParameter(t *testing.T) {
 	exporterName := "influx-test-space"
 	influx := setupInfluxDB(exporterName, t)
 
-	if influx.url == expectedURL {
-		t.Logf("OK - url: [%s]", expectedURL)
-	} else {
+	if influx.url != expectedURL {
 		t.Fatalf("FAIL - expected [%s]\n                             got [%s]", expectedURL, influx.url)
 	}
 }

--- a/cmd/tools/doctor/testdata/testConfig.yml
+++ b/cmd/tools/doctor/testdata/testConfig.yml
@@ -51,6 +51,13 @@ Exporters:
     version: 4
     port: 8088
     token: abcdefghijklmnopqrstuvwxyz
+  influx-test-space:
+    exporter: InfluxDB
+    addr: localhost
+    port: 8086
+    org: harvest 2
+    bucket: harvest  09
+    token: REDACTED
 Defaults:
   collectors:
     - Zapi

--- a/jenkins/artifacts/jenkinsfile
+++ b/jenkins/artifacts/jenkinsfile
@@ -155,7 +155,7 @@ pipeline {
     stage('Run Tests') {
         when {
             expression {
-                return env.RUN_TEST == 'true';
+                return params.RUN_TEST == 'true';
             }
         }
         steps {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
@@ -124,6 +125,10 @@ func RemoveEmptyStrings(s []string) []string {
 		}
 	}
 	return r
+}
+
+func EscapeUrl(urlParam string) string {
+	return url.PathEscape(urlParam)
 }
 
 func GetPid(pollerName string) ([]int, error) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
@@ -125,10 +124,6 @@ func RemoveEmptyStrings(s []string) []string {
 		}
 	}
 	return r
-}
-
-func EscapeUrl(urlParam string) string {
-	return url.PathEscape(urlParam)
 }
 
 func GetPid(pollerName string) ([]int, error) {


### PR DESCRIPTION
Add url encoding for bucket and org parameter in InfluxDB parameters