### PR TITLE
fix: plugin logger changes

### DIFF
--- a/cmd/collectors/rest/plugins/certificate/certificate.go
+++ b/cmd/collectors/rest/plugins/certificate/certificate.go
@@ -71,13 +71,13 @@ func (my *Certificate) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 
 		// invoke private vserver cli rest and get admin vserver name
 		if adminVserver, err = my.GetAdminVserver(); err != nil {
-			my.Logger.Warn().Err(err).Msg("Failed to collect admin vserver")
+			my.Logger.Debug().Err(err).Msg("Failed to collect admin vserver")
 			return nil, nil
 		}
 
 		// invoke private ssl cli rest and get admin vserver's serial number
 		if adminVserverSerial, err = my.GetSecuritySsl(adminVserver); err != nil {
-			my.Logger.Warn().Err(err).Msg("Failed to collect admin vserver's serial number")
+			my.Logger.Debug().Err(err).Msg("Failed to collect admin vserver's serial number")
 			return nil, nil
 		}
 
@@ -111,19 +111,19 @@ func (my *Certificate) setCertificateIssuerType(instance *matrix.Instance) {
 	certUUID := instance.GetLabel("uuid")
 
 	if certificatePEM == "" {
-		my.Logger.Warn().Str("uuid", certUUID).Msg("Certificate is not found")
+		my.Logger.Debug().Str("uuid", certUUID).Msg("Certificate is not found")
 		instance.SetLabel("certificateIssuerType", "unknown")
 	} else {
 		instance.SetLabel("certificateIssuerType", "self_signed")
 		certDecoded, _ := pem.Decode([]byte(certificatePEM))
 		if certDecoded == nil {
-			my.Logger.Warn().Msg("PEM formatted object is not a X.509 certificate. Only PEM formatted X.509 certificate input is allowed")
+			my.Logger.Debug().Msg("PEM formatted object is not a X.509 certificate. Only PEM formatted X.509 certificate input is allowed")
 			instance.SetLabel("certificateIssuerType", "unknown")
 			return
 		}
 
 		if cert, err = x509.ParseCertificate(certDecoded.Bytes); err != nil {
-			my.Logger.Warn().Msg("PEM formatted object is not a X.509 certificate. Only PEM formatted X.509 certificate input is allowed")
+			my.Logger.Debug().Msg("PEM formatted object is not a X.509 certificate. Only PEM formatted X.509 certificate input is allowed")
 			instance.SetLabel("certificateIssuerType", "unknown")
 			return
 		}

--- a/cmd/collectors/rest/plugins/snapmirror/snapmirror.go
+++ b/cmd/collectors/rest/plugins/snapmirror/snapmirror.go
@@ -92,7 +92,7 @@ func (my *SnapMirror) updateNodeCache() error {
 		key := vserverName + volumeName
 
 		if _, ok := my.svmVolToNode[key]; ok {
-			my.Logger.Warn().Str("key", key).Msg("Duplicate key found")
+			my.Logger.Debug().Str("key", key).Msg("Duplicate key found")
 		}
 		my.svmVolToNode[key] = nodeName
 	}

--- a/cmd/collectors/rest/plugins/svm/svm.go
+++ b/cmd/collectors/rest/plugins/svm/svm.go
@@ -33,8 +33,7 @@ func (my *SVM) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 
 	// invoke nameservice-nsswitch-get-iter zapi and get nsswitch info
 	if my.nsswitchInfo, err = my.GetNSSwitchInfo(data); err != nil {
-		my.Logger.Warn().Err(err).Msg("Failed to collect nsswitch info")
-		//return nil, nil
+		my.Logger.Debug().Err(err).Msg("Failed to collect nsswitch info")
 	}
 
 	// update svm instance based on the above zapi response

--- a/cmd/collectors/rest/plugins/volume/volume.go
+++ b/cmd/collectors/rest/plugins/volume/volume.go
@@ -88,15 +88,15 @@ func (my *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 
 		// invoke snapmirror rest and populate info in source and destination snapmirror maps
 		if smSourceMap, smDestinationMap, err := my.GetSnapMirrors(); err != nil {
-			my.Logger.Warn().Err(err).Msg("Failed to collect snapmirror data")
+			my.Logger.Debug().Err(err).Msg("Failed to collect snapmirror data")
 		} else {
 			// update internal cache based on volume and SM maps
 			my.updateMaps(data, smSourceMap, smDestinationMap)
 		}
 
 		// invoke disk rest and populate info in aggrsMap
-		if disks, err := my.getDiskData(); err != nil {
-			my.Logger.Warn().Err(err).Msg("Failed to collect disk data")
+		if disks, err := my.getEncryptedDisks(); err != nil {
+			my.Logger.Debug().Err(err).Msg("Failed to collect disk data")
 		} else {
 			// update aggrsMap based on disk data
 			my.updateAggrMap(disks)
@@ -268,7 +268,7 @@ func (my *Volume) updateVolumeLabels(data *matrix.Matrix) {
 	}
 }
 
-func (my *Volume) getDiskData() ([]gjson.Result, error) {
+func (my *Volume) getEncryptedDisks() ([]gjson.Result, error) {
 	var (
 		result []gjson.Result
 		err    error

--- a/cmd/collectors/zapi/plugins/certificate/certificate.go
+++ b/cmd/collectors/zapi/plugins/certificate/certificate.go
@@ -60,11 +60,9 @@ func (my *Certificate) Init() error {
 	if b := my.Params.GetChildContentS("batch_size"); b != "" {
 		if _, err := strconv.Atoi(b); err == nil {
 			my.batchSize = b
-			my.Logger.Info().Str("BatchSize", my.batchSize).Msg("using batch-size")
 		}
 	} else {
 		my.batchSize = BatchSize
-		my.Logger.Trace().Str("BatchSize", BatchSize).Msg("Using default batch-size")
 	}
 
 	return nil
@@ -83,13 +81,13 @@ func (my *Certificate) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 
 		// invoke vserver-get-iter zapi and get admin vserver name
 		if adminVserver, err = my.GetAdminVserver(); err != nil {
-			my.Logger.Warn().Err(err).Msg("Failed to collect admin vserver")
+			my.Logger.Debug().Err(err).Msg("Failed to collect admin vserver")
 			return nil, nil
 		}
 
 		// invoke security-ssl-get-iter zapi and get admin vserver's serial number
 		if adminVserverSerial, err = my.GetSecuritySsl(adminVserver); err != nil {
-			my.Logger.Warn().Err(err).Msg("Failed to collect admin vserver's serial number")
+			my.Logger.Debug().Err(err).Msg("Failed to collect admin vserver's serial number")
 			return nil, nil
 		}
 
@@ -123,19 +121,19 @@ func (my *Certificate) setCertificateIssuerType(instance *matrix.Instance) {
 	certUUID := instance.GetLabel("uuid")
 
 	if certificatePEM == "" {
-		my.Logger.Warn().Str("uuid", certUUID).Msg("Certificate is not found")
+		my.Logger.Debug().Str("uuid", certUUID).Msg("Certificate is not found")
 		instance.SetLabel("certificateIssuerType", "unknown")
 	} else {
 		instance.SetLabel("certificateIssuerType", "self_signed")
 		certDecoded, _ := pem.Decode([]byte(certificatePEM))
 		if certDecoded == nil {
-			my.Logger.Warn().Msg("PEM formatted object is not a X.509 certificate. Only PEM formatted X.509 certificate input is allowed")
+			my.Logger.Debug().Msg("PEM formatted object is not a X.509 certificate. Only PEM formatted X.509 certificate input is allowed")
 			instance.SetLabel("certificateIssuerType", "unknown")
 			return
 		}
 
 		if cert, err = x509.ParseCertificate(certDecoded.Bytes); err != nil {
-			my.Logger.Warn().Msg("PEM formatted object is not a X.509 certificate. Only PEM formatted X.509 certificate input is allowed")
+			my.Logger.Debug().Msg("PEM formatted object is not a X.509 certificate. Only PEM formatted X.509 certificate input is allowed")
 			instance.SetLabel("certificateIssuerType", "unknown")
 			return
 		}

--- a/cmd/collectors/zapi/plugins/security/security.go
+++ b/cmd/collectors/zapi/plugins/security/security.go
@@ -69,14 +69,12 @@ func (my *Security) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 
 		// invoke security-config-get zapi with 'ssl' interface and get fips status
 		if my.fipsEnabled, err = my.getSecurityConfig(); err != nil {
-			my.Logger.Warn().Err(err).Msg("Failed to collect fips enable status")
-			//return nil, nil
+			my.Logger.Debug().Err(err).Msg("Failed to collect fips enable status")
 		}
 
 		// invoke security-protocol-get zapi with 'telnet' and 'rsh' and get
 		if my.telnetEnabled, my.rshEnabled, err = my.getSecurityProtocols(); err != nil {
-			my.Logger.Warn().Err(err).Msg("Failed to collect telnet and rsh enable status")
-			//return nil, nil
+			my.Logger.Debug().Err(err).Msg("Failed to collect telnet and rsh enable status")
 		}
 
 		// update instance based on the above zapi response

--- a/cmd/collectors/zapi/plugins/svm/svm.go
+++ b/cmd/collectors/zapi/plugins/svm/svm.go
@@ -79,11 +79,9 @@ func (my *SVM) Init() error {
 	if b := my.Params.GetChildContentS("batch_size"); b != "" {
 		if _, err := strconv.Atoi(b); err == nil {
 			my.batchSize = b
-			my.Logger.Info().Str("BatchSize", my.batchSize).Msg("using batch-size")
 		}
 	} else {
 		my.batchSize = BatchSize
-		my.Logger.Trace().Str("BatchSize", BatchSize).Msg("Using default batch-size")
 	}
 
 	return nil
@@ -99,44 +97,37 @@ func (my *SVM) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 
 		// invoke fileservice-audit-config-get-iter zapi and get audit protocols
 		if my.auditProtocols, err = my.GetAuditProtocols(); err != nil {
-			my.Logger.Warn().Err(err).Msg("Failed to collect audit protocols")
-			//return nil, nil
+			my.Logger.Debug().Err(err).Msg("Failed to collect audit protocols")
 		}
 
 		// invoke cifs-security-get-iter zapi and get cifs protocols
 		if my.cifsProtocols, err = my.GetCifsProtocols(); err != nil {
-			my.Logger.Warn().Err(err).Msg("Failed to collect cifs protocols")
-			//return nil, nil
+			my.Logger.Debug().Err(err).Msg("Failed to collect cifs protocols")
 		}
 
 		// invoke nameservice-nsswitch-get-iter zapi and get nsswitch info
 		if my.nsswitchInfo, err = my.GetNSSwitchInfo(); err != nil {
-			my.Logger.Warn().Err(err).Msg("Failed to collect nsswitch info")
-			//return nil, nil
+			my.Logger.Debug().Err(err).Msg("Failed to collect nsswitch info")
 		}
 
 		// invoke nis-get-iter zapi and get nisdomain info
 		if my.nisInfo, err = my.GetNisInfo(); err != nil {
-			my.Logger.Warn().Err(err).Msg("Failed to collect nisdomain info")
-			//return nil, nil
+			my.Logger.Debug().Err(err).Msg("Failed to collect nisdomain info")
 		}
 
 		// invoke cifs-server-get-iter zapi and get cifsenabled info
 		if my.cifsEnabled, err = my.GetCifsEnabled(); err != nil {
-			my.Logger.Warn().Err(err).Msg("Failed to collect cifsenabled info")
-			//return nil, nil
+			my.Logger.Debug().Err(err).Msg("Failed to collect cifsenabled info")
 		}
 
 		// invoke nfs-service-get-iter zapi and get cifsenabled info
 		if my.nfsEnabled, err = my.GetNfsEnabled(); err != nil {
-			my.Logger.Warn().Err(err).Msg("Failed to collect nfsenabled info")
-			//return nil, nil
+			my.Logger.Debug().Err(err).Msg("Failed to collect nfsenabled info")
 		}
 
 		// invoke security-ssh-get-iter zapi and get ssh data
 		if my.sshData, err = my.GetSSHData(); err != nil {
-			my.Logger.Warn().Err(err).Msg("Failed to collect ssh data")
-			//return nil, nil
+			my.Logger.Debug().Err(err).Msg("Failed to collect ssh data")
 		}
 
 		// update svm instance based on the above zapi response


### PR DESCRIPTION
1. As the plugin code-flow would be invoking few ZAPI/REST calls and add/update the labels in existing metrics based on the response. 
2. Based on the ONTAP version, few ZAPI/REST calls won't work and those labels would be empty as design - NO impact

Changed the plugin logger from Info/Warn to Debug to reduce the log spam for bullet 2 above.