### PR TITLE
fix: grafana import saves token to wrong file

### DIFF
--- a/cmd/tools/grafana/grafana.go
+++ b/cmd/tools/grafana/grafana.go
@@ -283,6 +283,7 @@ func askForToken() {
 }
 
 func adjustOptions() {
+	opts.config = conf.ConfigPath(opts.config)
 	homePath = conf.GetHarvestHomePath()
 	if opts.dircDOT != "" {
 		opts.dircDOT = path.Join(homePath, opts.dircDOT)


### PR DESCRIPTION
Happens when using env var `HARVEST_CONFIG`