### PR TITLE
fix: network detail dashboard issues

### DIFF
--- a/cmd/collectors/zapiperf/plugins/nic/nic.go
+++ b/cmd/collectors/zapiperf/plugins/nic/nic.go
@@ -78,11 +78,9 @@ func (me *Nic) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 			if err != nil {
 				me.Logger.Warn().Msgf("convert speed [%s]", s)
 			} else {
-				// NIC speed value converted from Mbps to bps(bits per second)
-				speed = base * 1000000
+				// NIC speed value converted from Mbps to Bps(bytes per second)
+				speed = base * 125000
 				instance.SetLabel("speed", strconv.Itoa(speed))
-				// For calculation of tx_bytes and rx_bytes percent, speed would be in Bps(bytes per second)
-				speed = speed / 8
 				me.Logger.Debug().Msgf("converted speed (%s) to numeric (%d)", s, speed)
 			}
 		} else if speed, err = strconv.Atoi(s); err != nil {

--- a/cmd/collectors/zapiperf/plugins/nic/nic.go
+++ b/cmd/collectors/zapiperf/plugins/nic/nic.go
@@ -78,8 +78,11 @@ func (me *Nic) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 			if err != nil {
 				me.Logger.Warn().Msgf("convert speed [%s]", s)
 			} else {
-				speed = base * 125000
+				// NIC speed value converted from Mbps to bps(bits per second)
+				speed = base * 1000000
 				instance.SetLabel("speed", strconv.Itoa(speed))
+				// For calculation of tx_bytes and rx_bytes percent, speed would be in Bps(bytes per second)
+				speed = speed / 8
 				me.Logger.Debug().Msgf("converted speed (%s) to numeric (%d)", s, speed)
 			}
 		} else if speed, err = strconv.Atoi(s); err != nil {

--- a/grafana/dashboards/7mode/harvest_dashboard_network7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_network7.json
@@ -217,19 +217,6 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "text": "UP"
-                },
-                "1": {
-                  "text": "DOWN"
-                }
-              },
-              "type": "value"
-            }
-          ],
           "noValue": "0",
           "thresholds": {
             "mode": "absolute",
@@ -285,19 +272,6 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "text": "UP"
-                },
-                "1": {
-                  "text": "DOWN"
-                }
-              },
-              "type": "value"
-            }
-          ],
           "noValue": "0",
           "thresholds": {
             "mode": "absolute",
@@ -816,6 +790,30 @@
                 "value": 398
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "linkSpeed"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 169
+              },
+              {
+                "id": "unit",
+                "value": "bps"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "displayName",
+                "value": "speed"
+              }
+            ]
           }
         ]
       },
@@ -839,7 +837,7 @@
       "pluginVersion": "7.5.4",
       "targets": [
         {
-          "expr": "nic_labels{datacenter=\"$Datacenter\",node=~\"$Node\"}",
+          "expr": "nic_labels{datacenter=\"$Datacenter\",node=~\"$Node\",nic=~\"$Eth\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -847,7 +845,7 @@
           "refId": "A"
         },
         {
-          "expr": "nic_new_status{datacenter=\"$Datacenter\",node=~\"$Node\"}",
+          "expr": "nic_new_status{datacenter=\"$Datacenter\",node=~\"$Node\",nic=~\"$Eth\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -856,7 +854,7 @@
           "refId": "B"
         },
         {
-          "expr": "nic_util_percent{datacenter=\"$Datacenter\",node=~\"$Node\"}",
+          "expr": "nic_util_percent{datacenter=\"$Datacenter\",node=~\"$Node\",nic=~\"$Eth\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -865,7 +863,7 @@
           "refId": "C"
         },
         {
-          "expr": "nic_tx_bytes{datacenter=\"$Datacenter\",node=~\"$Node\"}",
+          "expr": "nic_tx_bytes{datacenter=\"$Datacenter\",node=~\"$Node\",nic=~\"$Eth\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -874,7 +872,7 @@
           "refId": "D"
         },
         {
-          "expr": "nic_rx_bytes{datacenter=\"$Datacenter\",node=~\"$Node\"}",
+          "expr": "nic_rx_bytes{datacenter=\"$Datacenter\",node=~\"$Node\",nic=~\"$Eth\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -907,6 +905,40 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "cluster": true,
+              "datacenter": true,
+              "instance": true,
+              "job": true,
+              "speed": true,
+              "state": true
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value": 12,
+              "Value #B": 4,
+              "Value #C": 5,
+              "Value #D": 6,
+              "Value #E": 7,
+              "__name__": 1,
+              "cluster": 5,
+              "datacenter": 6,
+              "instance": 7,
+              "job": 8,
+              "linkSpeed": 2,
+              "nic": 0,
+              "node": 1,
+              "type": 3
+            },
+            "renameByName": {}
+          }
         }
       ],
       "type": "table"
@@ -963,7 +995,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk($TopResources, nic_tx_bytes{datacenter=\"$Datacenter\",node=~\"$Node\"})",
+          "expr": "topk($TopResources, nic_tx_bytes{datacenter=\"$Datacenter\",node=~\"$Node\",nic=~\"$Eth\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "{{node}} - {{nic}}",
@@ -1065,7 +1097,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk($TopResources, nic_rx_bytes{datacenter=\"$Datacenter\",node=~\"$Node\"})",
+          "expr": "topk($TopResources, nic_rx_bytes{datacenter=\"$Datacenter\",node=~\"$Node\",nic=~\"$Eth\"})",
           "interval": "",
           "legendFormat": "{{node}} - {{nic}}",
           "refId": "A"
@@ -1167,7 +1199,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "nic_util_percent{datacenter=\"$Datacenter\",node=~\"$Node\"}",
+          "expr": "nic_util_percent{datacenter=\"$Datacenter\",node=~\"$Node\",nic=~\"$Eth\"}",
           "interval": "",
           "legendFormat": "{{node}} {{nic}}",
           "refId": "A"
@@ -1198,13 +1230,13 @@
           "format": "percent",
           "label": null,
           "logBase": 1,
-          "max": "1",
+          "max": "100",
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:245",
-          "format": "short",
+          "format": "percent",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1612,7 +1644,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "fcp_util_percent{datacenter=\"$Datacenter\",node=~\"$Node\"}",
+          "expr": "fcp_util_percent{datacenter=\"$Datacenter\",node=~\"$Node\",port=~\"$FCP\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1621,7 +1653,7 @@
           "refId": "C"
         },
         {
-          "expr": "fcp_read_data{datacenter=\"$Datacenter\",node=~\"$Node\"}",
+          "expr": "fcp_read_data{datacenter=\"$Datacenter\",node=~\"$Node\",port=~\"$FCP\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1630,7 +1662,7 @@
           "refId": "B"
         },
         {
-          "expr": "fcp_write_data{datacenter=\"$Datacenter\",node=~\"$Node\"}",
+          "expr": "fcp_write_data{datacenter=\"$Datacenter\",node=~\"$Node\",port=~\"$FCP\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1717,7 +1749,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk($TopResources, fcp_read_data{datacenter=\"$Datacenter\",node=~\"$Node\"})",
+          "expr": "topk($TopResources, fcp_read_data{datacenter=\"$Datacenter\",node=~\"$Node\",port=~\"$FCP\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "{{node}} - {{port}}",
@@ -1820,7 +1852,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "topk($TopResources, fcp_write_data{datacenter=\"$Datacenter\",node=~\"$Node\"})",
+          "expr": "topk($TopResources, fcp_write_data{datacenter=\"$Datacenter\",node=~\"$Node\",port=~\"$FCP\"})",
           "interval": "",
           "legendFormat": "{{node}} - {{port}}",
           "refId": "A"
@@ -1921,7 +1953,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk($TopResources, fcp_avg_read_latency{datacenter=\"$Datacenter\",node=~\"$Node\"})",
+          "expr": "topk($TopResources, fcp_avg_read_latency{datacenter=\"$Datacenter\",node=~\"$Node\",port=~\"$FCP\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "{{node}} - {{port}}",
@@ -2023,7 +2055,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk($TopResources, fcp_avg_write_latency{datacenter=\"$Datacenter\",node=~\"$Node\"})",
+          "expr": "topk($TopResources, fcp_avg_write_latency{datacenter=\"$Datacenter\",node=~\"$Node\",port=~\"$FCP\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "{{node}} - {{port}}",

--- a/grafana/dashboards/7mode/harvest_dashboard_network7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_network7.json
@@ -907,6 +907,26 @@
           "options": {}
         },
         {
+          "id": "calculateField",
+          "options": {
+            "alias": "linkSpeed",
+            "binary": {
+              "left": "speed",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "8"
+            },
+            "mode": "binary",
+            "reduce": {
+              "include": [
+                "speed"
+              ],
+              "reducer": "last"
+            },
+            "replaceFields": false
+          }
+        },
+        {
           "id": "organize",
           "options": {
             "excludeByName": {

--- a/grafana/dashboards/cmode/harvest_dashboard_network_detail.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_network_detail.json
@@ -1177,8 +1177,7 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "links": [],
-          "unit": "percent"
+          "links": []
         },
         "overrides": []
       },
@@ -1249,10 +1248,10 @@
         {
           "$$hashKey": "object:244",
           "decimals": null,
-          "format": "percent",
+          "format": "percentunit",
           "label": null,
           "logBase": 1,
-          "max": "100",
+          "max": "1",
           "min": "0",
           "show": true
         },

--- a/grafana/dashboards/cmode/harvest_dashboard_network_detail.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_network_detail.json
@@ -792,6 +792,30 @@
                 "value": 398
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "linkSpeed"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 169
+              },
+              {
+                "id": "unit",
+                "value": "bps"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "displayName",
+                "value": "speed"
+              }
+            ]
           }
         ]
       },
@@ -883,6 +907,60 @@
         {
           "id": "merge",
           "options": {}
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "linkSpeed",
+            "binary": {
+              "left": "speed",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "8"
+            },
+            "mode": "binary",
+            "reduce": {
+              "include": [
+                "speed"
+              ],
+              "reducer": "last"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "cluster": true,
+              "datacenter": true,
+              "instance": true,
+              "job": true,
+              "speed": true,
+              "state": true
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value": 12,
+              "Value #B": 4,
+              "Value #C": 5,
+              "Value #D": 6,
+              "Value #E": 7,
+              "__name__": 1,
+              "cluster": 5,
+              "datacenter": 6,
+              "instance": 7,
+              "job": 8,
+              "linkSpeed": 2,
+              "nic": 0,
+              "node": 1,
+              "type": 3
+            },
+            "renameByName": {}
+          }
         }
       ],
       "type": "table"
@@ -1477,7 +1555,7 @@
             "properties": [
               {
                 "id": "unit",
-                "value": "bps"
+                "value": "Bps"
               },
               {
                 "id": "custom.width",

--- a/grafana/dashboards/cmode/harvest_dashboard_network_detail.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_network_detail.json
@@ -217,19 +217,6 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "text": "UP"
-                },
-                "1": {
-                  "text": "DOWN"
-                }
-              },
-              "type": "value"
-            }
-          ],
           "noValue": "0",
           "thresholds": {
             "mode": "absolute",
@@ -285,19 +272,6 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "text": "UP"
-                },
-                "1": {
-                  "text": "DOWN"
-                }
-              },
-              "type": "value"
-            }
-          ],
           "noValue": "0",
           "thresholds": {
             "mode": "absolute",
@@ -592,7 +566,7 @@
             "properties": [
               {
                 "id": "unit",
-                "value": "Bps"
+                "value": "bps"
               },
               {
                 "id": "custom.width",
@@ -841,7 +815,7 @@
       "pluginVersion": "8.0.6",
       "targets": [
         {
-          "expr": "nic_labels{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\"}",
+          "expr": "nic_labels{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",nic=~\"$Eth\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -849,7 +823,7 @@
           "refId": "A"
         },
         {
-          "expr": "nic_new_status{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\"}",
+          "expr": "nic_new_status{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",nic=~\"$Eth\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -858,7 +832,7 @@
           "refId": "B"
         },
         {
-          "expr": "nic_util_percent{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\"}",
+          "expr": "nic_util_percent{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",nic=~\"$Eth\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -867,7 +841,7 @@
           "refId": "C"
         },
         {
-          "expr": "nic_tx_bytes{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\"}",
+          "expr": "nic_tx_bytes{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",nic=~\"$Eth\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -876,7 +850,7 @@
           "refId": "D"
         },
         {
-          "expr": "nic_rx_bytes{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\"}",
+          "expr": "nic_rx_bytes{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",nic=~\"$Eth\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -965,7 +939,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk($TopResources, nic_tx_bytes{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\"})",
+          "expr": "topk($TopResources, nic_tx_bytes{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",nic=~\"$Eth\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "{{node}} - {{nic}}",
@@ -1067,7 +1041,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk($TopResources, nic_rx_bytes{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\"})",
+          "expr": "topk($TopResources, nic_rx_bytes{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",nic=~\"$Eth\"})",
           "interval": "",
           "legendFormat": "{{node}} - {{nic}}",
           "refId": "A"
@@ -1169,7 +1143,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "nic_util_percent{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\"}",
+          "expr": "nic_util_percent{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",nic=~\"$Eth\"}",
           "interval": "",
           "legendFormat": "{{node}} {{nic}}",
           "refId": "A"
@@ -1200,13 +1174,13 @@
           "format": "percent",
           "label": null,
           "logBase": 1,
-          "max": "1",
+          "max": "100",
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:245",
-          "format": "short",
+          "format": "percent",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1503,7 +1477,7 @@
             "properties": [
               {
                 "id": "unit",
-                "value": "Bps"
+                "value": "bps"
               },
               {
                 "id": "custom.width",
@@ -1638,7 +1612,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "fcp_util_percent{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\"}",
+          "expr": "fcp_util_percent{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",port=~\"$FCP\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1648,7 +1622,7 @@
         },
         {
           "exemplar": false,
-          "expr": "fcp_read_data+fcp_nvmf_read_data{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\"}",
+          "expr": "fcp_read_data+fcp_nvmf_read_data{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",port=~\"$FCP\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1658,7 +1632,7 @@
         },
         {
           "exemplar": false,
-          "expr": "fcp_write_data+fcp_nvmf_write_data{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\"}",
+          "expr": "fcp_write_data+fcp_nvmf_write_data{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",port=~\"$FCP\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1849,7 +1823,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "topk($TopResources, fcp_write_data+fcp_nvmf_write_data{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\"})",
+          "expr": "topk($TopResources, fcp_write_data+fcp_nvmf_write_data{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",port=~\"$FCP\"})",
           "interval": "",
           "legendFormat": "{{node}} - {{port}}",
           "refId": "A"
@@ -1951,7 +1925,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "topk($TopResources, fcp_avg_read_latency+fcp_nvmf_avg_read_latency{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\"})",
+          "expr": "topk($TopResources, fcp_avg_read_latency+fcp_nvmf_avg_read_latency{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",port=~\"$FCP\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "{{node}} - {{port}}",
@@ -2054,7 +2028,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "topk($TopResources, fcp_avg_write_latency+fcp_nvmf_avg_write_latency{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\"})",
+          "expr": "topk($TopResources, fcp_avg_write_latency+fcp_nvmf_avg_write_latency{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",port=~\"$FCP\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "{{node}} - {{port}}",
@@ -2422,7 +2396,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk($TopResources, fcp_link_down{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\"})",
+          "expr": "topk($TopResources, fcp_link_down{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",port=~\"$FCP\"})",
           "interval": "",
           "legendFormat": "{{node}} - {{port}}",
           "refId": "A"
@@ -2523,7 +2497,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk($TopResources, fcp_link_failure{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\"})",
+          "expr": "topk($TopResources, fcp_link_failure{datacenter=\"$Datacenter\",cluster=\"$Cluster\",node=~\"$Node\",port=~\"$FCP\"})",
           "interval": "",
           "legendFormat": "{{node}} - {{port}}",
           "refId": "A"
@@ -2643,7 +2617,7 @@
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
         "tagValuesQuery": "",
         "tagsQuery": "",
         "type": "query",
@@ -2669,7 +2643,7 @@
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
         "tagValuesQuery": "",
         "tagsQuery": "",
         "type": "query",
@@ -2695,7 +2669,7 @@
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
         "tagValuesQuery": "",
         "tagsQuery": "",
         "type": "query",
@@ -2721,7 +2695,7 @@
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
         "tagValuesQuery": "",
         "tagsQuery": "",
         "type": "query",


### PR DESCRIPTION
Issues: [with fix]
- all Variables have sorting disabled
--> All variables(cluster, node, Eth, Fcp) would support sorting now but Datacenter
- Ethernet Receive & Ethernet Send have Value Mappings defined that makes the timeseries show "UP" when there is 0 traffic
--> Removed the value mapping as it's not required here, When there is 0 traffic, it would show 0 B/s
- Port Utilization uses wrong unit, Percent 0-100 instead 0-1
--> Corrected the percent issue 
- Top Resources variable is not used
--> It's used for 8 graphs, Ethernet drilldown: send throughput, receive throughput, FC drildown:  send throughput, receive throughput, send latency, receive latency, link down, link failure
--> There is identified issue for TopN resource https://github.com/NetApp/harvest/issues/587, we are working in this
- Ethernet drilldown panels do not use Eth variable
--> Added the Eth var in queries
- FC panels do not use the FCP variable
--> Added the FCP var in queries
- Speed is shown in Gbyte instead of Gbit
--> converted to Gbit/s