### PR TITLE
fix: node_new_status correction for 7mode

### DIFF
--- a/conf/zapi/7mode/8.6.0/node.yaml
+++ b/conf/zapi/7mode/8.6.0/node.yaml
@@ -19,14 +19,6 @@ counters:
 
 
 
-plugins:
-  - LabelAgent:
-    value_mapping:
-      - status healthy true `1`
-    # metric label zapi_value rest_value `default_value`
-    value_to_num:
-      - new_status healthy true up `0`
-
 export_options:
   require_instance_keys: false
   instance_labels:

--- a/conf/zapi/7mode/8.6.0/status_7.yaml
+++ b/conf/zapi/7mode/8.6.0/status_7.yaml
@@ -16,7 +16,10 @@ plugins:
   - LabelAgent:
     # metric label zapi_value rest_value `default_value`
     value_to_num:
-      - 7mode_status health ok todo `0`
+      - new_status health ok todo `0`
+    exclude_equals:
+      - monitor `controller`
+      - monitor `system`
 
 export_options:
   instance_keys:

--- a/conf/zapi/7mode/8.6.0/status_7.yaml
+++ b/conf/zapi/7mode/8.6.0/status_7.yaml
@@ -14,6 +14,8 @@ collect_only_labels: true
 
 plugins:
   - LabelAgent:
+    value_mapping:
+      - status health ok `1`
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status health ok todo `0`

--- a/grafana/dashboards/7mode/harvest_dashboard_cluster7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_cluster7.json
@@ -236,7 +236,7 @@
         },
         {
           "exemplar": false,
-          "expr": "node_7mode_status{datacenter=\"$Datacenter\",cluster=\"$Cluster\",monitor=\"node-connect\"}",
+          "expr": "node_new_status{datacenter=\"$Datacenter\",cluster=\"$Cluster\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -418,7 +418,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "node_7mode_status{datacenter=\"$Datacenter\",cluster=\"$Cluster\", monitor=\"node-connect\"}",
+          "expr": "node_new_status{datacenter=\"$Datacenter\",cluster=\"$Cluster\"}",
           "instant": true,
           "interval": "",
           "legendFormat": "",


### PR DESCRIPTION
Before the change:
![image](https://user-images.githubusercontent.com/83282894/134914682-4d9cae8f-4821-41cc-aa7a-50805c62d7a7.png)

and we only want node-connect monitor for our use-case in 7mode
![image](https://user-images.githubusercontent.com/83282894/134914749-845edc5f-2390-4464-b878-7c099fea42bc.png)


After the change:
removed the node_7mode_status metric and updated the dashboards as well.
![image](https://user-images.githubusercontent.com/83282894/134914771-30abc2b7-6c85-4141-a5ea-667e0e7d1271.png)

![image](https://user-images.githubusercontent.com/83282894/134914784-3e408ca3-f657-475b-afa5-4ca13bb8a658.png)
