### PR TITLE
fix: remove only_cluster_instance for security_audit_destination_status

### DIFF
--- a/conf/rest/9.12.0/security_audit_dest.yaml
+++ b/conf/rest/9.12.0/security_audit_dest.yaml
@@ -4,9 +4,8 @@ query:            api/security/audit/destinations
 object:           security_audit_destination
 
 counters:
-  - ^protocol     => protocol
+  - ^^protocol    => protocol
 
-only_cluster_instance: true
 
 plugins:
   - LabelAgent:

--- a/conf/zapi/cdot/9.8.0/security_audit_dest.yaml
+++ b/conf/zapi/cdot/9.8.0/security_audit_dest.yaml
@@ -5,10 +5,9 @@ object:     security_audit_destination
 
 counters:
   cluster-log-forward-info:
-    - ^protocol                  => protocol
+    - ^^protocol                 => protocol
     - port                       => port
 
-only_cluster_instance: true
 
 plugins:
   - LabelAgent:


### PR DESCRIPTION
Solving for rest-zapi cli diff 
################## Missing Metrics by Object in prometheus ##############
security [security_audit_destination_status]



=======================================
Before the change:
![image](https://user-images.githubusercontent.com/83282894/178276122-d4bc8a1a-e95f-4187-a787-414da790c317.png)
**line 2 and 4 are entries where zapi call is empty but due to `only_cluster_instance` this metric was created which is actually not required.** 


==================================
After the change:
![image](https://user-images.githubusercontent.com/83282894/178275199-44f4b7e4-41d5-4aa8-8592-05d0267fb7af.png)


we do change status metric value 1/0 based on `tcp_encrypted`
![image](https://user-images.githubusercontent.com/83282894/178275314-5ac3187a-256b-437b-8274-79022ae4ef1b.png)
