### PR TITLE
fix: fetching only tree quotas in zapi request

### DIFF
--- a/cmd/collectors/zapi/plugins/quota/quota.go
+++ b/cmd/collectors/zapi/plugins/quota/quota.go
@@ -129,6 +129,10 @@ func (my *Quota) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 
 	if my.client.IsClustered() && my.batchSize != "" {
 		request.NewChildS("max-records", my.batchSize)
+		// Fetching only tree quotas
+		query := request.NewChildS("query", "")
+		quotaQuery := query.NewChildS("quota", "")
+		quotaQuery.NewChildS("quota-type", "tree")
 	}
 
 	tag := "initial"
@@ -166,11 +170,6 @@ func (my *Quota) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 			volume := quota.GetChildContentS("volume")
 			if my.client.IsClustered() {
 				vserver = quota.GetChildContentS("vserver")
-			}
-
-			// If quota-type is not a Qtree, then skip
-			if quota.GetChildContentS("quota-type") != "tree" {
-				continue
 			}
 
 			for attribute, m := range my.data.GetMetrics() {


### PR DESCRIPTION
Added one logger to verify only tree quotas would be fetched. First call fetched 20 quotas [16 tree and 4 user quotas]

Before the changes:
```
hardikl@hardikl-mac-0 harvest % ./bin/poller --poller cluster-01  --promPort 12988 --config harvest.yml
4:31PM INF ./poller.go:182 > log level used: info Poller=cluster-01
4:31PM INF ./poller.go:183 > options config: harvest.yml Poller=cluster-01
4:31PM INF ./poller.go:220 > started in foreground [pid=11910] Poller=cluster-01
4:31PM INF goharvest2/cmd/poller/collector/helpers.go:123 > best-fit template [conf/zapi/cdot/9.8.0/qtree.yaml] for [9.3.0] Poller=cluster-01 collector=Zapi:Qtree
4:31PM INF ./poller.go:344 > Autosupport scheduled. Poller=cluster-01 asupSchedule=24h
4:31PM INF ./poller.go:353 > poller start-up complete Poller=cluster-01
4:31PM INF ./poller.go:501 > updated status, up collectors: 1 (of 1), up exporters: 1 (of 1) Poller=cluster-01
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type user Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type user Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-threshold] instances on this vs3.vs3. Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-soft-file-limit] instances on this vs3.vs3. Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-soft-disk-limit] instances on this vs3.vs3. Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-file-limit] instances on this vs3.vs3. Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type user Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-file-limit] instances on this vs_kiran_prot.vs_kiran_prot_vol1.mkk_qtree1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-soft-disk-limit] instances on this vs_kiran_prot.vs_kiran_prot_vol1.mkk_qtree1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-threshold] instances on this vs_kiran_prot.vs_kiran_prot_vol1.mkk_qtree1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-soft-file-limit] instances on this vs_kiran_prot.vs_kiran_prot_vol1.mkk_qtree1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type user Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-file-limit] instances on this vs2.kanchanv1.q1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-soft-disk-limit] instances on this vs2.kanchanv1.q1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-threshold] instances on this vs2.kanchanv1.q1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-soft-file-limit] instances on this vs2.kanchanv1.q1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-file-limit] instances on this vs2.kanchanv2.q2 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-disk-limit] instances on this vs2.kanchanv2.q2 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-soft-file-limit] instances on this vs2.kanchanv2.q2 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-soft-disk-limit] instances on this vs2.kanchanv2.q2 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-threshold] instances on this vs2.kanchanv2.q2 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-threshold] instances on this CIFS_test_9345.kanchan1.qtree1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-threshold] instances on this vs2.k2.q2 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-threshold] instances on this vs2.vol3.q3 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-soft-disk-limit] instances on this vs2.vol_dinesh2.qtree_test&amp;_ps1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-threshold] instances on this vs2.vol_dinesh2.qtree_test&amp;_ps1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-soft-file-limit] instances on this vs2.vol_dinesh2.qtree_test&amp;_ps1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-file-limit] instances on this vs2.vol_dinesh2.qtree_test&amp;_ps1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-soft-disk-limit] instances on this vs2.vol_dinesh2.qtree_test&apos;_ps1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-threshold] instances on this vs2.vol_dinesh2.qtree_test&apos;_ps1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-soft-file-limit] instances on this vs2.vol_dinesh2.qtree_test&apos;_ps1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-file-limit] instances on this vs2.vol_dinesh2.qtree_test&apos;_ps1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-soft-disk-limit] instances on this vs2.vol_dinesh2. Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-threshold] instances on this vs2.vol_dinesh2. Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-soft-file-limit] instances on this vs2.vol_dinesh2. Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-file-limit] instances on this vs2.vol_dinesh2. Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-soft-disk-limit] instances on this vs2.vol_dinesh1.qtree_din1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-threshold] instances on this vs2.vol_dinesh1.qtree_din1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-soft-file-limit] instances on this vs2.vol_dinesh1.qtree_din1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-file-limit] instances on this vs2.vol_dinesh1.qtree_din1 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-soft-disk-limit] instances on this vs2.vol_dinesh1.qtree_din2 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-threshold] instances on this vs2.vol_dinesh1.qtree_din2 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-soft-file-limit] instances on this vs2.vol_dinesh1.qtree_din2 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-file-limit] instances on this vs2.vol_dinesh1.qtree_din2 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-threshold] instances on this vs2.vol_dinesh1.qtree_din3 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-soft-file-limit] instances on this vs2.vol_dinesh1.qtree_din3 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-soft-disk-limit] instances on this vs2.vol_dinesh1.qtree_din3 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-file-limit] instances on this vs2.vol_dinesh1.qtree_din3 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-soft-disk-limit] instances on this vs2.vol_dinesh1.qtree_din4 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-threshold] instances on this vs2.vol_dinesh1.qtree_din4 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-soft-file-limit] instances on this vs2.vol_dinesh1.qtree_din4 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-file-limit] instances on this vs2.vol_dinesh1.qtree_din4 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:173 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-file-limit] instances on this vs3.kanchan2.qtree2 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-soft-disk-limit] instances on this vs3.kanchan2.qtree2 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [disk-used-pct-threshold] instances on this vs3.kanchan2.qtree2 Poller=cluster-01 plugin=Zapi:Qtree
4:31PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:183 > no [files-used-pct-soft-file-limit] instances on this vs3.kanchan2.qtree2 Poller=cluster-01 plugin=Zapi:Qtree
```



After the changes:
```
hardikl@hardikl-mac-0 harvest % ./bin/poller --poller cluster-01  --promPort 12988 --config harvest.yml
5:28PM INF ./poller.go:182 > log level used: info Poller=cluster-01
5:28PM INF ./poller.go:183 > options config: harvest.yml Poller=cluster-01
5:28PM INF ./poller.go:220 > started in foreground [pid=16460] Poller=cluster-01
5:28PM INF goharvest2/cmd/poller/collector/helpers.go:123 > best-fit template [conf/zapi/cdot/9.8.0/qtree.yaml] for [9.3.0] Poller=cluster-01 collector=Zapi:Qtree
5:29PM INF ./poller.go:344 > Autosupport scheduled. Poller=cluster-01 asupSchedule=24h
5:29PM INF ./poller.go:353 > poller start-up complete Poller=cluster-01
5:29PM INF ./poller.go:501 > updated status, up collectors: 1 (of 1), up exporters: 1 (of 1) Poller=cluster-01
5:29PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:175 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-threshold] instances on this vs3.vs3. Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-soft-file-limit] instances on this vs3.vs3. Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-soft-disk-limit] instances on this vs3.vs3. Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-file-limit] instances on this vs3.vs3. Poller=cluster-01 plugin=Zapi:Qtree
5:29PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:175 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
5:29PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:175 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-threshold] instances on this vs_kiran_prot.vs_kiran_prot_vol1.mkk_qtree1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-soft-file-limit] instances on this vs_kiran_prot.vs_kiran_prot_vol1.mkk_qtree1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-soft-disk-limit] instances on this vs_kiran_prot.vs_kiran_prot_vol1.mkk_qtree1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-file-limit] instances on this vs_kiran_prot.vs_kiran_prot_vol1.mkk_qtree1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:175 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-soft-disk-limit] instances on this vs2.kanchanv1.q1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-file-limit] instances on this vs2.kanchanv1.q1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-threshold] instances on this vs2.kanchanv1.q1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-soft-file-limit] instances on this vs2.kanchanv1.q1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:175 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-disk-limit] instances on this vs2.kanchanv2.q2 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-soft-disk-limit] instances on this vs2.kanchanv2.q2 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-file-limit] instances on this vs2.kanchanv2.q2 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-threshold] instances on this vs2.kanchanv2.q2 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-soft-file-limit] instances on this vs2.kanchanv2.q2 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:175 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-threshold] instances on this CIFS_test_9345.kanchan1.qtree1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:175 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-threshold] instances on this vs2.k2.q2 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:175 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-threshold] instances on this vs2.vol3.q3 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:175 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-threshold] instances on this vs2.vol_dinesh2.qtree_test&amp;_ps1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-soft-file-limit] instances on this vs2.vol_dinesh2.qtree_test&amp;_ps1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-soft-disk-limit] instances on this vs2.vol_dinesh2.qtree_test&amp;_ps1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-file-limit] instances on this vs2.vol_dinesh2.qtree_test&amp;_ps1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:175 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-soft-file-limit] instances on this vs2.vol_dinesh2.qtree_test&apos;_ps1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-threshold] instances on this vs2.vol_dinesh2.qtree_test&apos;_ps1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-file-limit] instances on this vs2.vol_dinesh2.qtree_test&apos;_ps1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-soft-disk-limit] instances on this vs2.vol_dinesh2.qtree_test&apos;_ps1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:175 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-threshold] instances on this vs2.vol_dinesh2. Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-soft-file-limit] instances on this vs2.vol_dinesh2. Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-soft-disk-limit] instances on this vs2.vol_dinesh2. Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-file-limit] instances on this vs2.vol_dinesh2. Poller=cluster-01 plugin=Zapi:Qtree
5:29PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:175 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-threshold] instances on this vs2.vol_dinesh1.qtree_din1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-soft-file-limit] instances on this vs2.vol_dinesh1.qtree_din1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-soft-disk-limit] instances on this vs2.vol_dinesh1.qtree_din1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-file-limit] instances on this vs2.vol_dinesh1.qtree_din1 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:175 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-file-limit] instances on this vs2.vol_dinesh1.qtree_din2 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-soft-disk-limit] instances on this vs2.vol_dinesh1.qtree_din2 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-soft-file-limit] instances on this vs2.vol_dinesh1.qtree_din2 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-threshold] instances on this vs2.vol_dinesh1.qtree_din2 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:175 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-soft-disk-limit] instances on this vs2.vol_dinesh1.qtree_din3 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-file-limit] instances on this vs2.vol_dinesh1.qtree_din3 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-threshold] instances on this vs2.vol_dinesh1.qtree_din3 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-soft-file-limit] instances on this vs2.vol_dinesh1.qtree_din3 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:175 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-file-limit] instances on this vs2.vol_dinesh1.qtree_din4 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-soft-disk-limit] instances on this vs2.vol_dinesh1.qtree_din4 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-soft-file-limit] instances on this vs2.vol_dinesh1.qtree_din4 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-threshold] instances on this vs2.vol_dinesh1.qtree_din4 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM INF goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:175 > H quota type tree Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-threshold] instances on this vs3.kanchan2.qtree2 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-soft-file-limit] instances on this vs3.kanchan2.qtree2 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [files-used-pct-file-limit] instances on this vs3.kanchan2.qtree2 Poller=cluster-01 plugin=Zapi:Qtree
5:29PM WRN goharvest2/cmd/collectors/zapi/plugins/quota/quota.go:185 > no [disk-used-pct-soft-disk-limit] instances on this vs3.kanchan2.qtree2 Poller=cluster-01 plugin=Zapi:Qtree

```