### PR TITLE
fix: restdiff issues

### DIFF
--- a/conf/rest/9.12.0/aggr.yaml
+++ b/conf/rest/9.12.0/aggr.yaml
@@ -19,7 +19,7 @@ counters:
   - space.block_storage.inactive_user_data                         => space_performance_tier_inactive_user_data
   - space.block_storage.inactive_user_data_percent                 => space_performance_tier_inactive_user_data_percent
   - space.block_storage.physical_used                              => space_physical_used
-  - space.block_storage.physical_used_percent                      => space_physical_used_percent
+  - space.block_storage.physical_used_percent                      => space_used_percent
   - space.block_storage.volume_deduplication_shared_count          => space_sis_shared_count
   - space.block_storage.volume_deduplication_space_saved           => space_sis_saved
   - space.block_storage.volume_deduplication_space_saved_percent   => space_sis_saved_percent
@@ -49,6 +49,12 @@ counters:
   - block_storage.primary.disk_count                               => primary_disk_count
   - block_storage.hybrid_cache.disk_count                          => hybrid_disk_count
   - block_storage.plexes.#                                         => raid_plex_count
+  - space.efficiency.logical_used                                  => total_logical_used
+  - space.efficiency.savings                                       => efficiency_savings
+  - space.efficiency_without_snapshots.logical_used                => logical_used_wo_snapshots
+  - space.efficiency_without_snapshots.savings                     => efficiency_savings_wo_snapshots
+  - space.efficiency_without_snapshots_flexclones.logical_used     => logical_used_wo_snapshots_flexclones
+  - space.efficiency_without_snapshots_flexclones.savings          => efficiency_savings_wo_snapshots_flexclones
   - hidden_fields:
       - inode_attributes
       - space
@@ -60,6 +66,9 @@ plugins:
       compute_metric:
         - snapshot_maxfiles_possible ADD snapshot.max_files_available snapshot.max_files_used
         - raid_disk_count ADD block_storage.primary.disk_count block_storage.hybrid_cache.disk_count
+        - total_physical_used SUBTRACT space.efficiency.logical_used space.efficiency.savings
+        - physical_used_wo_snapshots SUBTRACT space.efficiency_without_snapshots.logical_used space.efficiency_without_snapshots.savings
+        - physical_used_wo_snapshots_flexclones SUBTRACT space.efficiency_without_snapshots_flexclones.logical_used space.efficiency_without_snapshots_flexclones.savings
 
 export_options:
   instance_keys:


### PR DESCRIPTION
This cluster don't return any data in audit REST call.
 
################## Missing Metrics by Object in prometheus ##############
aggr [aggr_space_reserved aggr_hybrid_cache_size_total aggr_inode_used_percent]
security [security_audit_destination_status]
################## Missing Metrics from dashboard ##############
security [security_audit_destination_status]
aggr [aggr_inode_used_percent]
##################

aggr_space_reserved -> deprecated
aggr_hybrid_cache_size_total -> hybrid is disabled. 
aggr_inode_used_percent -> checking

@rahulguptajss 
any specific reason to change name from `space_used_percent` to `space_physical_used_percent` in https://github.com/NetApp/harvest/commit/3d6e8d50cfb7ed5efb8feb39bdebbe4e9151f142