### PR TITLE
feat: rest gaps for dashboard - aggr object[3 fields pending]

### DIFF
--- a/conf/rest/9.13.0/aggr.yaml
+++ b/conf/rest/9.13.0/aggr.yaml
@@ -8,6 +8,7 @@ fields:
   - space.block_storage.inactive_user_data_percent
   - inode_attributes.file_public_capacity
   - inode_attributes.file_private_capacity
+  - inode_attributes.files_private_used
 
 counters:
   - ^name  => aggr
@@ -18,16 +19,12 @@ counters:
   #- aggr-get-iter.aggr-attributes.aggr-raid-attributes.plex-count  => raid_plex_count #mapping missing
   - block_storage.primary.raid_size => raid_size
   - ^state  => state
-  #- aggr-get-iter.aggr-attributes.aggr-inode-attributes.files-private-used  => inode_files_private_used #mapping missing
-  #- aggr-get-iter.aggr-attributes.aggr-inode-attributes.maxfiles-available => inode_maxfiles_available #mapping missing
-  #- aggr-get-iter.aggr-attributes.aggr-inode-attributes.maxfiles-possible => inode_maxfiles_possible #mapping missing
-  #- aggr-get-iter.aggr-attributes.aggr-inode-attributes.maxfiles-used => inode_maxfiles_used #mapping missing
   #- aggr-get-iter.aggr-attributes.aggr-inode-attributes.percent-inode-used-capacity => percent_inode_used_capacity #mapping missing
   - space.cloud_storage.used => space_capacity_tier_used
   - space.block_storage.data_compacted_count => space_data_compacted_count
   - space.block_storage.data_compaction_space_saved => space_data_compaction_saved
   - space.block_storage.data_compaction_space_saved_percent  => space_data_compaction_saved_percent
-  - space.block_storage.hybrid_cache.size  => hybrid_cache_size_total  #mapping seems wrong in doc
+  - block_storage.hybrid_cache.size  => hybrid_cache_size_total
   - snapshot.percent_used_capacity => space_used_percent #mapping seems wrong in doc
   - space.block_storage.inactive_user_data => space_performance_tier_inactive_user_data
   - space.block_storage.inactive_user_data_percent => space_performance_tier_inactive_user_data_percent
@@ -40,7 +37,6 @@ counters:
   - space.block_storage.size => space_total
   - space.block_storage.used => space_used
   #- aggr-get-iter.aggr-attributes.aggr-space-attributes.total-reserved-space => space_reserved #Missing mapping
-  #- aggr-get-iter.aggr-attributes.aggr-volume-count-attributes.flexvol-count => volume_count_flexvol #Missing mapping
   - snapshot.files_total => snapshot_files_total
   - snapshot.files_used => snapshot_files_used
   - snapshot.max_files_available => snapshot_maxfiles_available
@@ -50,12 +46,16 @@ counters:
   - inode_attributes.file_private_capacity => inode_inodefile_private_capacity
   - inode_attributes.files_used => inode_files_used
   - inode_attributes.files_total => inode_files_total
+  - inode_attributes.files_private_used => inode_files_private_used
+  - inode_attributes.max_files_available => inode_maxfiles_available
+  - inode_attributes.max_files_possible => inode_maxfiles_possible
+  - inode_attributes.max_files_used => inode_maxfiles_used
   #- aggr-get-iter.aggr-attributes.aggr-snapshot-attributes.percent-inode-used-capacity => snapshot_inode_used_percent #missing mapping
   - space.snapshot.available => snapshot_size_available
   - space.snapshot.used => snapshot_size_used
   - space.snapshot.used_percent => snapshot_used_percent
   - space.snapshot.reserve_percent => snapshot_reserve_percent
-  - snapshot.size_total => snapshot_size_total  #mapping seems wrong in doc
+  - space.snapshot.total => snapshot_size_total
   - volume_count => volume_count_flexvol
   - block_storage.primary.disk_count => raid_disk_count
   #- block_storage.hybrid_cache.disk_count => raid_disk_count  need to sum this and above, handle in plugin

--- a/conf/rest/9.13.0/aggr.yaml
+++ b/conf/rest/9.13.0/aggr.yaml
@@ -6,6 +6,8 @@ object:             aggr
 fields:
   - space.block_storage.inactive_user_data
   - space.block_storage.inactive_user_data_percent
+  - inode_attributes.file_public_capacity
+  - inode_attributes.file_private_capacity
 
 counters:
   - ^name  => aggr
@@ -17,10 +19,6 @@ counters:
   - block_storage.primary.raid_size => raid_size
   - ^state  => state
   #- aggr-get-iter.aggr-attributes.aggr-inode-attributes.files-private-used  => inode_files_private_used #mapping missing
-  #- aggr-get-iter.aggr-attributes.aggr-inode-attributes.files-total => inode_files_total #mapping missing
-  #- aggr-get-iter.aggr-attributes.aggr-inode-attributes.files-used => inode_files_used #mapping missing
-  #- aggr-get-iter.aggr-attributes.aggr-inode-attributes.inodefile-private-capacity => inodefile_private_capacity #mapping missing
-  #- aggr-get-iter.aggr-attributes.aggr-inode-attributes.inodefile-public-capacity => inodefile_public_capacity #mapping missing
   #- aggr-get-iter.aggr-attributes.aggr-inode-attributes.maxfiles-available => inode_maxfiles_available #mapping missing
   #- aggr-get-iter.aggr-attributes.aggr-inode-attributes.maxfiles-possible => inode_maxfiles_possible #mapping missing
   #- aggr-get-iter.aggr-attributes.aggr-inode-attributes.maxfiles-used => inode_maxfiles_used #mapping missing
@@ -47,17 +45,27 @@ counters:
   - snapshot.files_used => snapshot_files_used
   - snapshot.max_files_available => snapshot_maxfiles_available
   - snapshot.max_files_used => snapshot_maxfiles_used
+  - inode_attributes.used_percent => inode_used_percent
+  - inode_attributes.file_public_capacity => inode_inodefile_public_capacity
+  - inode_attributes.file_private_capacity => inode_inodefile_private_capacity
+  - inode_attributes.files_used => inode_files_used
+  - inode_attributes.files_total => inode_files_total
   #- aggr-get-iter.aggr-attributes.aggr-snapshot-attributes.percent-inode-used-capacity => snapshot_inode_used_percent #missing mapping
-  #- aggr-get-iter.aggr-attributes.aggr-snapshot-attributes.percent-used-capacity => snapshot_used_percent #missing mapping
-  - snapshot.size_available => snapshot_size_available  #mapping seems wrong in doc
+  - space.snapshot.available => snapshot_size_available
+  - space.snapshot.used => snapshot_size_used
+  - space.snapshot.used_percent => snapshot_used_percent
+  - space.snapshot.reserve_percent => snapshot_reserve_percent
   - snapshot.size_total => snapshot_size_total  #mapping seems wrong in doc
-  - snapshot.size_used => snapshot_size_used  #mapping seems wrong in doc
-  - snapshot.percent_snapshot_space => snapshot_reserve_percent #mapping seems wrong in doc
+  - volume_count => volume_count_flexvol
+  - block_storage.primary.disk_count => raid_disk_count
+  #- block_storage.hybrid_cache.disk_count => raid_disk_count  need to sum this and above, handle in plugin
+
 
 plugins:
   LabelAgent:
     value_to_num:
       - new_status state online online `0`
+# aggr_snapshot_maxfiles_possible would be calculated in plugin based on snapshot.max_files_available and snapshot.max_files_used
 
 export_options:
   instance_keys:


### PR DESCRIPTION
From : 
aggr [aggr_snapshot_used_percent aggr_volume_count_flexvol aggr_inode_used_percent aggr_inode_files_total aggr_inode_inodefile_public_capacity aggr_snapshot_inode_used_percent aggr_snapshot_size_available aggr_raid_disk_count aggr_inode_inodefile_private_capacity aggr_inode_files_used aggr_snapshot_size_used aggr_snapshot_reserve_percent aggr_space_used_percent aggr_snapshot_maxfiles_possible]


To:
aggr [aggr_space_used_percent aggr_snapshot_maxfiles_possible aggr_snapshot_inode_used_percent]


3 fields:
aggr_snapshot_maxfiles_possible rejected --> handle by plugin based on used/avail
aggr_snapshot_inode_used_percent rejected
aggr_space_used_percent ??


Cluster used: 10.236.44.123 [NetApp Release Metropolitan__9.11.1: Sun Jan 09 02:11:31 UTC 2022]