### PR TITLE
feat: asup rest

### DIFF
--- a/cmd/collectors/rest/plugins/volume/volume.go
+++ b/cmd/collectors/rest/plugins/volume/volume.go
@@ -92,7 +92,7 @@ func (my *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 
 		// invoke snapmirror zapi and populate info in source and destination snapmirror maps
 		if smSourceMap, smDestinationMap, err := my.GetSnapMirrors(); err != nil {
-			my.Logger.Error().Stack().Err(err).Msg("Failed to collect snapmirror data")
+			my.Logger.Warn().Stack().Err(err).Msg("Failed to collect snapmirror data")
 		} else {
 			// update internal cache based on volume and SM maps
 			my.updateMaps(data, smSourceMap, smDestinationMap)
@@ -253,7 +253,7 @@ func (my *Volume) updateMaps(data *matrix.Matrix, smSourceMap map[string][]*matr
 
 		// Update outgoingSM map based on the protectedByMap
 		protectedByValue = nil
-		for protectedByKey, _ := range protectedByMap {
+		for protectedByKey := range protectedByMap {
 			protectedByValue = append(protectedByValue, protectedByKey)
 		}
 		if protectedByValue != nil {

--- a/cmd/collectors/rest/rest.go
+++ b/cmd/collectors/rest/rest.go
@@ -17,6 +17,8 @@ import (
 	"goharvest2/pkg/matrix"
 	"goharvest2/pkg/tree/node"
 	"os"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -237,7 +239,7 @@ func (r *Rest) PollData() (*matrix.Matrix, error) {
 
 	startTime = time.Now()
 
-	if records, err = r.GetRestData(r.prop, r.client); err != nil {
+	if records, err = r.GetRestData(r.prop.query, strings.Join(r.prop.fields, ","), r.prop.returnTimeOut, r.client); err != nil {
 		r.Logger.Error().Stack().Err(err).Msg("Failed to fetch data")
 		return nil, err
 	}
@@ -276,14 +278,16 @@ func (r *Rest) PollData() (*matrix.Matrix, error) {
 	parseD = time.Since(startTime)
 
 	r.Logger.Info().
+		Uint64("instances", numRecords.Uint()).
 		Uint64("dataPoints", count).
 		Str("apiTime", apiD.String()).
 		Str("parseTime", parseD.String()).
 		Msg("Collected")
 
+	_ = r.Metadata.LazySetValueInt64("count", "data", numRecords.Int())
 	_ = r.Metadata.LazySetValueInt64("api_time", "data", apiD.Microseconds())
 	_ = r.Metadata.LazySetValueInt64("parse_time", "data", parseD.Microseconds())
-	_ = r.Metadata.LazySetValueUint64("count", "data", count)
+	_ = r.Metadata.LazySetValueUint64("datapoint_count", "data", count)
 	r.AddCollectCount(count)
 
 	return r.Matrix, nil
@@ -306,7 +310,7 @@ func (r *Rest) processEndPoints() error {
 			i++
 		}
 
-		if records, err = r.GetRestData(endpoint.prop, r.client); err != nil {
+		if records, err = r.GetRestData(endpoint.prop.query, strings.Join(endpoint.prop.fields, ","), r.prop.returnTimeOut, r.client); err != nil {
 			r.Logger.Error().Stack().Err(err).Msg("Failed to fetch data")
 			return err
 		}
@@ -394,12 +398,6 @@ func (r *Rest) HandleResults(result gjson.Result, prop *prop, allowInstanceCreat
 			}
 		}
 
-		if r.Params.GetChildContentS("only_cluster_instance") != "true" {
-			if instanceKey == "" {
-				return true
-			}
-		}
-
 		instance = r.Matrix.GetInstance(instanceKey)
 
 		if !allowInstanceCreation && instance == nil {
@@ -472,13 +470,13 @@ func (r *Rest) HandleResults(result gjson.Result, prop *prop, allowInstanceCreat
 	return count
 }
 
-func (r *Rest) GetRestData(prop *prop, client *rest.Client) ([]interface{}, error) {
+func (r *Rest) GetRestData(query string, fields string, returnTimeOut string, client *rest.Client) ([]interface{}, error) {
 	var (
 		err     error
 		records []interface{}
 	)
 
-	href := rest.BuildHref(prop.query, strings.Join(prop.fields, ","), nil, "", "", "", prop.returnTimeOut, prop.query)
+	href := rest.BuildHref(query, fields, nil, "", "", "", returnTimeOut, query)
 
 	r.Logger.Debug().Str("href", href).Msg("")
 	if href == "" {
@@ -492,6 +490,121 @@ func (r *Rest) GetRestData(prop *prop, client *rest.Client) ([]interface{}, erro
 	}
 
 	return records, nil
+}
+
+func (r *Rest) CollectAutoSupport(p *collector.Payload) {
+	var exporterTypes []string
+	for _, exporter := range r.Exporters {
+		exporterTypes = append(exporterTypes, exporter.GetClass())
+	}
+
+	var counters = make([]string, 0)
+	for k := range r.prop.counters {
+		counters = append(counters, k)
+	}
+
+	var schedules = make([]collector.Schedule, 0)
+	tasks := r.Params.GetChildS("schedule")
+	if tasks != nil && len(tasks.GetChildren()) > 0 {
+		for _, task := range tasks.GetChildren() {
+			schedules = append(schedules, collector.Schedule{
+				Name:     task.GetNameS(),
+				Schedule: task.GetContentS(),
+			})
+		}
+	}
+
+	// Add collector information
+	p.AddCollectorAsup(collector.AsupCollector{
+		Name:      r.Name,
+		Query:     r.prop.query,
+		Exporters: exporterTypes,
+		Counters: collector.Counters{
+			Count: len(counters),
+			List:  counters,
+		},
+		Schedules:     schedules,
+		ClientTimeout: r.client.Timeout.String(),
+	})
+
+	if r.Name == "Rest" && (r.Object == "Volume" || r.Object == "Node") {
+		version := r.client.Cluster().Version
+		p.Target.Version = strconv.Itoa(version[0]) + "." + strconv.Itoa(version[1]) + "." + strconv.Itoa(version[2])
+		p.Target.Model = "cdot"
+		p.Target.Serial = r.client.Cluster().Uuid
+		p.Target.ClusterUuid = r.client.Cluster().Uuid
+
+		md := r.GetMetadata()
+		info := collector.InstanceInfo{
+			Count:      md.LazyValueInt64("count", "data"),
+			DataPoints: md.LazyValueInt64("datapoint_count", "data"),
+			PollTime:   md.LazyValueInt64("poll_time", "data"),
+			ApiTime:    md.LazyValueInt64("api_time", "data"),
+			ParseTime:  md.LazyValueInt64("parse_time", "data"),
+			PluginTime: md.LazyValueInt64("plugin_time", "data"),
+		}
+
+		if r.Object == "Node" {
+			nodeIds, err := r.getNodeUuids()
+			if err != nil {
+				// log but don't return so the other info below is collected
+				r.Logger.Error().
+					Err(err).
+					Msg("Unable to get nodes.")
+				nodeIds = make([]collector.Id, 0)
+			}
+			info.Ids = nodeIds
+			p.Nodes = &info
+
+			if len(nodeIds) > 0 {
+				p.Target.Serial = nodeIds[0].SerialNumber
+			}
+		} else if r.Object == "Volume" {
+			p.Volumes = &info
+		}
+	}
+}
+
+func (r *Rest) getNodeUuids() ([]collector.Id, error) {
+	var (
+		records []interface{}
+		err     error
+		infos   []collector.Id
+	)
+	query := "api/cluster/nodes"
+
+	if records, err = r.GetRestData(query, "serial_number,system_id", r.prop.returnTimeOut, r.client); err != nil {
+		r.Logger.Error().Stack().Err(err).Msg("Failed to fetch data")
+		return nil, err
+	}
+
+	all := rest.Pagination{
+		Records:    records,
+		NumRecords: len(records),
+	}
+
+	content, err := json.Marshal(all)
+	if err != nil {
+		r.Logger.Error().Err(err).Str("ApiPath", query).Msg("Unable to marshal rest pagination")
+	}
+
+	if !gjson.ValidBytes(content) {
+		return nil, fmt.Errorf("json is not valid for: %s", r.prop.query)
+	}
+
+	results := gjson.GetManyBytes(content, "num_records", "records")
+
+	results[1].ForEach(func(key, instanceData gjson.Result) bool {
+		infos = append(infos, collector.Id{SerialNumber: instanceData.Get("serial_number").String(), SystemId: instanceData.Get("system_id").String()})
+		return true
+	})
+
+	// When Harvest monitors a c-mode system, the first node is picked.
+	// Sort so there's a higher chance the same node is picked each time this method is called
+	sort.SliceStable(infos, func(i, j int) bool {
+		return infos[i].SerialNumber < infos[j].SerialNumber
+	})
+	return infos, nil
 }
 
 // Interface guards

--- a/cmd/collectors/rest/rest.go
+++ b/cmd/collectors/rest/rest.go
@@ -570,7 +570,6 @@ func (r *Rest) CollectAutoSupport(p *collector.Payload) {
 			// use the first node's serial number instead (the nodes were ordered in getNodeUuids())
 			if len(nodeIds) > 0 {
 				p.Target.Serial = nodeIds[0].SerialNumber
-				fmt.Println(p.Target.Serial)
 			}
 		} else if r.Object == "Volume" {
 			p.Volumes = &info

--- a/cmd/collectors/rest/templating.go
+++ b/cmd/collectors/rest/templating.go
@@ -69,6 +69,7 @@ func (r *Rest) initCache() error {
 	}
 
 	r.ParseRestCounters(counters, r.prop)
+	r.Metadata.NewMetricUint64("datapoint_count")
 
 	r.Logger.Info().Strs("extracted Instance Keys", r.prop.instanceKeys).Msg("")
 	r.Logger.Info().Int("count metrics", len(r.prop.metrics)).Int("count labels", len(r.prop.instanceLabels)).Msg("initialized metric cache")

--- a/cmd/poller/poller.go
+++ b/cmd/poller/poller.go
@@ -876,7 +876,7 @@ var pollerCmd = &cobra.Command{
 // when we add other Ontap collectors, e.g. REST)
 func (p *Poller) targetIsOntap() bool {
 	for _, c := range p.collectors {
-		if c.GetName() == "ZapiPerf" || c.GetName() == "Zapi" {
+		if c.GetName() == "ZapiPerf" || c.GetName() == "Zapi" || c.GetName() == "Rest" {
 			return true
 		}
 	}

--- a/cmd/tools/rest/client.go
+++ b/cmd/tools/rest/client.go
@@ -32,6 +32,7 @@ type Client struct {
 	cluster  Cluster
 	password string
 	username string
+	Timeout  time.Duration
 }
 
 type Cluster struct {
@@ -66,6 +67,7 @@ func New(poller conf.Poller, timeout time.Duration) (*Client, error) {
 		url = "https://" + addr + "/"
 	}
 	client.baseURL = url
+	client.Timeout = timeout
 
 	// by default, enforce secure TLS, if not requested otherwise by user
 	if x := poller.UseInsecureTls; x != nil {

--- a/conf/rest/9.12.0/status.yaml
+++ b/conf/rest/9.12.0/status.yaml
@@ -9,7 +9,6 @@ counters:
       - health
 
 collect_only_labels: true
-only_cluster_instance: true
 no_max_records: true
 
 plugins:


### PR DESCRIPTION
```json
{
 "Target": {
  "Version": "9.11.0",
  "Model": "cdot",
  "Serial": "redacted",
  "Ping": 0,
  "ClusterUuid": "redacted"
 },
 "Harvest": {
  "HostHash": "redacted",
  "UUID": "redacted",
  "Version": "22.02.0915",
  "Release": "v21.11.1",
  "Commit": "7c4e4c0",
  "BuildDate": "2022-02-09T15:04:03+0530",
  "NumClusters": 1
 },
 "Platform": {
  "OS": "darwin",
  "Arch": "darwin",
  "Memory": {
   "TotalKb": 16777216,
   "AvailableKb": 5931728,
   "UsedKb": 10845488
  },
  "CPUs": 1
 },
 "Nodes": {
  "Count": 2,
  "DataPoints": 26,
  "PollTime": 2324723,
  "ApiTime": 2009857,
  "ParseTime": 314359,
  "PluginTime": 11,
  "Ids": [
   {
    "serial-number": "4083664-19-5",
    "system-id": "4083664195"
   },
   {
    "serial-number": "4083664-19-6",
    "system-id": "4083664196"
   }
  ]
 },
 "Volumes": {
  "Count": 4,
  "DataPoints": 116,
  "PollTime": 3581761,
  "ApiTime": 2017120,
  "ParseTime": 354133,
  "PluginTime": 1209761
 },
 "Collectors": [
  {
   "Name": "Rest",
   "Query": "api/storage/disks",
   "ClientTimeout": "30s",
   "Schedules": [
    {
     "Name": "data",
     "Schedule": "180s"
    }
   ],
   "Exporters": [
    "Prometheus"
   ],
   "Counters": {
    "Count": 19,
    "List": [
     "home_node.name",
     "model",
     "bay",
     "sector_count",
     "stats.power_on_hours",
     "usable_size",
     "bytes_per_sector",
     "stats.throughput",
     "uid",
     "state",
     "node.uuid",
     "node.name",
     "stats.average_latency",
     "name",
     "type",
     "container_type",
     "serial_number",
     "shelf.uid",
     "outage.reason"
    ]
   }
  },
  {
   "Name": "Rest",
   "Query": "api/storage/luns",
   "ClientTimeout": "30s",
   "Schedules": [
    {
     "Name": "data",
     "Schedule": "180s"
    }
   ],
   "Exporters": [
    "Prometheus"
   ],
   "Counters": {
    "Count": 9,
    "List": [
     "svm.name",
     "space.size",
     "uuid",
     "status.state",
     "location.volume.name",
     "space.used",
     "location.node.name",
     "name",
     "location.qtree.name"
    ]
   }
  },
  {
   "Name": "Rest",
   "Query": "api/cluster",
   "ClientTimeout": "30s",
   "Schedules": [
    {
     "Name": "data",
     "Schedule": "180s"
    }
   ],
   "Exporters": [
    "Prometheus"
   ],
   "Counters": {
    "Count": 1,
    "List": [
     "health"
    ]
   }
  },
  {
   "Name": "Rest",
   "Query": "api/cluster/nodes",
   "ClientTimeout": "30s",
   "Schedules": [
    {
     "Name": "data",
     "Schedule": "180s"
    }
   ],
   "Exporters": [
    "Prometheus"
   ],
   "Counters": {
    "Count": 13,
    "List": [
     "name",
     "controller.failed_power_supply.message.message",
     "controller.over_temperature",
     "state",
     "model",
     "metric.processor_utilization",
     "controller.failed_fan.count",
     "controller.failed_fan.message.message",
     "location",
     "serial_number",
     "version.full",
     "uptime",
     "controller.failed_power_supply.count"
    ]
   }
  },
  {
   "Name": "Rest",
   "Query": "api/storage/aggregates",
   "ClientTimeout": "30s",
   "Schedules": [
    {
     "Name": "data",
     "Schedule": "180s"
    }
   ],
   "Exporters": [
    "Prometheus"
   ],
   "Counters": {
    "Count": 35,
    "List": [
     "space.block_storage.data_compaction_space_saved_percent",
     "space.block_storage.physical_used_percent",
     "space.block_storage.volume_deduplication_space_saved",
     "space.block_storage.used",
     "uuid",
     "state",
     "block_storage.primary.disk_type",
     "space.block_storage.volume_deduplication_space_saved_percent",
     "space.snapshot.available",
     "space.snapshot.reserve_percent",
     "space.block_storage.data_compaction_space_saved",
     "block_storage.hybrid_cache.size",
     "space.block_storage.inactive_user_data_percent",
     "snapshot.files_used",
     "space.snapshot.used",
     "block_storage.primary.disk_count",
     "space.block_storage.inactive_user_data",
     "space.block_storage.volume_deduplication_shared_count",
     "space.block_storage.size",
     "space.block_storage.available",
     "snapshot.files_total",
     "block_storage.hybrid_cache.disk_count",
     "name",
     "space.cloud_storage.used",
     "space.snapshot.total",
     "volume_count",
     "block_storage.plexes.#",
     "home_node.name",
     "space.block_storage.physical_used",
     "snapshot.max_files_available",
     "space.block_storage.data_compacted_count",
     "snapshot.max_files_used",
     "block_storage.primary.raid_type",
     "block_storage.primary.raid_size",
     "space.snapshot.used_percent"
    ]
   }
  },
  {
   "Name": "Rest",
   "Query": "api/private/cli/snapmirror",
   "ClientTimeout": "30s",
   "Schedules": [
    {
     "Name": "data",
     "Schedule": "180s"
    }
   ],
   "Exporters": [
    "Prometheus"
   ],
   "Counters": {
    "Count": 28,
    "List": [
     "destination_volume_node",
     "unhealthy_reason",
     "total_transfer_time_secs",
     "update_successful_count",
     "destination_path",
     "healthy",
     "last_transfer_size",
     "resync_failed_count",
     "source_volume",
     "source_vserver",
     "relationship_group_type",
     "last_transfer_end_timestamp",
     "update_failed_count",
     "relationship_id",
     "lag_time",
     "last_transfer_duration",
     "schedule",
     "total_transfer_bytes",
     "break_failed_count",
     "state",
     "type",
     "resync_successful_count",
     "destination_vserver",
     "policy_type",
     "newest_snapshot_timestamp",
     "destination_volume",
     "break_successful_count",
     "last_transfer_type"
    ]
   }
  },
  {
   "Name": "Rest",
   "Query": "api/storage/volumes",
   "ClientTimeout": "30s",
   "Schedules": [
    {
     "Name": "data",
     "Schedule": "180s"
    }
   ],
   "Exporters": [
    "Prometheus"
   ],
   "Counters": {
    "Count": 30,
    "List": [
     "space.physical_used",
     "space.used",
     "space.size_available_for_snapshots",
     "autosize.grow_threshold",
     "space.filesystem_size",
     "space.snapshot.reserve_size",
     "space.afs_total",
     "space.snapshot.used",
     "state",
     "autosize.maximum",
     "space.logical_space.used_by_afs",
     "space.logical_space.used_by_snapshots",
     "space.logical_space.used_percent",
     "style",
     "space.snapshot.space_used_percent",
     "uuid",
     "name",
     "svm.name",
     "space.expected_available",
     "space.snapshot.reserve_available",
     "space.logical_space.available",
     "space.logical_space.used",
     "space.available",
     "type",
     "snapshot_policy.name",
     "space.physical_used_percent",
     "space.percent_used",
     "space.snapshot.reserve_percent",
     "aggregates.#.name",
     "space.size"
    ]
   }
  },
  {
   "Name": "Rest",
   "Query": "api/private/cli/system/health/subsystem",
   "ClientTimeout": "30s",
   "Schedules": [
    {
     "Name": "data",
     "Schedule": "180s"
    }
   ],
   "Exporters": [
    "Prometheus"
   ],
   "Counters": {
    "Count": 4,
    "List": [
     "outstanding_alert_count",
     "suppressed_alert_count",
     "health",
     "subsystem"
    ]
   }
  },
  {
   "Name": "Rest",
   "Query": "api/private/cli/snapshot/policy",
   "ClientTimeout": "30s",
   "Schedules": [
    {
     "Name": "data",
     "Schedule": "180s"
    }
   ],
   "Exporters": [
    "Prometheus"
   ],
   "Counters": {
    "Count": 4,
    "List": [
     "vserver",
     "policy",
     "comment",
     "total_schedules"
    ]
   }
  },
  {
   "Name": "Rest",
   "Query": "api/network/ethernet/ports",
   "ClientTimeout": "30s",
   "Schedules": [
    {
     "Name": "data",
     "Schedule": "180s"
    }
   ],
   "Exporters": [
    "Prometheus"
   ],
   "Counters": {
    "Count": 11,
    "List": [
     "state",
     "vlan.base_port.node.name",
     "vlan.base_port.name",
     "node.name",
     "broadcast_domain.name",
     "lag.mode",
     "type",
     "vlan.tag",
     "name",
     "lag.distribution_policy",
     "speed"
    ]
   }
  },
  {
   "Name": "Rest",
   "Query": "api/storage/qtrees",
   "ClientTimeout": "30s",
   "Schedules": [
    {
     "Name": "data",
     "Schedule": "180s"
    }
   ],
   "Exporters": [
    "Prometheus"
   ],
   "Counters": {
    "Count": 6,
    "List": [
     "security_style",
     "id",
     "svm.name",
     "volume.name",
     "name",
     "export_policy.name"
    ]
   }
  },
  {
   "Name": "Rest",
   "Query": "api/storage/shelves",
   "ClientTimeout": "30s",
   "Schedules": [
    {
     "Name": "data",
     "Schedule": "180s"
    }
   ],
   "Exporters": [
    "Prometheus"
   ],
   "Counters": {
    "Count": 7,
    "List": [
     "module_type",
     "name",
     "model",
     "state",
     "manufacturer.name",
     "disk_count",
     "serial_number"
    ]
   }
  },
  {
   "Name": "Rest",
   "Query": "api/private/cli/system/node/environment/sensors",
   "ClientTimeout": "30s",
   "Schedules": [
    {
     "Name": "data",
     "Schedule": "180s"
    }
   ],
   "Exporters": [
    "Prometheus"
   ],
   "Counters": {
    "Count": 12,
    "List": [
     "discrete_value",
     "state",
     "units",
     "type",
     "warn_hi",
     "warn_low",
     "value",
     "crit_hi",
     "crit_low",
     "node",
     "name",
     "discrete_state"
    ]
   }
  }
 ]
}
