### PR TITLE
fix: consolidate all flexgroup_constituents across nodes

### DIFF
--- a/cmd/collectors/zapiperf/plugins/volume/volume.go
+++ b/cmd/collectors/zapiperf/plugins/volume/volume.go
@@ -32,7 +32,8 @@ func (me *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 	// create flexgroup instance cache
 	for _, i := range data.GetInstances() {
 		if match := re.FindStringSubmatch(i.GetLabel("volume")); len(match) == 3 {
-			key := i.GetLabel("node") + "." + i.GetLabel("svm") + "." + match[1]
+			// instance key is svm.flexgroup-volume
+			key := i.GetLabel("svm") + "." + match[1]
 			if cache.GetInstance(key) == nil {
 				fg, _ := cache.NewInstance(key)
 				fg.SetLabels(i.GetLabels().Copy())
@@ -53,7 +54,8 @@ func (me *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 	// create summary
 	for _, i := range data.GetInstances() {
 		if match := re.FindStringSubmatch(i.GetLabel("volume")); len(match) == 3 {
-			key := i.GetLabel("node") + "." + i.GetLabel("svm") + "." + match[1]
+			// instance key is svm.flexgroup-volume
+			key := i.GetLabel("svm") + "." + match[1]
 			fg := cache.GetInstance(key)
 			if fg == nil {
 				me.Logger.Error().Stack().Err(nil).Msgf("instance [%s] not in local cache", key)


### PR DESCRIPTION
**Fix**: replace the flexgroup instance key from {node}.{svm}.{volume} to {svm}.{volume}

**Before the changes:** [enabled debug log to see more detail] earlier we treated as 4 flexgroup when spanned across nodes
```
hardikl@hardikl-mac-0 harvest % ./bin/poller --poller cluster-06 --loglevel 2  --promPort 12991  -c ZapiPerf --config harvest.yml
6:14PM INF ./poller.go:178 > log level used: info Poller=cluster-06
6:14PM INF ./poller.go:179 > options config: harvest.yml Poller=cluster-06
6:14PM INF ./poller.go:216 > started in foreground [pid=18512] Poller=cluster-06
6:14PM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapiperf/cdot/9.8.0/volume.yaml] for [9.10.1] Poller=cluster-06 collector=ZapiPerf:Volume
6:14PM INF ./poller.go:340 > Autosupport scheduled. Poller=cluster-06 asupSchedule=24h
6:14PM INF ./poller.go:349 > poller start-up complete Poller=cluster-06
6:14PM INF ./poller.go:496 > updated status, up collectors: 1 (of 1), up exporters: 1 (of 1) Poller=cluster-06
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:35 >  Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:36 > optimus-01 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:37 > certl_jamaica_cache__0003 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:38 > aggr1_optimus_01 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:39 > svm_certl_nas Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:35 >  Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:36 > optimus-01 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:37 > certl_nas_prod__0001 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:38 > aggr1_optimus_01 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:39 > svm_certl_nas Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:35 >  Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:36 > optimus-02 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:37 > certl_jamaica_cache__0004 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:38 > aggr1_optimus_02 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:39 > svm_certl_nas Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:35 >  Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:36 > optimus-02 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:37 > certl_nas_prod__0002 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:38 > aggr1_optimus_02 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:39 > svm_certl_nas Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:35 >  Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:36 > optimus-02 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:37 > certl_jamaica_cache__0002 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:38 > aggr1_optimus_02 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:39 > svm_certl_nas Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:35 >  Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:36 > optimus-01 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:37 > certl_jamaica_cache__0001 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:38 > aggr1_optimus_01 Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:39 > svm_certl_nas Poller=cluster-06 plugin=ZapiPerf:Volume
6:15PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:55 > extracted 4 flexgroup volumes Poller=cluster-06 plugin=ZapiPerf:Volume
```

![image](https://user-images.githubusercontent.com/83282894/144248156-814ac48e-2a31-42ff-8c33-ded0c8962a3b.png)

**After the Changes:** Now we treated as 2 flexgroups when spanned across nodes
```
hardikl@hardikl-mac-0 harvest % ./bin/poller --poller cluster-06 --loglevel 2  --promPort 12991  -c ZapiPerf --config harvest.yml
7:23PM INF ./poller.go:179 > log level used: info Poller=cluster-06
7:23PM INF ./poller.go:180 > options config: harvest.yml Poller=cluster-06
7:23PM INF ./poller.go:217 > started in foreground [pid=23889] Poller=cluster-06
7:23PM INF goharvest2/cmd/poller/collector/helpers.go:122 > best-fit template [conf/zapiperf/cdot/9.8.0/volume.yaml] for [9.10.1] Poller=cluster-06 collector=ZapiPerf:Volume
7:23PM INF ./poller.go:341 > Autosupport scheduled. Poller=cluster-06 asupSchedule=24h
7:23PM INF ./poller.go:350 > poller start-up complete Poller=cluster-06
7:23PM INF ./poller.go:497 > updated status, up collectors: 1 (of 1), up exporters: 1 (of 1) Poller=cluster-06
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:35 >  Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:36 > optimus-02 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:37 > certl_nas_prod__0002 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:38 > aggr1_optimus_02 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:39 > svm_certl_nas Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:35 >  Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:36 > optimus-01 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:37 > certl_jamaica_cache__0003 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:38 > aggr1_optimus_01 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:39 > svm_certl_nas Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:35 >  Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:36 > optimus-01 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:37 > certl_nas_prod__0001 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:38 > aggr1_optimus_01 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:39 > svm_certl_nas Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:35 >  Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:36 > optimus-02 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:37 > certl_jamaica_cache__0002 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:38 > aggr1_optimus_02 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:39 > svm_certl_nas Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:35 >  Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:36 > optimus-02 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:37 > certl_jamaica_cache__0004 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:38 > aggr1_optimus_02 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:39 > svm_certl_nas Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:35 >  Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:36 > optimus-01 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:37 > certl_jamaica_cache__0001 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:38 > aggr1_optimus_01 Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:39 > svm_certl_nas Poller=cluster-06 plugin=ZapiPerf:Volume
7:25PM INF goharvest2/cmd/collectors/zapiperf/plugins/volume/volume.go:55 > extracted 2 flexgroup volumes Poller=cluster-06 plugin=ZapiPerf:Volume
```

![image](https://user-images.githubusercontent.com/83282894/144248194-061d2623-e355-464c-8676-5fad6a052f1d.png)


Tried out scenarios:
1. tried to create 2 svm with same name --> Not possible
```
Error: command failed: The Vserver name is already used by another Vserver
```
2. tried to create 2 flexgroup with same name in same svm with different aggrs --> Not possible
```
Error: command failed: Duplicate volume name vol_h1_flex.
```
This would make the svm-volume name key as unique in per poller.

3. checked the logic in Harvest 1.6, it used key as {svm}.{volumename} in flexgroup plugin and copy the other labels from first constituents. We are doing the same in Harvest 2.0
```
for instance in data.get_instances():

            style = instance.get('style')

            if style != 'flexgroup_constituent':
                continue

            name = instance.get('volume_name')
            if not name:
                continue
            name = name[:-6]  # strip trailing digits
            vserver = instance.get('vserver_name')
            fg_instance = n_data.get_instance( (vserver, name) )

            if not fg_instance:
                fg_instance = n_data.add_instance(
                    name = (vserver, name),
                    volume_name = name,
                    vserver_name = vserver,
                    node_name = instance.get('node_name'),
                    aggregate_name = instance.get('aggregate_name'),
                    style = 'flexgroup',
                    state = instance.get('state'),
                    status = instance.get('status'),
                    count = 1 )
                self.logger.debug('Added FlexGroup instance [{} : {}]'.format(*fg_instance.name))
            else:
                fg_instance.labels['count'] += 1

        self.logger.debug('Extracted {} FlexGroup instances'.format(len(n_data.instances)))

```