### PR TITLE
fix: color changes for data protection + few other dashboards

### DIFF
--- a/grafana/dashboards/7mode/harvest_dashboard_volume7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_volume7.json
@@ -938,7 +938,7 @@
               },
               "custom": {
                 "align": "auto",
-                "displayMode": "color-background-solid",
+                "displayMode": "auto",
                 "filterable": false
               },
               "mappings": [],
@@ -1049,7 +1049,7 @@
               },
               "custom": {
                 "align": "auto",
-                "displayMode": "color-background-solid",
+                "displayMode": "auto",
                 "filterable": false
               },
               "mappings": [],
@@ -1278,7 +1278,7 @@
               },
               "custom": {
                 "align": "auto",
-                "displayMode": "color-background-solid",
+                "displayMode": "auto",
                 "filterable": false
               },
               "mappings": [],
@@ -1389,7 +1389,7 @@
               },
               "custom": {
                 "align": "auto",
-                "displayMode": "color-background-solid",
+                "displayMode": "auto",
                 "filterable": false
               },
               "mappings": [],

--- a/grafana/dashboards/cmode/harvest_dashboard_data_protection_snapshot.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_data_protection_snapshot.json
@@ -587,7 +587,7 @@
           },
           "custom": {
             "align": "auto",
-            "displayMode": "color-background-solid",
+            "displayMode": "auto",
             "filterable": false
           },
           "mappings": [],
@@ -1261,7 +1261,7 @@
           },
           "custom": {
             "align": "left",
-            "displayMode": "color-background-solid",
+            "displayMode": "auto",
             "filterable": false
           },
           "mappings": [],

--- a/grafana/dashboards/cmode/harvest_dashboard_snapmirror.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_snapmirror.json
@@ -2880,7 +2880,7 @@
           },
           "custom": {
             "align": "left",
-            "displayMode": "color-background-solid",
+            "displayMode": "auto",
             "filterable": false
           },
           "mappings": [],
@@ -3044,7 +3044,7 @@
           },
           "custom": {
             "align": "left",
-            "displayMode": "color-background-solid",
+            "displayMode": "auto",
             "filterable": false
           },
           "mappings": [],
@@ -3965,7 +3965,7 @@
           },
           "custom": {
             "align": "left",
-            "displayMode": "color-background-solid",
+            "displayMode": "auto",
             "filterable": false
           },
           "mappings": [],
@@ -4131,7 +4131,7 @@
           },
           "custom": {
             "align": "left",
-            "displayMode": "color-background-solid",
+            "displayMode": "auto",
             "filterable": false
           },
           "mappings": [],

--- a/grafana/dashboards/cmode/harvest_dashboard_volume_details.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_volume_details.json
@@ -1056,7 +1056,7 @@
               },
               "custom": {
                 "align": "auto",
-                "displayMode": "color-background-solid",
+                "displayMode": "auto",
                 "filterable": false
               },
               "mappings": [],
@@ -1167,7 +1167,7 @@
               },
               "custom": {
                 "align": "auto",
-                "displayMode": "color-background-solid",
+                "displayMode": "auto",
                 "filterable": false
               },
               "mappings": [],
@@ -1396,7 +1396,7 @@
               },
               "custom": {
                 "align": "auto",
-                "displayMode": "color-background-solid",
+                "displayMode": "auto",
                 "filterable": false
               },
               "mappings": [],
@@ -1507,7 +1507,7 @@
               },
               "custom": {
                 "align": "auto",
-                "displayMode": "color-background-solid",
+                "displayMode": "auto",
                 "filterable": false
               },
               "mappings": [],


### PR DESCRIPTION
When color is single(fixed) then displaymode should be auto to visible in light UI
![image](https://user-images.githubusercontent.com/83282894/178455784-0a2d10b5-61e4-4d37-a8b8-edc9f728a6fc.png)


When color is based on threshold then displaymode as color-background-solid would be visible in light UI.
![image](https://user-images.githubusercontent.com/83282894/178456073-3cca9510-0154-4c77-85d5-fa7a33820abd.png)
