### PR TITLE
fix: space used % query correction[cluster, aggregate]

### DIFF
--- a/grafana/dashboards/7mode/harvest_dashboard_aggregate7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_aggregate7.json
@@ -445,7 +445,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "avg(aggr_space_used_percent{datacenter=\"$Datacenter\",node=~\"$Node\",aggr=~\"$Aggregate\"})",
+          "expr": "100*sum(aggr_space_used{datacenter=\"$Datacenter\",node=~\"$Node\",aggr=~\"$Aggregate\"})/sum(aggr_space_total{datacenter=\"$Datacenter\",node=~\"$Node\",aggr=~\"$Aggregate\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"

--- a/grafana/dashboards/7mode/harvest_dashboard_cluster7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_cluster7.json
@@ -892,7 +892,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "avg(aggr_space_used_percent{datacenter=~\"$Datacenter\",node=\"$Node\"})",
+          "expr": "100*sum(aggr_space_used{datacenter=~\"$Datacenter\",node=\"$Node\"})/sum(aggr_space_total{datacenter=~\"$Datacenter\",node=\"$Node\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "",

--- a/grafana/dashboards/harvest_dashboard_aggregate.json
+++ b/grafana/dashboards/harvest_dashboard_aggregate.json
@@ -445,7 +445,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "avg(aggr_space_used_percent{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"})",
+          "expr": "100*sum(aggr_space_used{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"})/sum(aggr_space_total{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"

--- a/grafana/dashboards/harvest_dashboard_cluster.json
+++ b/grafana/dashboards/harvest_dashboard_cluster.json
@@ -892,7 +892,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "avg(aggr_space_used_percent{datacenter=~\"$Datacenter\",cluster=\"$Cluster\"})",
+          "expr": "100*sum(aggr_space_used{datacenter=~\"$Datacenter\",cluster=\"$Cluster\"})/sum(aggr_space_total{datacenter=~\"$Datacenter\",cluster=\"$Cluster\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "",


### PR DESCRIPTION
Fixing this:
Issue 2: "Space Used%” calculation is questionable from us when looking at the “Total Space” and "Available Space”


detail: 
At datacenter level, earlier it was averaging the percentage value which was showing wrong number, Now calculating based on used and total.