### PR TITLE
fix: prometheus datasource missing on dashboards

### DIFF
--- a/conf/zapi/cdot/9.8.0/volume.yaml
+++ b/conf/zapi/cdot/9.8.0/volume.yaml
@@ -27,7 +27,7 @@ counters:
       - percentage-compression-space-saved    => sis_compress_saved_percent
       - percentage-deduplication-space-saved  => sis_dedup_saved_percent
       - percentage-total-space-saved          => sis_total_saved_percent
-      - ^is-sis-volume                        => is-sis-volume
+      - ^is-sis-volume                        => is_sis_volume
 
     - volume-space-attributes:
       - expected-available
@@ -78,5 +78,5 @@ export_options:
     - style
   instance_labels:
     - state
-    - is-sis-volume
+    - is_sis_volume
 

--- a/grafana/dashboards/7mode/harvest_dashboard_disk7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_disk7.json
@@ -1920,6 +1920,24 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "selected": false,

--- a/grafana/dashboards/7mode/harvest_dashboard_nvme_fc7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_nvme_fc7.json
@@ -2312,6 +2312,24 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",

--- a/grafana/dashboards/cmode/harvest_dashboard_disk.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_disk.json
@@ -1940,6 +1940,24 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "selected": false,

--- a/grafana/dashboards/cmode/harvest_dashboard_network_detail.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_network_detail.json
@@ -2580,6 +2580,24 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",

--- a/grafana/dashboards/cmode/harvest_dashboard_nvme_fc.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_nvme_fc.json
@@ -3170,6 +3170,24 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",


### PR DESCRIPTION
fix: label name contains dash

curl -s http://localhost:12994/metrics | promtool check metrics
error while linting: text format parsing error in line 1817: expected '=' after label name, found '-'

Fixes #562