### PR TITLE
fix: handling vfiler for qtree 7mode

### DIFF
--- a/conf/zapi/7mode/8.6.0/qtree.yaml
+++ b/conf/zapi/7mode/8.6.0/qtree.yaml
@@ -14,7 +14,7 @@ counters:
     - ^security-style
     - ^status
     - ^^volume
-    - ^^owning-vfiler => svm
+    - ^owning-vfiler  => svm
     - ^^qtree         => qtree
 
 plugins:
@@ -32,9 +32,9 @@ export_options:
   instance_keys:
     - qtree
     - volume
-    - svm
 
   instance_labels:
+    - svm
     - export_policy
     - oplocks
     - security_style


### PR DESCRIPTION
7mode testing:
1. volume uniqueness: same name volume can't be created in cluster. volume is unique within cluster irrespective of vfiler.

a. created volab in aggr tobago_2_aggr0
```
tobago-2> vol create volab tobago_2_aggr0  20m 
Creation of volume 'volab' with size 20m on containing aggregate
'tobago_2_aggr0' has completed.
tobago-2> vol status                          
         Volume State           Status                Options
   vol_4kb_neuM online          raid_dp, flex         snapmirrored=on, create_ucode=on, 
                                snapmirrored          convert_ucode=on, fs_size_fixed=on
                                read-only             
                                64-bit                
           vol0 online          raid4, flex           root, create_ucode=on, convert_ucode=on
                                64-bit                
              D online          raid4, flex           snapmirrored=on, create_ucode=on, 
                                snapmirrored          convert_ucode=on, fs_size_fixed=on
                                read-only             
                                64-bit                
          volab online          raid4, flex           create_ucode=on, convert_ucode=on
                                64-bit                
```
b. trying to create the same volume in same aggr, it got failed
```
tobago-2> vol create volab tobago_2_aggr0  20m
vol create: Volume 'volab' already exists
tobago-2> 
```
c. trying to create same volume in another aggr, it got failed
```
tobago-2> vol create volab tobago_2_aggr1_SAS  20m
vol create: Volume 'volab' already exists
tobago-2> 
```

2. qtree uniqueness: same name qtree can't be created in one volume. qtree is unique within volume irrespective of vfiler.

a. created qtree qt1 in volume volab
```
tobago-2> qtree create /vol/volab/qt1
tobago-2> qtree status               
Volume   Tree     Style Oplocks  Status   
-------- -------- ----- -------- ---------
vol_4kb_neuM          unix  enabled  normal   
vol0              unix  enabled  normal   
vol0     help     unix  enabled  normal   
vol0     qtreea   unix  enabled  normal   
D                 unix  enabled  normal   
volab             unix  enabled  normal   
volab    qt1      unix  enabled  normal   
```

b. created qt2 qtree in same volume volab 
```
tobago-2> qtree create /vol/volab/qt2
tobago-2> qtree status               
Volume   Tree     Style Oplocks  Status   
-------- -------- ----- -------- ---------
vol_4kb_neuM          unix  enabled  normal   
vol0              unix  enabled  normal   
vol0     help     unix  enabled  normal   
vol0     qtreea   unix  enabled  normal   
D                 unix  enabled  normal   
volab             unix  enabled  normal   
volab    qt1      unix  enabled  normal   
volab    qt2      unix  enabled  normal   
```

c. trying to create qtree qt1 in same volume, it got failed
```
tobago-2> qtree create /vol/volab/qt1
qtree create: Can't create qtree (qtree exists).
tobago-2> 
```
d. trying to create qtree qt1 in another volume vol0, it's get created.
```
tobago-2> qtree create qt1           
tobago-2> qtree status    
Volume   Tree     Style Oplocks  Status   
-------- -------- ----- -------- ---------
vol_4kb_neuM          unix  enabled  normal   
vol0              unix  enabled  normal   
vol0     help     unix  enabled  normal   
vol0     qt1      unix  enabled  normal   
vol0     qtreea   unix  enabled  normal   
D                 unix  enabled  normal   
volab             unix  enabled  normal   
volab    qt1      unix  enabled  normal   
volab    qt2      unix  enabled  normal   
tobago-2> 
```

So, for 7 mode, irrespective of vfiler, volume-qtree combination is unique key for qtree and quota. If vfiler name can be available in response, still uniqueness of the records won't be impacted.