### PR TITLE
refactor: remove value_mapping

### DIFF
--- a/cmd/poller/plugin/README.md
+++ b/cmd/poller/plugin/README.md
@@ -91,7 +91,7 @@ The plugin tries to intelligently aggregate metrics based on a few rules:
   - metric name has prefix `average_` or `avg_`
   - metric has property (`metric.GetProperty()`) `percent` or `average`
 - **Weighted Average** - applied if metric has property `average` and suffix `_latency` and if there is a matching `_ops` metric. (This is currently only matching to ZapiPerf metrics, which use the Property field of metrics.)
-- **Ignore** - metrics created by some plugins, such as value_mapping by LabelAgent
+- **Ignore** - metrics created by some plugins, such as value_to_num by LabelAgent
 
 # LabelAgent
 LabelAgent allows to manipulate instance labels based on rules. You can define multiple rules, here is an example of what you could add to the yaml file of a collector:
@@ -107,17 +107,22 @@ plugins:
 
 Notice that the rules are executed in the same order as you've added them. List of currently available rules:
 
-- [split](#split)
-- [split_regex](#split_regex)
-- [split_pairs](#split_pairs)
-- [join](#join)
-- [replace](#replace)
-- [replace_regex](#replace_regex)
-- [exclude_equals](#exclude_equals)
-- [exclude_contains](#exclude_contains)
-- [exclude_regex](#exclude_regex)
-- [value_mapping](#value_mapping)
-- [value_to_num](#value_to_num)
+- [Built-in Plugins](#built-in-plugins)
+- [Aggregator](#aggregator)
+    - [Rule syntax](#rule-syntax)
+    - [Aggregation rules](#aggregation-rules)
+- [LabelAgent](#labelagent)
+  - [split](#split)
+  - [split_regex](#split_regex)
+  - [split_pairs](#split_pairs)
+  - [join](#join)
+  - [replace](#replace)
+  - [replace_regex](#replace_regex)
+  - [exclude_equals](#exclude_equals)
+  - [exclude_contains](#exclude_contains)
+  - [exclude_regex](#exclude_regex)
+  - [value_mapping](#value_mapping)
+  - [value_to_num](#value_to_num)
 
 ## split
 
@@ -298,43 +303,14 @@ exclude_equals: vol_type `flexgroup_`
 
 ## value_mapping
 
-value_mapping is deprecated and you should always use value_to_num mapping.
-
-Maps values of a given label to a numeric metric (of type `uint8`). This is sometimes handy to manipulate the data in the DB or Grafana (e.g. change color based on status or create alert).
-
-Note that you don't define the numeric values yourself, instead, you only provide the possible (expected) values, the plugin will map each value to its index in the rule.
-
-Rule syntax:
-
-```yaml
-value_mapping: METRIC LABEL VALUE1,VALUE2 `N`
-# maps values of LABEL to 0 or 1 if it is VALUE1 or VALUE2 (respectively)
-# otherwise value of METRIC is set to N
-```
-The default value `N` is optional, if no default value is given and the label value does not match to any of the given values, the metric value will not be set.
-
-Examples:
-
-```yaml
-value_mapping: status state up,sleeping,unknown,down
-# a new metric will be crreated with the name "status"
-# if an instance has label "state" with value "up", the metric value will be 0,
-# if it's "sleeping", the value will be set to 1, etc.
-```
-
-```yaml
-value_mapping: status state up `1`
-# metric value will be set to 0 if "state" is "up", otherwise to **1**
-```
-
+value_mapping was deprecated in 21.11 and removed in 22.02. Use [value_to_num mapping](#value_to_num) instead.
 
 ## value_to_num
 
-This rule is similar to value_mapping but in this mapping, healthy is mapped to 1 and all non healthy values are mapped to 0.
+Maps values of a given label to a numeric metric (of type `uint8`).
+This rule maps values of a given label to a numeric metric (of type `unit8`). Healthy is mapped to 1 and all non-healthy values are mapped to 0.
 
-Going further, We should always use value_to_num mapping as value_mapping is deprecated.
-
-Maps values of a given label to a numeric metric (of type `uint8`). This is sometimes handy to manipulate the data in the DB or Grafana (e.g. change color based on status or create alert).
+This is handy to manipulate the data in the DB or Grafana (e.g. change color based on status or create alert).
 
 Note that you don't define the numeric values yourself, instead, you only provide the possible (expected) values, the plugin will map each value to its index in the rule.
 

--- a/conf/zapi/7mode/8.6.0/aggr.yaml
+++ b/conf/zapi/7mode/8.6.0/aggr.yaml
@@ -54,8 +54,6 @@ counters:
 
 plugins:
   LabelAgent:
-    value_mapping:
-      - status state online `1`
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status state online online `0`

--- a/conf/zapi/7mode/8.6.0/disk.yaml
+++ b/conf/zapi/7mode/8.6.0/disk.yaml
@@ -24,8 +24,6 @@ counters:
 
 plugins:
   - LabelAgent:
-    value_mapping:
-      - status offline false `0`
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status offline - - `0` #ok_value is empty value, '-' would be converted to blank while processing.

--- a/conf/zapi/7mode/8.6.0/lun.yaml
+++ b/conf/zapi/7mode/8.6.0/lun.yaml
@@ -18,7 +18,6 @@ counters:
 
 plugins:
   - LabelAgent:
-    value_mapping: status online true `1`
     # metric label zapi_value rest_value `default_value`
     value_to_num: new_status online true true `0`
     # path is something like "/vol/vol_georg_fcp401/lun401"

--- a/conf/zapi/7mode/8.6.0/shelf.yaml
+++ b/conf/zapi/7mode/8.6.0/shelf.yaml
@@ -77,8 +77,6 @@ plugins:
 #        - ^power-supply-is-error
 #        - ^power-supply-is-not-installed
   LabelAgent:
-    value_mapping:
-      - status state normal `1`
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status state normal ok `0`

--- a/conf/zapi/7mode/8.6.0/status.yaml
+++ b/conf/zapi/7mode/8.6.0/status.yaml
@@ -16,8 +16,6 @@ no_max_records: true
 
 plugins:
   - LabelAgent:
-    value_mapping:
-      - status status ok `1`
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status status ok ok `0`

--- a/conf/zapi/7mode/8.6.0/status_7.yaml
+++ b/conf/zapi/7mode/8.6.0/status_7.yaml
@@ -16,8 +16,6 @@ collect_only_labels: true
 
 plugins:
   - LabelAgent:
-    value_mapping:
-      - status health ok `1`
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status health ok todo `0`

--- a/conf/zapi/7mode/8.6.0/subsystem.yaml
+++ b/conf/zapi/7mode/8.6.0/subsystem.yaml
@@ -16,8 +16,6 @@ counters:
 
 plugins:
   - LabelAgent:
-    value_mapping:
-      - status health ok `1`
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status health ok todo `0`  # REST gap will be filled up later.

--- a/conf/zapi/7mode/8.6.0/volume.yaml
+++ b/conf/zapi/7mode/8.6.0/volume.yaml
@@ -32,8 +32,6 @@ counters:
 
 plugins:
   LabelAgent:
-    value_mapping:
-      - status state online `1`
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status state online online `0`

--- a/conf/zapi/cdot/9.8.0/aggr.yaml
+++ b/conf/zapi/cdot/9.8.0/aggr.yaml
@@ -60,8 +60,6 @@ counters:
 
 plugins:
   LabelAgent:
-    value_mapping:
-      - status state online `1`
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status state online online `0`

--- a/conf/zapi/cdot/9.8.0/disk.yaml
+++ b/conf/zapi/cdot/9.8.0/disk.yaml
@@ -34,8 +34,6 @@ counters:
 
 plugins:
   - LabelAgent:
-    value_mapping:
-      - status outage , `0` # ok_value is empty value
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status outage - - `0` #ok_value is empty value, '-' would be converted to blank while processing.

--- a/conf/zapi/cdot/9.8.0/lun.yaml
+++ b/conf/zapi/cdot/9.8.0/lun.yaml
@@ -17,8 +17,6 @@ counters:
 
 plugins:
   - LabelAgent:
-    value_mapping:
-      - status state online `1`
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status state online online `0`

--- a/conf/zapi/cdot/9.8.0/node.yaml
+++ b/conf/zapi/cdot/9.8.0/node.yaml
@@ -41,8 +41,6 @@ counters:
 
 plugins:
   - LabelAgent:
-    value_mapping:
-      - status healthy true `1`
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status healthy true up `0`

--- a/conf/zapi/cdot/9.8.0/shelf.yaml
+++ b/conf/zapi/cdot/9.8.0/shelf.yaml
@@ -63,8 +63,6 @@ plugins:
           - voltage-sensor-reading => reading
 
   LabelAgent:
-    value_mapping:
-      - status op_status normal `1`
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status state online ok `0`

--- a/conf/zapi/cdot/9.8.0/status.yaml
+++ b/conf/zapi/cdot/9.8.0/status.yaml
@@ -12,8 +12,6 @@ no_max_records: true
 
 plugins:
   - LabelAgent:
-    value_mapping:
-      - status status ok `1`
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status status ok ok `0`

--- a/conf/zapi/cdot/9.8.0/subsystem.yaml
+++ b/conf/zapi/cdot/9.8.0/subsystem.yaml
@@ -12,8 +12,6 @@ counters:
 
 plugins:
   - LabelAgent:
-    value_mapping:
-      - status health ok `1`
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status health ok todo `0`  # REST gap will be filled up later.

--- a/conf/zapi/cdot/9.8.0/volume.yaml
+++ b/conf/zapi/cdot/9.8.0/volume.yaml
@@ -60,8 +60,6 @@ counters:
 
 plugins:
   LabelAgent:
-    value_mapping:
-      - status state online `1`
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status state online online `0`

--- a/conf/zapiperf/7mode/8.2.5/nic_common.yaml
+++ b/conf/zapiperf/7mode/8.2.5/nic_common.yaml
@@ -33,8 +33,6 @@ override:
 plugins:
   - Nic
   - LabelAgent:
-    value_mapping:
-      - status state up `1`
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status state up up `0`

--- a/conf/zapiperf/cdot/9.8.0/nic_common.yaml
+++ b/conf/zapiperf/cdot/9.8.0/nic_common.yaml
@@ -30,8 +30,6 @@ override:
 plugins:
   - Nic
   - LabelAgent:
-    value_mapping:
-      - status state up `1`
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status state up up `0`

--- a/pkg/test/mergeTemplates/21.08.0_lun_merge_21.08.0_extended.yaml
+++ b/pkg/test/mergeTemplates/21.08.0_lun_merge_21.08.0_extended.yaml
@@ -14,9 +14,6 @@ counters:
     - ^vserver => svm
 plugins:
   LabelAgent:
-    value_mapping:
-      - status state online `1`
-      - custom_status state online `1`
     value_to_num:
       - new_status state online online `0`
     split:

--- a/pkg/test/mergeTemplates/21.08.0_lun_merge_extended.yaml
+++ b/pkg/test/mergeTemplates/21.08.0_lun_merge_extended.yaml
@@ -14,9 +14,6 @@ counters:
     - ^vserver => svm
 plugins:
   LabelAgent:
-    value_mapping:
-      - status state online `1`
-      - custom_status state online `1`
     value_to_num:
       - new_status state online online `0`
     split:

--- a/pkg/test/mergeTemplates/lun_merge.yaml
+++ b/pkg/test/mergeTemplates/lun_merge.yaml
@@ -14,9 +14,6 @@ counters:
     - ^vserver => svm
 plugins:
   LabelAgent:
-    value_mapping:
-      - status state online `1`
-      - custom_status state online `1`
     value_to_num:
       - new_status state online online `0`
     split:

--- a/pkg/test/mergeTemplates/lun_merge_21.08.0_extended.yaml
+++ b/pkg/test/mergeTemplates/lun_merge_21.08.0_extended.yaml
@@ -14,9 +14,6 @@ counters:
     - ^vserver => svm
 plugins:
   LabelAgent:
-    value_mapping:
-      - status state online `1`
-      - custom_status state online `1`
     value_to_num:
       - new_status state online online `0`
     split:

--- a/pkg/test/node_test.go
+++ b/pkg/test/node_test.go
@@ -93,20 +93,6 @@ func TestNode_MergeCollector(t *testing.T) {
 		t.Errorf("got %v, want %v", got1, want1)
 	}
 
-	// plugins labelagent add new child to existing plugin
-	want2 := 2
-	got2 := 0
-	counters = defaultTemplate.GetChildS("plugins").GetChildS("LabelAgent").GetChildS("value_mapping")
-	if counters != nil {
-		for range counters.GetChildren() {
-			got2 += 1
-		}
-	}
-
-	if got2 != want2 {
-		t.Errorf("got %v, want %v", got2, want2)
-	}
-
 	// plugins labelagent add same child to existing plugin
 	want3 := 1
 	got3 := 0
@@ -226,24 +212,10 @@ func TestNode_MergeCollectorOld(t *testing.T) {
 	customTemplate.PreprocessTemplate()
 	defaultTemplate.Merge(customTemplate, nil)
 
-	// plugins labelagent add new child to existing plugin
-	want2 := 2
-	got2 := 0
-	counters := defaultTemplate.GetChildS("plugins").GetChildS("LabelAgent").GetChildS("value_mapping")
-	if counters != nil {
-		for range counters.GetChildren() {
-			got2 += 1
-		}
-	}
-
-	if got2 != want2 {
-		t.Errorf("got %v, want %v", got2, want2)
-	}
-
 	// plugins labelagent add same child to existing plugin
 	want3 := 1
 	got3 := 0
-	counters = defaultTemplate.GetChildS("plugins").GetChildS("LabelAgent").GetChildS("value_to_num")
+	counters := defaultTemplate.GetChildS("plugins").GetChildS("LabelAgent").GetChildS("value_to_num")
 	if counters != nil {
 		for range counters.GetChildren() {
 			got3 += 1

--- a/pkg/test/preProcessResultData/p_21.08.0_extend_lun.yaml
+++ b/pkg/test/preProcessResultData/p_21.08.0_extend_lun.yaml
@@ -1,8 +1,6 @@
 plugins:
   - nic
   LabelAgent:
-    value_mapping:
-      - custom_status state online `1`
     value_to_num:
       - new_status state online online `0`
     new_mapping:

--- a/pkg/test/preProcessResultData/p_21.08.0_lun.yaml
+++ b/pkg/test/preProcessResultData/p_21.08.0_lun.yaml
@@ -14,8 +14,6 @@ counters:
     - ^vserver => svm
 plugins:
   LabelAgent:
-    value_mapping:
-      - status state online `1`
     value_to_num:
       - new_status state online online `0`
     split:

--- a/pkg/test/preProcessResultData/p_extend_lun.yaml
+++ b/pkg/test/preProcessResultData/p_extend_lun.yaml
@@ -4,8 +4,6 @@ counters:
     - ^vserver => svm
 plugins:
   LabelAgent:
-    value_mapping:
-      - custom_status state online `1`
     value_to_num:
       - new_status state online online `0`
     new_mapping:

--- a/pkg/test/preProcessResultData/p_lun.yaml
+++ b/pkg/test/preProcessResultData/p_lun.yaml
@@ -14,8 +14,6 @@ counters:
     - ^vserver => svm
 plugins:
   LabelAgent:
-    value_mapping:
-      - status state online `1`
     value_to_num:
       - new_status state online online `0`
     split:

--- a/pkg/test/testdata/21.08.0_extend_lun.yaml
+++ b/pkg/test/testdata/21.08.0_extend_lun.yaml
@@ -1,7 +1,6 @@
 plugins:
   - nic
   LabelAgent:
-    value_mapping: custom_status state online `1`
     value_to_num: new_status state online online `0`
     new_mapping: xyz
   Aggregator:

--- a/pkg/test/testdata/21.08.0_lun.yaml
+++ b/pkg/test/testdata/21.08.0_lun.yaml
@@ -14,7 +14,6 @@ counters:
     - ^vserver => svm
 plugins:
   - LabelAgent:
-    value_mapping: status state online `1`
     value_to_num: new_status state online online `0`
     split: path `/` ,,,lun
 export_options:

--- a/pkg/test/testdata/extend_lun.yaml
+++ b/pkg/test/testdata/extend_lun.yaml
@@ -4,8 +4,6 @@ counters:
     - ^vserver => svm
 plugins:
   LabelAgent:
-    value_mapping:
-      - custom_status state online `1`
     value_to_num:
       - new_status state online online `0`
     new_mapping:

--- a/pkg/test/testdata/lun.yaml
+++ b/pkg/test/testdata/lun.yaml
@@ -14,8 +14,6 @@ counters:
     - ^vserver => svm
 plugins:
   LabelAgent:
-    value_mapping:
-      - status state online `1`
     value_to_num:
       - new_status state online online `0`
     split:


### PR DESCRIPTION
`value_mapping` was deprecated in 21.11 and removed in next release