### PR TITLE
feat: Harvest should support logging to file when running in foreground

### DIFF
--- a/cmd/harvest/harvest.go
+++ b/cmd/harvest/harvest.go
@@ -51,6 +51,7 @@ type options struct {
 	debug      bool
 	foreground bool
 	loglevel   int
+	logTo      string
 	config     string
 	profiling  bool
 	longStatus bool
@@ -374,6 +375,10 @@ func startPoller(pollerName string, promPort int, opts *options) {
 	argv[3] = "--loglevel"
 	argv[4] = strconv.Itoa(opts.loglevel)
 
+	if opts.logTo != "auto" {
+		argv = append(argv, "--logto", opts.logTo)
+	}
+
 	if promPort != 0 {
 		argv = append(argv, "--promPort")
 		argv = append(argv, strconv.Itoa(promPort))
@@ -571,6 +576,12 @@ Feedback
 		"l",
 		2,
 		"logging level (0=trace, 1=debug, 2=info, 3=warning, 4=error, 5=critical)",
+	)
+	startCmd.PersistentFlags().StringVar(
+		&opts.logTo,
+		"logto",
+		"auto",
+		"Where to log to. auto|file|stdout. Auto means daemon logs to file and foreground to stdout",
 	)
 	startCmd.PersistentFlags().BoolVar(
 		&opts.profiling,

--- a/cmd/poller/options/options.go
+++ b/cmd/poller/options/options.go
@@ -35,6 +35,7 @@ type Options struct {
 	Objects    []string // objects to load (overrides collector config)
 	Profiling  int      // in case of profiling, the HTTP port used to display results
 	Asup       bool     // if true, invoke autosupport at start up
+	LogTo      string   // One of: auto|file|stdout. Auto means daemon logs to file and foreground to stdout
 }
 
 // String provides a string representation of Options

--- a/cmd/poller/options/options.go
+++ b/cmd/poller/options/options.go
@@ -29,13 +29,13 @@ type Options struct {
 	HomePath   string   // path to harvest home (usually "/opt/harvest")
 	LogPath    string   // log files location (usually "/var/log/harvest")
 	LogLevel   int      // logging level, 0 for trace, 5 for fatal
+	LogToFile  bool     // when running in the foreground, log to file instead of stdout
 	Version    string   // harvest version
 	Hostname   string   // hostname of the machine harvest is running
 	Collectors []string // name of collectors to load (override poller config)
 	Objects    []string // objects to load (overrides collector config)
 	Profiling  int      // in case of profiling, the HTTP port used to display results
 	Asup       bool     // if true, invoke autosupport at start up
-	LogTo      string   // One of: auto|file|stdout. Auto means daemon logs to file and foreground to stdout
 }
 
 // String provides a string representation of Options

--- a/cmd/poller/poller.go
+++ b/cmd/poller/poller.go
@@ -131,11 +131,12 @@ func (p *Poller) Init() error {
 	consoleLoggingEnabled := false
 	zeroLogLevel := logging.GetZerologLevel(p.options.LogLevel)
 	// if we are daemon, use file logging
-	if p.options.Daemon || p.options.LogTo == "file" {
+	if p.options.Daemon {
 		logFileName = "poller_" + p.name + ".log"
 		fileLoggingEnabled = true
 	} else {
-		consoleLoggingEnabled = true
+		consoleLoggingEnabled = !p.options.LogToFile
+		fileLoggingEnabled = p.options.LogToFile
 	}
 
 	err = conf.LoadHarvestConfig(p.options.Config)
@@ -1061,7 +1062,7 @@ func init() {
 	flags.BoolVarP(&args.Debug, "debug", "d", false, "Debug mode, no data will be exported")
 	flags.BoolVar(&args.Daemon, "daemon", false, "Start as daemon")
 	flags.IntVarP(&args.LogLevel, "loglevel", "l", 2, "Logging level (0=trace, 1=debug, 2=info, 3=warning, 4=error, 5=critical)")
-	flags.StringVar(&args.LogTo, "logto", "auto", "Where to log to. auto|file|stdout. Auto means daemon logs to file and foreground to stdout")
+	flags.BoolVar(&args.LogToFile, "logtofile", false, "When running in the foreground, log to file instead of stdout")
 	flags.IntVar(&args.Profiling, "profiling", 0, "If profiling port > 0, enables profiling via localhost:PORT/debug/pprof/")
 	flags.IntVar(&args.PromPort, "promPort", 0, "Prometheus Port")
 	flags.StringVar(&args.Config, "config", configPath, "Harvest config file path")
@@ -1075,6 +1076,7 @@ func init() {
 	}
 
 	_ = pollerCmd.MarkFlagRequired("poller")
+	_ = pollerCmd.Flags().MarkHidden("logtofile")
 }
 
 // start poller, if fails try to write to syslog

--- a/cmd/poller/poller.go
+++ b/cmd/poller/poller.go
@@ -131,7 +131,7 @@ func (p *Poller) Init() error {
 	consoleLoggingEnabled := false
 	zeroLogLevel := logging.GetZerologLevel(p.options.LogLevel)
 	// if we are daemon, use file logging
-	if p.options.Daemon {
+	if p.options.Daemon || p.options.LogTo == "file" {
 		logFileName = "poller_" + p.name + ".log"
 		fileLoggingEnabled = true
 	} else {
@@ -1061,6 +1061,7 @@ func init() {
 	flags.BoolVarP(&args.Debug, "debug", "d", false, "Debug mode, no data will be exported")
 	flags.BoolVar(&args.Daemon, "daemon", false, "Start as daemon")
 	flags.IntVarP(&args.LogLevel, "loglevel", "l", 2, "Logging level (0=trace, 1=debug, 2=info, 3=warning, 4=error, 5=critical)")
+	flags.StringVar(&args.LogTo, "logto", "auto", "Where to log to. auto|file|stdout. Auto means daemon logs to file and foreground to stdout")
 	flags.IntVar(&args.Profiling, "profiling", 0, "If profiling port > 0, enables profiling via localhost:PORT/debug/pprof/")
 	flags.IntVar(&args.PromPort, "promPort", 0, "Prometheus Port")
 	flags.StringVar(&args.Config, "config", configPath, "Harvest config file path")


### PR DESCRIPTION
Fixes #810


Add `logtofile` option to `bin/harvest` and `bin/poller`. When running in the foreground, use file logging, instead of stdout