### PR TITLE
feat: config support for alertmanager with ems alerting rules

### DIFF
--- a/docker/alertmanager/alertmanager.yml
+++ b/docker/alertmanager/alertmanager.yml
@@ -1,0 +1,74 @@
+global:
+  #  smtp_smarthost: smtp.gmail.com:587
+  #  smtp_smarthost: smtp-mail.outlook.com:587
+  resolve_timeout: 3m
+  smtp_smarthost: smtp.gmail.com:465
+  smtp_from: 'hardikpleuva@gmail.com' #[todo] for testing, will remove before submit
+  smtp_auth_username: 'hardikpleuva@gmail.com' #[todo] for testing, will remove before submit
+  smtp_auth_password: 'xxxxxxxxxxxxxxxx' #16 digit passcode
+  smtp_require_tls: false
+
+
+route:
+  group_by: ['alertname', 'cluster', 'message']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 1h
+
+  # A default receiver
+  receiver: admin-mail
+
+  # All the above attributes are inherited by all child routes and can overwritten on each.
+  # The child route trees.
+  routes:
+    # This routes performs a regular expression match on alert labels to catch alerts that are related to a list of messages.
+    - matchers:
+        - message=~"nis.server.not.available|xyz|abc"
+      receiver: info-mails
+      continue: true
+      # The service has a sub-route for critical alerts, any alerts that do not match, i.e. severity != critical, fall-back to the
+      # parent node and are sent to 'info-mails'
+      routes:
+        - matchers:
+            - severity="critical"
+          receiver: error-mails
+
+    - matchers:
+        - message=~"mgmtgwd.certificate.expiring|cde"
+      receiver: info-mails
+      continue: true
+      # The service has a sub-route for critical alerts, any alerts that do not match, i.e. severity != error, fall-back to the
+      # parent node and are sent to 'info-mails'
+      routes:
+        - matchers:
+            - severity="error"
+          receiver: error-mails
+
+
+receivers:
+  - name: 'admin-mail'
+    email_configs:
+      - to: 'hardik.leuva@netapp.com, hardikpleuva@gmail.com'
+        send_resolved: true
+  #    require_tls: yes
+
+  - name: 'info-mails'
+    email_configs:
+      - to: 'hardik.leuva@netapp.com'
+        send_resolved: true
+
+  - name: 'error-mails'
+    email_configs:
+      - to: 'hardikpleuva@gmail.com'
+        send_resolved: true
+
+
+  - name: 'null'
+
+
+inhibit_rules:
+  - source_match:
+      severity: 'critical'
+    target_match:
+      severity: 'warning'
+    equal: ['message_severity', 'node', 'cluster']

--- a/docker/prometheus/alert_rules.yml
+++ b/docker/prometheus/alert_rules.yml
@@ -75,3 +75,36 @@ groups:
     annotations:
       summary: "Snapmirror [{{ $labels.relationship_id }}] has [{{$value}}] lag time (in secs)"
       description: "Snapmirror [{{ $labels.relationship_id }}] has [{{$value}}] lag time (in secs)"
+
+
+- name: Harvest Ems Alert
+  rules:
+
+  # Alert for lun offline bookend ems
+  # [todo] to validate this end-to-end
+  - alert: EMS for lun offline
+    expr: group by (severity, node, object_uuid) ((count by (severity, node, object_uuid)(ems_events{message="LUN.offline"} offset 5m ) - count by (severity, node, object_uuid) (ems_events{message="LUN.online"})) > 0) or group by (severity, node, object_uuid) (ems_events{message="LUN.offline"} offset 5m unless on (object_uuid) ems_events{message="LUN.online"})
+    for: 0m
+    labels:
+      severity: "critical"
+    annotations:
+      summary: "Node [{{ $labels.node }}] has EMS [LUN.offline] with severity [{{ $labels.severity }}] for uuid [{{ $labels.object_uuid }}]"
+      description: "Node [{{ $labels.node }}] has EMS [LUN.offline] with severity [{{ $labels.severity }}] for uuid [{{ $labels.object_uuid }}]"
+
+  # Alert for nis not available ems
+  - alert: nis not available
+    expr: ems_events{message="nis.server.not.available"} offset 5m == 1
+    labels:
+      severity: "error"
+    annotations:
+      summary: "None of the NIS servers configured for SVM [{{ $labels.svm }}] can be contacted."
+      description: "None of the NIS servers configured for SVM [{{ $labels.svm }}] can be contacted."
+
+  # Alert for certificate expiring ems
+  - alert: certificate expiring
+    expr: ems_events{message="mgmtgwd.certificate.expiring"} offset 5m == 1
+    labels:
+      severity: "error"
+    annotations:
+      summary: "A digital certificate with Serial Number [{{ $labels.serial_number }}] for SVM [{{ $labels.svm }}] will expire in the next [{{ $labels.days }}] day(s)."
+      description: "A digital certificate with Serial Number [{{ $labels.serial_number }}] for SVM [{{ $labels.svm }}] will expire in the next [{{ $labels.days }}] day(s)."

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -4,6 +4,13 @@ global:
   external_labels:
     monitor: 'harvest'
 
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - 'localhost:9093'
+
 # Load and evaluate rules in this file every 'evaluation_interval' seconds.
 rule_files:
   - 'alert_rules.yml'


### PR DESCRIPTION
With this config, complete configuration in alertmanager would be like this(few things are defaults):

```
global:
  resolve_timeout: 3m
  http_config:
    follow_redirects: true
  smtp_from: hardikpleuva@gmail.com
  smtp_hello: localhost
  smtp_smarthost: smtp.gmail.com:465
  smtp_auth_username: hardikpleuva@gmail.com
  smtp_auth_password: <secret>
  smtp_require_tls: false
  pagerduty_url: https://events.pagerduty.com/v2/enqueue
  opsgenie_api_url: https://api.opsgenie.com/
  wechat_api_url: https://qyapi.weixin.qq.com/cgi-bin/
  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/
  telegram_api_url: https://api.telegram.org
route:
  receiver: admin-mail
  group_by:
  - alertname
  - cluster
  - message
  continue: false
  routes:
  - receiver: info-mails
    matchers:
    - message=~"nis.server.not.available|xyz|abc"
    continue: true
    routes:
    - receiver: error-mails
      matchers:
      - severity="critical"
      continue: false
  - receiver: info-mails
    matchers:
    - message=~"mgmtgwd.certificate.expiring|cde"
    continue: true
    routes:
    - receiver: error-mails
      matchers:
      - severity="error"
      continue: false
  group_wait: 30s
  group_interval: 5m
  repeat_interval: 1h
inhibit_rules:
- source_match:
    severity: critical
  target_match:
    severity: warning
  equal:
  - message_severity
  - node
  - cluster
receivers:
- name: admin-mail
  email_configs:
  - send_resolved: true
    to: hardik.leuva@netapp.com, hardikpleuva@gmail.com
    from: hardikpleuva@gmail.com
    hello: localhost
    smarthost: smtp.gmail.com:465
    auth_username: hardikpleuva@gmail.com
    auth_password: <secret>
    headers:
      From: hardikpleuva@gmail.com
      Subject: '{{ template "email.default.subject" . }}'
      To: hardik.leuva@netapp.com, hardikpleuva@gmail.com
    html: '{{ template "email.default.html" . }}'
    require_tls: false
- name: info-mails
  email_configs:
  - send_resolved: true
    to: hardik.leuva@netapp.com
    from: hardikpleuva@gmail.com
    hello: localhost
    smarthost: smtp.gmail.com:465
    auth_username: hardikpleuva@gmail.com
    auth_password: <secret>
    headers:
      From: hardikpleuva@gmail.com
      Subject: '{{ template "email.default.subject" . }}'
      To: hardik.leuva@netapp.com
    html: '{{ template "email.default.html" . }}'
    require_tls: false
- name: error-mails
  email_configs:
  - send_resolved: true
    to: hardikpleuva@gmail.com
    from: hardikpleuva@gmail.com
    hello: localhost
    smarthost: smtp.gmail.com:465
    auth_username: hardikpleuva@gmail.com
    auth_password: <secret>
    headers:
      From: hardikpleuva@gmail.com
      Subject: '{{ template "email.default.subject" . }}'
      To: hardikpleuva@gmail.com
    html: '{{ template "email.default.html" . }}'
    require_tls: false
- name: "null"
templates: []
```