### PR TITLE
fix: add serial number as key for certificate

### DIFF
--- a/conf/zapi/cdot/9.8.0/security_certificate.yaml
+++ b/conf/zapi/cdot/9.8.0/security_certificate.yaml
@@ -7,7 +7,7 @@ counters:
   certificate-info:
     - ^^cert-name              => name
     - ^^vserver                => svm
-    - ^serial-number           => serial_number
+    - ^^serial-number          => serial_number
     - ^type                    => type
     - ^public-certificate      => certificatePEM
     - expiration-date          => expiry_time
@@ -26,8 +26,8 @@ export_options:
   instance_keys:
     - name
     - svm
-  instance_labels:
     - serial_number
+  instance_labels:
     - type
     - certificateIssuerType
     - certificateExpiryStatus


### PR DESCRIPTION
Adding serial-number to key because
- it's already exist as label in template, so no new addition in template.
- comman-name would be small or similar to cert-name as it's used to form cert-name.  cert-name=comman-name+serial 

cluster 10.193.6.61:
![image](https://user-images.githubusercontent.com/83282894/175554326-f0a80fc7-c7f5-4e3c-8e3a-5d0f4a0076c5.png)


other cluster > 9.1:
![image](https://user-images.githubusercontent.com/83282894/175554719-4936a33d-5f2f-4f3e-ac16-208e8d4cb31e.png)

