### PR TITLE
feat: make perf zapi volume labels consistent with zapi volume

### DIFF
--- a/cmd/collectors/zapiperf/plugins/volume/volume.go
+++ b/cmd/collectors/zapiperf/plugins/volume/volume.go
@@ -1,6 +1,7 @@
 /*
  * Copyright NetApp Inc, 2021 All rights reserved
  */
+
 package volume
 
 import (
@@ -38,12 +39,12 @@ func (me *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 				fg, _ := cache.NewInstance(key)
 				fg.SetLabels(i.GetLabels().Copy())
 				fg.SetLabel("volume", match[1])
-				fg.SetLabel("type", "flexgroup")
+				fg.SetLabel("style", "flexgroup")
 			}
-			i.SetLabel("type", "flexgroup_constituent")
+			i.SetLabel("style", "flexgroup_constituent")
 			i.SetExportable(false)
 		} else {
-			i.SetLabel("type", "flexvol")
+			i.SetLabel("style", "flexvol")
 		}
 	}
 

--- a/conf/zapiperf/cdot/9.8.0/volume.yaml
+++ b/conf/zapiperf/cdot/9.8.0/volume.yaml
@@ -46,4 +46,4 @@ export_options:
     - node
     - svm
     - aggr
-    - type
+    - style


### PR DESCRIPTION
Thanks to Papadopoulos Anastasios for raising on Slack.

The label `type` was changed to `style` for perf zapi volume.

Before:
```
volume_read_latency{aggr="umeng_aff300_aggr1",cluster="umeng-aff300-05-06",datacenter="dc-1",node="umeng-aff300-06",type="flexgroup",svm="vs_test",volume="vol_fc_1"} 100.5
```

After
```
volume_read_latency{aggr="umeng_aff300_aggr1",cluster="umeng-aff300-05-06",datacenter="dc-1",node="umeng-aff300-06",style="flexgroup",svm="vs_test",volume="vol_fc_1"} 100.5
```