### PR TITLE
fix: remove unused metric

### DIFF
--- a/grafana/dashboards/cmode/harvest_dashboard_compliance.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_compliance.json
@@ -1399,16 +1399,6 @@
           "refId": "F"
         },
         {
-          "exemplar": false,
-          "expr": "security_audit_destination_status{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"}",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "H"
-        },
-        {
           "exemplar": true,
           "expr": "count by (datacenter, cluster) (ntpserver_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\"})",
           "format": "table",


### PR DESCRIPTION
This column #H is not used anywhere in the table.

Rest of the places `security_audit_destination_status` metric used as `security_audit_destination_status{datacenter="$Datacenter",cluster=~"$Cluster", protocol!="tcp_encrypted"}`.