### PR TITLE
fix: security certificate duplicate key issue

### DIFF
--- a/conf/zapi/cdot/9.8.0/security_certificate.yaml
+++ b/conf/zapi/cdot/9.8.0/security_certificate.yaml
@@ -25,8 +25,8 @@ plugins:
 export_options:
   instance_keys:
     - name
-  instance_labels:
     - svm
+  instance_labels:
     - serial_number
     - type
     - certificateIssuerType

--- a/conf/zapi/cdot/9.8.0/security_certificate.yaml
+++ b/conf/zapi/cdot/9.8.0/security_certificate.yaml
@@ -6,6 +6,7 @@ object:     security_certificate
 counters:
   certificate-info:
     - ^^cert-name              => name
+    - ^^vserver                => svm
     - ^serial-number           => serial_number
     - ^type                    => type
     - ^public-certificate      => certificatePEM
@@ -25,6 +26,7 @@ export_options:
   instance_keys:
     - name
   instance_labels:
+    - svm
     - serial_number
     - type
     - certificateIssuerType


### PR DESCRIPTION
We were using different `-cert-name` for all svms(admin svm as well) for local clusters, so haven't identify this issue earlier. 

I have reproduce this issue locally by creating the same `-cert-name` 
```
ocum-infinity::> security certificate create -cert-name 0016d08e-807d-4159-a6fe-feec7e344cc0 -vserver dp_test -common-name anvtest -type server 

ocum-infinity::> security certificate show -cert-name 0016d08e-807d-4159-a6fe-feec7e344cc0
Vserver    Serial Number   Certificate Name                       Type
---------- --------------- -------------------------------------- ------------
dp_test    16F6A6EC8DE4E0A3 
                           0016d08e-807d-4159-a6fe-feec7e344cc0   server
    Certificate Authority: anvtest
          Expiration Date: Thu Jun 08 09:04:08 2023

ocum-infinity 
           2908E23B        0016d08e-807d-4159-a6fe-feec7e344cc0   client
    Certificate Authority: 0016d08e-807d-4159-a6fe-feec7e344cc0
          Expiration Date: Wed Jan 06 05:58:47 2027

2 entries were displayed.
```

And in next poll, It throws duplicate instance key error 
```
6:43PM ERR collector/zapi.go:294 >  error="duplicate instance key => 0016d08e-807d-4159-a6fe-feec7e344cc0" Poller=cluster-21 collector=Zapi:SecurityCert stack="goroutine 26 [running]:\ngithub.com/netapp/harvest/v2/pkg/logging.MarshalStack({0x4756c20?, 0xc001292c20?})\n\tgithub.com/netapp/harvest/v2/pkg/logging/logger.go:152 +0x89\ngithub.com/rs/zerolog.(*Event).Err(0xc00060e720, {0x4756c20, 0xc001292c20})\n\tgithub.com/rs/zerolog@v1.26.1/event.go:374 +0x63\ngithub.com/netapp/harvest/v2/cmd/collectors/zapi/collector.(*Zapi).PollInstance(0xc0002b79e0)\n\tgithub.com/netapp/harvest/v2/cmd/collectors/zapi/collector/zapi.go:294 +0xca5\ngithub.com/netapp/harvest/v2/cmd/poller/schedule.(*task).Run(0xc00009f450)\n\tgithub.com/netapp/harvest/v2/cmd/poller/schedule/schedule.go:61 +0x4e\ngithub.com/netapp/harvest/v2/cmd/poller/collector.(*AbstractCollector).Start(0xc0002944e0, 0x0?)\n\tgithub.com/netapp/harvest/v2/cmd/poller/collector/collector.go:304 +0x4b4\ncreated by main.(*Poller).Start\n\t./poller.go:399 +0x2c5\n"
```

Just to validate, any new certificate with same `-cert-name` can be allowed to create in same svm with different type, tried these but it's not supported.
```
ocum-infinity::> security certificate create -cert-name 0016d08e-807d-4159-a6fe-feec7e344cc0 -vserver dp_test -common-name ascvgb -type client 

Error: command failed: duplicate entry

ocum-infinity::> security certificate create -cert-name 0016d08e-807d-4159-a6fe-feec7e344cc0 -vserver dp_test -common-name ascvgb -type root-ca 

Error: command failed: duplicate entry

ocum-infinity::> 
```
 
**FIx:** For solving this issue, I added svm name in instancekey. 

For REST, 
We have uuid field for certificate which is unique. 
```
  {
     "uuid": "93e353fa-71cf-11ec-83e6-00a098e0219a",
     "name": "0016d08e-807d-4159-a6fe-feec7e344cc0",
     "_links": {
        "self": {
            "href": "/api/security/certificates/93e353fa-71cf-11ec-83e6-00a098e0219a"
        }
  }
  {
      "uuid": "7b7430d2-e72b-11ec-8a6c-00a098e0060e",
      "name": "0016d08e-807d-4159-a6fe-feec7e344cc0",
      "_links": {
          "self": {
              "href": "/api/security/certificates/7b7430d2-e72b-11ec-8a6c-00a098e0060e"
          }
  }
```