### PR TITLE
fix: remove aggr, node in rest for flexgroup

### DIFF
--- a/cmd/collectors/rest/plugins/volume/volume.go
+++ b/cmd/collectors/rest/plugins/volume/volume.go
@@ -226,7 +226,13 @@ func (my *Volume) updateVolumeLabels(data *matrix.Matrix) {
 		volumeName := volume.GetLabel("volume")
 		svmName := volume.GetLabel("svm")
 		volumeType := volume.GetLabel("type")
+
+		// For flexgroup, aggrUuid in Rest should be empty for parity with Zapi response
+		if volumeStyle := volume.GetLabel("style"); volumeStyle == "flexgroup" {
+			volume.SetLabel("aggrUuid", "")
+		}
 		aggrUUID := volume.GetLabel("aggrUuid")
+
 		key := volumeName + "-" + svmName
 
 		// Update protectionRole label in volume
@@ -285,12 +291,16 @@ func (my *Volume) getDiskData() ([]gjson.Result, error) {
 }
 
 func (my *Volume) updateAggrMap(disks []gjson.Result) {
-	// Clean aggrsMap map
-	my.aggrsMap = make(map[string]string)
+	if disks != nil {
+		// Clean aggrsMap map
+		my.aggrsMap = make(map[string]string)
 
-	for _, disk := range disks {
-		aggrName := disk.Get("aggregates.name").String()
-		aggrUUID := disk.Get("aggregates.uuid").String()
-		my.aggrsMap[aggrUUID] = aggrName
+		for _, disk := range disks {
+			aggrName := disk.Get("aggregates.name").String()
+			aggrUUID := disk.Get("aggregates.uuid").String()
+			if aggrUUID != "" {
+				my.aggrsMap[aggrUUID] = aggrName
+			}
+		}
 	}
 }

--- a/cmd/collectors/restperf/plugins/volume/volume.go
+++ b/cmd/collectors/restperf/plugins/volume/volume.go
@@ -31,6 +31,9 @@ func (me *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 				fg, _ := cache.NewInstance(key)
 				fg.SetLabels(i.GetLabels().Copy())
 				fg.SetLabel("volume", match[1])
+				// Flexgroup don't show any aggregate, node
+				fg.SetLabel("aggr", "")
+				fg.SetLabel("node", "")
 				fg.SetLabel("style", "flexgroup")
 			}
 			i.SetLabel("style", "flexgroup_constituent")

--- a/cmd/collectors/zapiperf/plugins/volume/volume.go
+++ b/cmd/collectors/zapiperf/plugins/volume/volume.go
@@ -39,6 +39,9 @@ func (me *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 				fg, _ := cache.NewInstance(key)
 				fg.SetLabels(i.GetLabels().Copy())
 				fg.SetLabel("volume", match[1])
+				// Flexgroup don't show any aggregate, node
+				fg.SetLabel("aggr", "")
+				fg.SetLabel("node", "")
 				fg.SetLabel("style", "flexgroup")
 			}
 			i.SetLabel("style", "flexgroup_constituent")

--- a/conf/rest/9.12.0/svm.yaml
+++ b/conf/rest/9.12.0/svm.yaml
@@ -5,7 +5,6 @@ object:                   svm
 counters:
   - ^^uuid                                  => svm_uuid
   - ^name                                   => svm
-  - ^aggregates.#.name                      => aggr
   - ^state                                  => state
   - ^anti_ransomware_default_volume_state   => anti_ransomware_state
   - ^nsswitch                               => nameservice_switch
@@ -68,7 +67,6 @@ plugins:
 export_options:
   instance_keys:
     - svm
-    - aggr
   instance_labels:
     - state
     - anti_ransomware_state

--- a/conf/rest/9.12.0/volume.yaml
+++ b/conf/rest/9.12.0/volume.yaml
@@ -6,8 +6,7 @@ counters:
   - ^^uuid                                        => instance_uuid
   - ^name                                         => volume
   - ^svm.name                                     => svm
-  - ^aggregates.#.name                            => aggr #zapi maps to field containing-aggregate-name while rest mapping is an array?
-  - ^aggregates.#.uuid                            => aggrUuid
+  - ^aggregates.#.uuid                            => aggrUuid        # handled in plugin for flexgroup
   - ^style                                        => style
   - ^type                                         => type
   - ^snapshot_policy.name                         => snapshot_policy
@@ -52,6 +51,7 @@ endpoints:
     counters:
       - ^^instance_uuid                           => instance_uuid
       - ^node                                     => node
+      - ^aggregate                                => aggr
       - ^is_sis_volume                            => is_sis_volume
       - compression_space_saved_percent           => sis_compress_saved_percent
       - dedupe_space_saved_percent                => sis_dedup_saved_percent

--- a/conf/zapi/cdot/9.8.0/svm.yaml
+++ b/conf/zapi/cdot/9.8.0/svm.yaml
@@ -7,7 +7,6 @@ counters:
   vserver-info:
     - ^^uuid                                  => svm_uuid
     - ^vserver-name                           => svm
-    - ^aggr-list                              => aggr
     - ^state                                  => state
     - ^anti-ransomware-default-volume-state   => anti_ransomware_state
     - name-server-switch:
@@ -26,7 +25,6 @@ plugins:
 export_options:
   instance_keys:
     - svm
-    - aggr
   instance_labels:
     - state
     - anti_ransomware_state

--- a/conf/zapi/cdot/9.8.0/volume.yaml
+++ b/conf/zapi/cdot/9.8.0/volume.yaml
@@ -17,6 +17,7 @@ counters:
       - ^node                       => node
       - ^owning-vserver-name        => svm
       - ^containing-aggregate-name  => aggr
+      - ^containing-aggregate-uuid  => aggrUuid
       - ^style-extended             => style
       - ^type                       => type
 


### PR DESCRIPTION
Fix details:
Rest/Zapi: aggr, node labels in Rest should be same as Zapi. 
 - node from private cli
 - aggr from private cli
 - aggrUuid - other use case in plugin for isHardwareEncrypted label, handled in plugin

RestPerf/ZapiPerf
- removed aggr, node labels in perf plugin for flexgroup.

Svm:
- Zapi can have aggr-list(list not supported) or root-volume-aggr, both would not be much useful at svm level
- Rest can have aggr-list or root-volume-aggr, both would not be much useful at svm level, - should be parity with Zapi
- we don't use aggr field from svm