### PR TITLE
fix: quota plugin qtreekey issue

### DIFF
--- a/cmd/collectors/zapi/plugins/quota/quota.go
+++ b/cmd/collectors/zapi/plugins/quota/quota.go
@@ -185,7 +185,7 @@ func (my *Quota) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 					if my.client.IsClustered() {
 						qtreeInstance = data.GetInstance(tree + "." + volume + "." + vserver)
 					} else {
-						qtreeInstance = data.GetInstance(tree + "." + volume)
+						qtreeInstance = data.GetInstance(volume + "." + tree)
 					}
 					if qtreeInstance == nil {
 						my.Logger.Warn().


### PR DESCRIPTION
**Issue:** qtree instance key order is different in cmode and 7mode.
**Reason:** qtree instance key formation is based on the order of fields in the response. In cmode, it's order as qtree,volume and svm, but in 7mode, it's volume, qree.
 

Cmode qtree key
```
3:41PM INF goharvest2/cmd/collectors/zapi/collector/zapi.go:271 > keys=[qtree1 test123 test] keypaths=[[qtree-info volume] [qtree-info vserver] [qtree-info qtree]] found=true Poller=cluster-07 collector=Zapi:Qtree
3:41PM INF goharvest2/cmd/collectors/zapi/collector/zapi.go:280 > added instance [qtree1.test123.test] Poller=cluster-07 collector=Zapi:Qtree
```

7mode qtree key:
```
3:44PM INF goharvest2/cmd/collectors/zapi/collector/zapi.go:271 > keys=[vol0 qt1] keypaths=[[qtree-info volume] [qtree-info qtree]] found=true Poller=cluster-05 collector=Zapi:Qtree
3:44PM INF goharvest2/cmd/collectors/zapi/collector/zapi.go:280 > added instance [vol0.qt1] Poller=cluster-05 collector=Zapi:Qtree
```


Tested locally with this change:
```
hardikl@hardikl-mac-0 harvest % curl -s 'http://localhost:12986/metrics' | grep qtree_
qtree_labels{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="",volume="vol0",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 1.0
qtree_id{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="",volume="vol0"} 0
qtree_labels{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="help",volume="vol0",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 1.0
qtree_id{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="help",volume="vol0"} 2
qtree_labels{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="qt1",volume="vol0",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 1.0
qtree_id{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="qt1",volume="vol0"} 3
qtree_labels{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="qt2",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 1.0
qtree_id{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="qt2",volume="volab"} 2
qtree_labels{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="",volume="vol_4kb_neuM",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 1.0
qtree_id{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="",volume="vol_4kb_neuM"} 0
qtree_labels{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="qtreea",volume="vol0",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 1.0
qtree_id{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="qtreea",volume="vol0"} 1
qtree_labels{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="",volume="D",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 1.0
qtree_id{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="",volume="D"} 0
qtree_labels{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 1.0
qtree_id{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="",volume="volab"} 0
qtree_labels{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="qt1",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 1.0
qtree_id{datacenter="DC-04",system_type="7mode",cluster="tobago-2",node="tobago-2",qtree="qt1",volume="volab"} 1
qtree_threshold{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="volab",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_disk_used{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="volab",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_file_limit{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="volab",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_soft_file_limit{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="volab",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_disk_limit{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="qt2",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_soft_file_limit{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="qt1",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_threshold{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="qt1",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_soft_disk_limit{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="qt2",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_disk_used{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="qt2",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_file_limit{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="qt2",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_soft_disk_limit{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="volab",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_soft_disk_limit{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="qt1",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_disk_limit{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="qt1",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_disk_used{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="qt1",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_files_used{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="qt2",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 1
qtree_soft_file_limit{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="qt2",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_threshold{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="qt2",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_disk_limit{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="volab",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_files_used{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="volab",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
qtree_files_used{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="qt1",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 1
qtree_file_limit{cluster="tobago-2",node="tobago-2",datacenter="DC-04",system_type="7mode",qtree="qt1",volume="volab",svm="vfiler0",export_policy="",oplocks="enabled",security_style="unix",status="normal"} 0
hardikl@hardikl-mac-0 harvest % 

```