### PR TITLE
fix: ignore transient volumes

### DIFF
--- a/conf/rest/9.12.0/volume.yaml
+++ b/conf/rest/9.12.0/volume.yaml
@@ -73,6 +73,20 @@ plugins:
         - style `flexgroup_constituent`
       replace:
         - style style `flexgroup_constituent` `flexgroup`
+      # To prevent visibility of transient volumes, uncomment the following lines
+#      exclude_regex:
+#        # Exclude SnapProtect/CommVault Intellisnap, Clone volumes have a “_CVclone” suffix
+#        - volume `.+_CVclone`
+#        # Exclude SnapCenter, Clone volumes have a “DDMMYYhhmmss” suffix
+#        - volume `.+(0[1-9]|[12][0-9]|3[01])(0[1-9]|1[012])\d\d[0-9]{6}`
+#        # Exclude manually created SnapCreator clones, Clone volumes have a “cl_” prefix and a “_YYYYMMDDhhmmss” suffix
+#        - volume `cl_.+_(19|20)\d\d(0[1-9]|1[012])( 0[1-9]|[12][0-9]|3[01])[0-9]{6}`
+#        # Exclude SnapDrive/SnapManager, Clone volumes have a “sdw_cl_” prefix
+#        - volume `sdw_cl_.+`
+#        # Exclude Metadata volumes, CRS volumes in SVM-DR or MetroCluster have a “MDV_CRS_” prefix
+#        - volume `MDV_CRS_.+`
+#        # Exclude Metadata volumes, Audit volumes have a “MDV_aud_” prefix
+#        - volume `MDV_aud_.+`
   - Aggregator:
       - volume<style=flexgroup>volume node,svm,aggr,style
 

--- a/conf/restperf/9.12.0/volume.yaml
+++ b/conf/restperf/9.12.0/volume.yaml
@@ -22,6 +22,21 @@ counters:
 
 #plugins:
 #  - Volume
+#  - LabelAgent:
+#      # To prevent visibility of transient volumes, uncomment the following lines
+#      exclude_regex: [todo: need to test after Restperf infra completed]
+#        # Exclude SnapProtect/CommVault Intellisnap, Clone volumes have a “_CVclone” suffix
+#        - volume `.+_CVclone`
+#        # Exclude SnapCenter, Clone volumes have a “DDMMYYhhmmss” suffix
+#        - volume `.+(0[1-9]|[12][0-9]|3[01])(0[1-9]|1[012])\d\d[0-9]{6}`
+#        # Exclude manually created SnapCreator clones, Clone volumes have a “cl_” prefix and a “_YYYYMMDDhhmmss” suffix
+#        - volume `cl_.+_(19|20)\d\d(0[1-9]|1[012])( 0[1-9]|[12][0-9]|3[01])[0-9]{6}`
+#        # Exclude SnapDrive/SnapManager, Clone volumes have a “sdw_cl_” prefix
+#        - volume `sdw_cl_.+`
+#        # Exclude Metadata volumes, CRS volumes in SVM-DR or MetroCluster have a “MDV_CRS_” prefix
+#        - volume `MDV_CRS_.+`
+#        # Exclude Metadata volumes, Audit volumes have a “MDV_aud_” prefix
+#        - volume `MDV_aud_.+`
 
 export_options:
   instance_keys:

--- a/conf/zapi/7mode/8.6.0/volume.yaml
+++ b/conf/zapi/7mode/8.6.0/volume.yaml
@@ -35,6 +35,20 @@ plugins:
     # metric label zapi_value rest_value `default_value`
     value_to_num:
       - new_status state online online `0`
+    # To prevent visibility of transient volumes, uncomment the following lines
+#    exclude_regex:
+#      # Exclude SnapProtect/CommVault Intellisnap, Clone volumes have a “_CVclone” suffix
+#      - volume `.+_CVclone`
+#      # Exclude SnapCenter, Clone volumes have a “DDMMYYhhmmss” suffix
+#      - volume `.+(0[1-9]|[12][0-9]|3[01])(0[1-9]|1[012])\d\d[0-9]{6}`
+#      # Exclude manually created SnapCreator clones, Clone volumes have a “cl_” prefix and a “_YYYYMMDDhhmmss” suffix
+#      - volume `cl_.+_(19|20)\d\d(0[1-9]|1[012])( 0[1-9]|[12][0-9]|3[01])[0-9]{6}`
+#      # Exclude SnapDrive/SnapManager, Clone volumes have a “sdw_cl_” prefix
+#      - volume `sdw_cl_.+`
+#      # Exclude Metadata volumes, CRS volumes in SVM-DR or MetroCluster have a “MDV_CRS_” prefix
+#      - volume `MDV_CRS_.+`
+#      # Exclude Metadata volumes, Audit volumes have a “MDV_aud_” prefix
+#      - volume `MDV_aud_.+`
 
 export_options:
   instance_keys:

--- a/conf/zapi/cdot/9.8.0/volume.yaml
+++ b/conf/zapi/cdot/9.8.0/volume.yaml
@@ -75,19 +75,19 @@ plugins:
       - new_status state online online `0`
     exclude_equals:
       - style `flexgroup_constituent`
-    # To prevent visibility of temporary volumes, uncomment these below lines
+    # To prevent visibility of temporary volumes, uncomment the following lines
 #    exclude_regex:
-#      # Exclusion for SnapProtect/CommVault Intellisnap, Clone volumes gets a “_CVclone” suffix
+#      # Exclude SnapProtect/CommVault Intellisnap, Clone volumes have a “_CVclone” suffix
 #      - volume `.+_CVclone`
-#      # Exclusion for SnapCenter, Clone volumes gets a “DDMMYYhhmmss” suffix
+#      # Exclude SnapCenter, Clone volumes have a “DDMMYYhhmmss” suffix
 #      - volume `.+(0[1-9]|[12][0-9]|3[01])(0[1-9]|1[012])\d\d[0-9]{6}`
-#      # Exclusion for SnapCreator, This is from creating a clone manually in SnapCreator, Clone volume gets a “cl_” prefix and a “_YYYYMMDDhhmmss” suffix
+#      # Exclude manually created SnapCreator clones, Clone volumes have a “cl_” prefix and a “_YYYYMMDDhhmmss” suffix
 #      - volume `cl_.+_(19|20)\d\d(0[1-9]|1[012])( 0[1-9]|[12][0-9]|3[01])[0-9]{6}`
-#      # Exclusion for SnapDrive/SnapManager, Clone volumes gets a “sdw_cl_” prefix
+#      # Exclude SnapDrive/SnapManager, Clone volumes have a “sdw_cl_” prefix
 #      - volume `sdw_cl_.+`
-#      # Exclusion for Metadata volumes that may also clutter menus, CRS volumes in SVM-DR or MetroCluster get a “MDV_CRS_” prefix
+#      # Exclude Metadata volumes, CRS volumes in SVM-DR or MetroCluster have a “MDV_CRS_” prefix
 #      - volume `MDV_CRS_.+`
-#      # Exclusion for Metadata volumes that may also clutter menus, Audit volumes get a “MDV_aud_” prefix
+#      # Exclude Metadata volumes, Audit volumes have a “MDV_aud_” prefix
 #      - volume `MDV_aud_.+`
     replace:
       - style style `flexgroup_constituent` `flexgroup`

--- a/conf/zapi/cdot/9.8.0/volume.yaml
+++ b/conf/zapi/cdot/9.8.0/volume.yaml
@@ -75,6 +75,20 @@ plugins:
       - new_status state online online `0`
     exclude_equals:
       - style `flexgroup_constituent`
+    # To prevent visibility of temporary volumes, uncomment these below lines
+#    exclude_regex:
+#      # Exclusion for SnapProtect/CommVault Intellisnap, Clone volumes gets a “_CVclone” suffix
+#      - volume `.+_CVclone`
+#      # Exclusion for SnapCenter, Clone volumes gets a “DDMMYYhhmmss” suffix
+#      - volume `.+(0[1-9]|[12][0-9]|3[01])(0[1-9]|1[012])\d\d[0-9]{6}`
+#      # Exclusion for SnapCreator, This is from creating a clone manually in SnapCreator, Clone volume gets a “cl_” prefix and a “_YYYYMMDDhhmmss” suffix
+#      - volume `cl_.+_(19|20)\d\d(0[1-9]|1[012])( 0[1-9]|[12][0-9]|3[01])[0-9]{6}`
+#      # Exclusion for SnapDrive/SnapManager, Clone volumes gets a “sdw_cl_” prefix
+#      - volume `sdw_cl_.+`
+#      # Exclusion for Metadata volumes that may also clutter menus, CRS volumes in SVM-DR or MetroCluster get a “MDV_CRS_” prefix
+#      - volume `MDV_CRS_.+`
+#      # Exclusion for Metadata volumes that may also clutter menus, Audit volumes get a “MDV_aud_” prefix
+#      - volume `MDV_aud_.+`
     replace:
       - style style `flexgroup_constituent` `flexgroup`
   Aggregator:

--- a/conf/zapi/cdot/9.8.0/volume.yaml
+++ b/conf/zapi/cdot/9.8.0/volume.yaml
@@ -75,7 +75,7 @@ plugins:
       - new_status state online online `0`
     exclude_equals:
       - style `flexgroup_constituent`
-    # To prevent visibility of temporary volumes, uncomment the following lines
+    # To prevent visibility of transient volumes, uncomment the following lines
 #    exclude_regex:
 #      # Exclude SnapProtect/CommVault Intellisnap, Clone volumes have a “_CVclone” suffix
 #      - volume `.+_CVclone`

--- a/conf/zapiperf/7mode/8.2.5/volume.yaml
+++ b/conf/zapiperf/7mode/8.2.5/volume.yaml
@@ -25,6 +25,21 @@ counters:
 
 plugins:
   - Volume
+#  - LabelAgent:
+#      # To prevent visibility of transient volumes, uncomment the following lines
+#      exclude_regex:
+#        # Exclude SnapProtect/CommVault Intellisnap, Clone volumes have a “_CVclone” suffix
+#        - volume `.+_CVclone`
+#        # Exclude SnapCenter, Clone volumes have a “DDMMYYhhmmss” suffix
+#        - volume `.+(0[1-9]|[12][0-9]|3[01])(0[1-9]|1[012])\d\d[0-9]{6}`
+#        # Exclude manually created SnapCreator clones, Clone volumes have a “cl_” prefix and a “_YYYYMMDDhhmmss” suffix
+#        - volume `cl_.+_(19|20)\d\d(0[1-9]|1[012])( 0[1-9]|[12][0-9]|3[01])[0-9]{6}`
+#        # Exclude SnapDrive/SnapManager, Clone volumes have a “sdw_cl_” prefix
+#        - volume `sdw_cl_.+`
+#        # Exclude Metadata volumes, CRS volumes in SVM-DR or MetroCluster have a “MDV_CRS_” prefix
+#        - volume `MDV_CRS_.+`
+#        # Exclude Metadata volumes, Audit volumes have a “MDV_aud_” prefix
+#        - volume `MDV_aud_.+`
 
 export_options:
   instance_keys:

--- a/conf/zapiperf/cdot/9.8.0/volume.yaml
+++ b/conf/zapiperf/cdot/9.8.0/volume.yaml
@@ -24,6 +24,21 @@ counters:
 
 plugins:
   - Volume
+#  - LabelAgent:
+#      # To prevent visibility of transient volumes, uncomment the following lines
+#      exclude_regex:
+#        # Exclude SnapProtect/CommVault Intellisnap, Clone volumes have a “_CVclone” suffix
+#        - volume `.+_CVclone`
+#        # Exclude SnapCenter, Clone volumes have a “DDMMYYhhmmss” suffix
+#        - volume `.+(0[1-9]|[12][0-9]|3[01])(0[1-9]|1[012])\d\d[0-9]{6}`
+#        # Exclude manually created SnapCreator clones, Clone volumes have a “cl_” prefix and a “_YYYYMMDDhhmmss” suffix
+#        - volume `cl_.+_(19|20)\d\d(0[1-9]|1[012])( 0[1-9]|[12][0-9]|3[01])[0-9]{6}`
+#        # Exclude SnapDrive/SnapManager, Clone volumes have a “sdw_cl_” prefix
+#        - volume `sdw_cl_.+`
+#        # Exclude Metadata volumes, CRS volumes in SVM-DR or MetroCluster have a “MDV_CRS_” prefix
+#        - volume `MDV_CRS_.+`
+#        # Exclude Metadata volumes, Audit volumes have a “MDV_aud_” prefix
+#        - volume `MDV_aud_.+`
 
 export_options:
   instance_keys:


### PR DESCRIPTION
Below details from the Netapp_Harvest_IAG_1.X.pdf

****C.** Use a blacklist to prevent visibility of temporary volumes [optional]**
Harvest will discover all instances of objects such as lifs, volumes, and luns on the cluster. Some of these instances may be temporary, such as those used by backup jobs, and add undesired clutter and storage consumption. Graphite provides the ability to blacklist (block) incoming metrics that match a regular expression string and this feature can be used to block metrics for these temporary instances.
The following steps can be used to block metrics on temporary volumes that are often created by NetApp and NetApp partner software integrations:

1. Login the graphite host and if not logged in as the root superuser, become root using sudo:
```
[user@host ~]# sudo -i
```

2. Use a text editor (nano, vi) to edit the blacklist.conf file. Depending on your installation the location can vary, but is typically one of:
```
[root@host ~]# nano /etc/carbon/blacklist.conf
or
[root@host ~]# nano /opt/graphite/conf/blacklist.conf
```

3. Add the following contents to this file, save, and exit to the command prompt.
```
#
# Exclusion for SnapProtect/CommVault Intellisnap
# Clone volumes gets a “_CVclone” suffix
# ^netapp\.(capacity|perf7?)\..+\.vol\..+_CVclone\..+
#
# Exclusion for SnapCenter
# Clone volumes gets a “DDMMYYhhmmss” suffix
# ^netapp\.(capacity|perf)\..+\.vol\..+(0[1-9]|[12][0-9]|3[01])(0[1-9]|1[012])\d\d[0- 9]{6}\..+
#
# Exclusion for SnapCreator
# This is from creating a clone manually in SnapCreator
# Clone volume gets a “cl_” prefix and a “_YYYYMMDDhhmmss” suffix
#
^netapp\.(capacity|perf7?)\..+\.vol\.cl_.+_(19|20)\d\d(0[1-9]|1[012])( 0[1-9]|[12][0- 9]|3[01])[0-9]{6}\..+
#
# Exclusion for SnapDrive/SnapManager
# Clone volumes gets a “sdw_cl_” prefix
# ^netapp\.(capacity|perf7?)\..+\.vol\.sdw_cl_.+\..+
#
# Exclusion for Metadata volumes that may also clutter menus. #
# CRS volumes in SVM-DR or MetroCluster get a “MDV_CRS_” prefix
# Audit volumes get a “MDV_aud_” prefix # ^netapp\.(perf)\..+\.vol\.MDV_CRS_.+\..+ ^netapp\.(perf)\..+\.vol\.MDV_aud_.+\..+
```

**As per the 1.X doc, these are not ignored by default, They can be ignored based on the above blacklist file.**


--> No transient volumes in my local setup, but MDV_CRS and MDV_aud. Tested them with given regex.