### PR TITLE
fix: Change loglevel from error to warning when no best template found

### DIFF
--- a/cmd/collectors/zapi/collector/zapi.go
+++ b/cmd/collectors/zapi/collector/zapi.go
@@ -106,7 +106,7 @@ func (me *Zapi) InitVars() error {
 
 	template, err := me.ImportSubTemplate(model, me.TemplateFn, me.Client.Version())
 	if err != nil {
-		me.Logger.Warn().Stack().Err(err).Msgf("Error importing subtemplate: %s", me.TemplateFn)
+		me.Logger.Warn().Stack().Err(err).Str("template", me.TemplateFn).Msg("Unable to import template")
 		return err
 	}
 	me.Params.Union(template)


### PR DESCRIPTION
Before:
```
hardikl@hardikl-mac-0 harvest % ./bin/poller --poller cluster-01 --loglevel 2  --promPort 12991  -c Zapi --config harvest.yml
10:54AM INF ./poller.go:176 > log level used: info Poller=cluster-01
10:54AM INF ./poller.go:177 > options config: harvest.yml Poller=cluster-01
10:54AM INF ./poller.go:214 > started in foreground [pid=3451] Poller=cluster-01
10:54AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/node.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Node
10:54AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/aggr.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Aggregate
10:54AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/volume.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Volume
10:54AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/snapmirror.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:SnapMirror
10:54AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/disk.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Disk
10:54AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/shelf.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Shelf
10:54AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/status.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Status
10:54AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/subsystem.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Subsystem
10:55AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/lun.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Lun
10:55AM ERR goharvest2/cmd/collectors/zapi/collector/zapi.go:109 > Error importing subtemplate: status_7.yaml error="No best-fit template found" Poller=cluster-01 collector=Zapi:Status_7mode
10:55AM WRN ./poller.go:647 > init collector-object (Zapi:Status_7mode): No best-fit template found Poller=cluster-01
10:55AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/sensor.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Sensor
10:55AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/qtree.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Qtree
10:55AM INF ./poller.go:338 > Autosupport scheduled. Poller=cluster-01 asupSchedule=24h
10:55AM INF ./poller.go:347 > poller start-up complete Poller=cluster-01
```



After the change:
```
hardikl@hardikl-mac-0 harvest % ./bin/poller --poller cluster-01 --loglevel 2  --promPort 12991  -c Zapi --config harvest.yml
11:01AM INF ./poller.go:177 > log level used: info Poller=cluster-01
11:01AM INF ./poller.go:178 > options config: harvest.yml Poller=cluster-01
11:01AM INF ./poller.go:215 > started in foreground [pid=4003] Poller=cluster-01
11:01AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/node.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Node
11:01AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/aggr.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Aggregate
11:01AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/volume.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Volume
11:01AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/snapmirror.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:SnapMirror
11:01AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/disk.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Disk
11:01AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/shelf.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Shelf
11:01AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/status.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Status
11:01AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/subsystem.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Subsystem
11:01AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/lun.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Lun
11:01AM WRN goharvest2/cmd/collectors/zapi/collector/zapi.go:110 > Error importing subtemplate: status_7.yaml error="No best-fit template found" Poller=cluster-01 collector=Zapi:Status_7mode
11:01AM WRN ./poller.go:648 > init collector-object (Zapi:Status_7mode): No best-fit template found Poller=cluster-01
11:01AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/sensor.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Sensor
11:01AM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapi/cdot/9.8.0/qtree.yaml] for [9.5.0] Poller=cluster-01 collector=Zapi:Qtree
11:01AM INF ./poller.go:339 > Autosupport scheduled. Poller=cluster-01 asupSchedule=24h
11:01AM INF ./poller.go:348 > poller start-up complete Poller=cluster-01
```
