### PR TITLE
fix: some minor issues in dashboard

### DIFF
--- a/cmd/collectors/zapi/plugins/volume/volume.go
+++ b/cmd/collectors/zapi/plugins/volume/volume.go
@@ -196,6 +196,11 @@ func (my *Volume) GetSnapMirrors() (map[string][]*matrix.Instance, map[string]*m
 				smDestinationMap[destinationKey] = instance
 			}
 		}
+
+		// To break the batch zapi call when all the records were fetched.
+		if tag == "" {
+			break
+		}
 	}
 
 	return smSourceMap, smDestinationMap, nil

--- a/grafana/dashboards/cmode/harvest_dashboard_data_protection.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_data_protection.json
@@ -1038,7 +1038,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count((volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",snapshot_policy!=\"\", snapshot_policy!~\"none.*\", volume!~\"MDV.*\"}  * on (snapshot_policy) group_left () group by (snapshot_policy) (snapshot_policy_total_schedules{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"})) * on (volume,svm,cluster) (volume_snapshot_count{} > 0 and volume_snapshot_count{} < 10)) OR on() vector(0)",
+          "expr": "count((volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",snapshot_policy!=\"\", snapshot_policy!~\"none.*\", volume!~\"MDV.*\"}  * on (snapshot_policy) group_left () group by (snapshot_policy) (snapshot_policy_total_schedules{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"})) * on (volume,svm,cluster) (volume_snapshot_count{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"} > 0 and volume_snapshot_count{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"} < 10)) OR on() vector(0)",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -1104,7 +1104,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count((volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",snapshot_policy!=\"\", snapshot_policy!~\"none.*\", volume!~\"MDV.*\"}  * on (snapshot_policy) group_left () group by (snapshot_policy) (snapshot_policy_total_schedules{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"})) * on (volume,svm,cluster) (volume_snapshot_count{} >= 10 and volume_snapshot_count{} <= 100)) OR on() vector(0)",
+          "expr": "count((volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",snapshot_policy!=\"\", snapshot_policy!~\"none.*\", volume!~\"MDV.*\"}  * on (snapshot_policy) group_left () group by (snapshot_policy) (snapshot_policy_total_schedules{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"})) * on (volume,svm,cluster) (volume_snapshot_count{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"} >= 10 and volume_snapshot_count{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"} <= 100)) OR on() vector(0)",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -1170,7 +1170,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count((volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",snapshot_policy!=\"\", snapshot_policy!~\"none.*\", volume!~\"MDV.*\"}  * on (snapshot_policy) group_left () group by (snapshot_policy) (snapshot_policy_total_schedules{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"})) * on (volume,svm,cluster) (volume_snapshot_count{} > 100 and volume_snapshot_count{} <= 500)) OR on() vector(0)",
+          "expr": "count((volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",snapshot_policy!=\"\", snapshot_policy!~\"none.*\", volume!~\"MDV.*\"}  * on (snapshot_policy) group_left () group by (snapshot_policy) (snapshot_policy_total_schedules{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"})) * on (volume,svm,cluster) (volume_snapshot_count{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"} > 100 and volume_snapshot_count{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"} <= 500)) OR on() vector(0)",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -1236,7 +1236,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count((volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",snapshot_policy!=\"\", snapshot_policy!~\"none.*\", volume!~\"MDV.*\"}  * on (snapshot_policy) group_left () group by (snapshot_policy) (snapshot_policy_total_schedules{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"})) * on (volume,svm,cluster) (volume_snapshot_count{} > 500)) OR on() vector(0)",
+          "expr": "count((volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",snapshot_policy!=\"\", snapshot_policy!~\"none.*\", volume!~\"MDV.*\"}  * on (snapshot_policy) group_left () group by (snapshot_policy) (snapshot_policy_total_schedules{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"})) * on (volume,svm,cluster) (volume_snapshot_count{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"} > 500)) OR on() vector(0)",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -1422,7 +1422,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",snapshot_policy!=\"\", snapshot_policy!~\"none.*\", volume!~\"MDV.*\"}  * on (snapshot_policy) group_left () group by (snapshot_policy) (snapshot_policy_total_schedules{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"})) * on (volume,svm,cluster) (volume_snapshot_count{} > 0)",
+          "expr": "(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",snapshot_policy!=\"\", snapshot_policy!~\"none.*\", volume!~\"MDV.*\"}  * on (snapshot_policy) group_left () group by (snapshot_policy) (snapshot_policy_total_schedules{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"})) * on (volume,svm,cluster) (volume_snapshot_count{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"} > 0)",
           "format": "table",
           "instant": true,
           "interval": "",


### PR DESCRIPTION
Found some minor issues in dashboard.
1. not able to stop the batchzapi call even when all records were fetched. 

reason: In case of tag=initial, it will invoke batch call and when it finished, we got tag="". As we have same util function for batch and non-batch zapi call, In this case, it is invoking next non-batch call and duplicate instance key error is found in volume plugin 

2. grafana panel error in data protection dashboard