### PR TITLE
fix: restdiff issues

### DIFF
--- a/cmd/tools/doctor/restZapiDiff.go
+++ b/cmd/tools/doctor/restZapiDiff.go
@@ -109,7 +109,6 @@ func metricValueDiff(metricName string) {
 	zapiMetric := make(map[string]float64)
 	restMetric := make(map[string]float64)
 	results := make([]gjson.Result, 0)
-
 	keyIndexes := make([]int, 0)
 
 	if strings.HasPrefix(metricName, "disk_") {
@@ -132,10 +131,7 @@ func metricValueDiff(metricName string) {
 		results = gjson.GetMany(data, "data.result.#.value.1", "data.result.#.metric.datacenter", "data.result.#.metric.qtree")
 		keyIndexes = []int{2}
 	}
-	if strings.HasPrefix(metricName, "environment_sensor_") {
-		results = gjson.GetMany(data, "data.result.#.value.1", "data.result.#.metric.datacenter", "data.result.#.metric.sensor", "data.result.#.metric.node")
-		keyIndexes = []int{2, 3}
-	}
+
 	if strings.HasPrefix(metricName, "shelf_") {
 		results = gjson.GetMany(data, "data.result.#.value.1", "data.result.#.metric.datacenter", "data.result.#.metric.shelf")
 		keyIndexes = []int{2}


### PR DESCRIPTION
While running zapirestdiff cli against infinity cluster, runtime errors are found, which belongs to environment_sensor. These are due to plugin generated metrics. we only have metrics for environment_sensor, but don't have environment_sensor_labels, so count won't match. 

```
################## Metrics Diffs in prometheus ##############
HH environment_sensor_ambient_temperaturepanic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
goharvest2/cmd/tools/doctor.metricValueDiff({0xc0002f5465, 0x26})
        goharvest2/cmd/tools/doctor/restZapiDiff.go:175 +0x1ae5
goharvest2/cmd/tools/doctor.metricDiff({0x7ff7bfeffa79?, 0xc000124008?}, {0x7ff7bfeffa8f, 0x4})
        goharvest2/cmd/tools/doctor/restZapiDiff.go:94 +0x525
goharvest2/cmd/tools/doctor.DoDiffRestZapi({0x7ff7bfeffa79, 0x4}, {0x7ff7bfeffa8f, 0x4})
        goharvest2/cmd/tools/doctor/restZapiDiff.go:27 +0x1e5
goharvest2/cmd/tools/doctor.doDiffRestZapiCmd(0x4962480?, {0x458a13e?, 0x4?, 0x4?})
        goharvest2/cmd/tools/doctor/doctor.go:57 +0x30
github.com/spf13/cobra.(*Command).execute(0x4962480, {0xc0001f8800, 0x4, 0x4})
        github.com/spf13/cobra@v1.3.0/command.go:860 +0x663
github.com/spf13/cobra.(*Command).ExecuteC(0x4964500)
        github.com/spf13/cobra@v1.3.0/command.go:974 +0x3b4
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.3.0/command.go:902
main.main()
        ./harvest.go:627 +0x27
```

Fix would be to ignore environment_sensor metrics from diff comparison.

```
################## Missing Metrics by Object in prometheus ##############
aggr [aggr_inode_inodefile_private_capacity aggr_space_physical_used_percent aggr_inode_maxfiles_used aggr_hybrid_cache_size_total aggr_inode_inodefile_public_capacity aggr_snapshot_inode_used_percent aggr_space_reserved aggr_inode_maxfiles_available aggr_inode_files_total aggr_inode_maxfiles_possible aggr_inode_used_percent aggr_inode_files_used aggr_inode_files_private_used]
security [security_audit_destination_status]
qtree [qtree_threshold]
################## Missing Metrics from dashboard ##############
aggr [aggr_inode_inodefile_private_capacity aggr_inode_inodefile_public_capacity aggr_snapshot_inode_used_percent aggr_inode_files_total aggr_inode_used_percent aggr_inode_files_used]
security [security_audit_destination_status]
##################
```

**-->** 9.11 don't have inode related fields, so they listed in aggr result.
