### PR TITLE
fix: exclude root aggr

### DIFF
--- a/conf/zapi/cdot/9.8.0/aggr.yaml
+++ b/conf/zapi/cdot/9.8.0/aggr.yaml
@@ -15,6 +15,7 @@ counters:
       - plex-count
       - raid-size
       - ^state                                 => state
+      - ^is-root-aggregate                     => root_aggr
     - aggr-inode-attributes:
       - files-private-used
       - files-total
@@ -63,6 +64,8 @@ plugins:
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status state online online `0`
+    exclude_equals:
+      - root_aggr `true`
 
 export_options:
   instance_keys:


### PR DESCRIPTION
1. aggrs before any changes

aggr_labels for rest
<img width="1773" alt="image" src="https://user-images.githubusercontent.com/83282894/164212524-e3f17edf-d7c6-4f9f-be01-ea6dff66a78f.png">

aggr labels for zapi (root_aggr label is visible, as we only show non-root aggr, so removed that label)
<img width="1769" alt="image" src="https://user-images.githubusercontent.com/83282894/164212588-18413cb6-1cb0-4834-a4f5-5dd5dc57652c.png">

aggr metrics for both
<img width="1773" alt="image" src="https://user-images.githubusercontent.com/83282894/164212678-db449fb9-b9a1-41d7-8b49-e3aa0aefc525.png">


2. Added the below changes to add label and exclude from label and metrics

aggr labels for zapi
<img width="1769" alt="image" src="https://user-images.githubusercontent.com/83282894/164212747-b676f50f-9696-4af1-87be-7640c742a6fd.png">

aggr metrics for both
<img width="1778" alt="image" src="https://user-images.githubusercontent.com/83282894/164212756-e94db7b1-ddde-4389-a65d-d6f3a0d0518c.png">

