### PR TITLE
fix: duplicate instance key for SecurityAccount

### DIFF
--- a/conf/zapi/cdot/9.8.0/security_account.yaml
+++ b/conf/zapi/cdot/9.8.0/security_account.yaml
@@ -9,6 +9,7 @@ counters:
     - ^^application                               => applications
     - ^^vserver                                   => svm
     - ^^authentication-method                     => methods
+    - ^^remote-switch-ipaddress                   => remote_switch_ipaddress
     - ^role-name                                  => role_name
     - ^password-hash-algorithm                    => hash_algorithm
     - ^is-locked                                  => locked
@@ -30,6 +31,7 @@ export_options:
     - applications
     - svm
     - methods
+    - remote_switch_ipaddress
   instance_labels:
     - role_name
     - hash_algorithm

--- a/pkg/tree/node/node.go
+++ b/pkg/tree/node/node.go
@@ -416,7 +416,7 @@ func (n *Node) SearchContent(prefix []string, paths [][]string) ([]string, bool)
 			newPath = make([]string, len(currentPath))
 			copy(newPath, currentPath)
 		}
-		//fmt.Printf(" -> current_path=%v \t new_path=%v\n", current_path, new_path)
+		//fmt.Printf(" -> current_path=%v \t new_path=%v\n", currentPath, newPath)
 		for _, path := range paths {
 			if util.EqualStringSlice(newPath, path) {
 				matches = append(matches, node.GetContentS())
@@ -434,7 +434,7 @@ func (n *Node) SearchContent(prefix []string, paths [][]string) ([]string, bool)
 	search(n, []string{})
 
 	//fmt.Printf("matches (%d):\n%v\n", len(matches), matches)
-	return matches, len(matches) == len(paths)
+	return matches, len(matches) > 0
 }
 
 func (n *Node) SearchChildren(path []string) []*Node {


### PR DESCRIPTION
In most of the clusters, this field `remote-switch-ipaddress` won't be available as it's based on the remote switch. That's why we haven't encountered in our UTs.

![image](https://user-images.githubusercontent.com/83282894/174063673-d1990e7d-f9ab-45b1-b8f3-2d279028c8a5.png)

**Fix:** added the `remote-switch-ipaddress` as instanceKey
**Detail:** 
- we have restriction in ZAPI workflow that if any key is not exist in response then we ignore/skip that instance
- This logic has been changed, and it will only skip the instance when all the asked keys were not exist in response.
- If one key exist, we would go ahead and parse that instance.  

