### PR TITLE
fix: label parity with zapi-rest

### DIFF
--- a/cmd/collectors/rest/plugins/certificate/certificate.go
+++ b/cmd/collectors/rest/plugins/certificate/certificate.go
@@ -98,7 +98,7 @@ func (my *Certificate) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 
 				if serialNumber == adminVserverSerial {
 					certificateInstance.SetExportable(true)
-					// Admin svm certificate is cluster scope and REST don't have svm name in it, adding for parity with ZAPI.
+					// Admin SVM certificate is cluster scoped, but the REST API does not return the SVM name in its response. Add here for ZAPI parity
 					certificateInstance.SetLabel("svm", adminVserver)
 					my.setCertificateIssuerType(certificateInstance)
 					my.setCertificateValidity(data, certificateInstance)

--- a/cmd/collectors/rest/plugins/certificate/certificate.go
+++ b/cmd/collectors/rest/plugins/certificate/certificate.go
@@ -98,6 +98,8 @@ func (my *Certificate) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 
 				if serialNumber == adminVserverSerial {
 					certificateInstance.SetExportable(true)
+					// Admin svm certificate is cluster scope and REST don't have svm name in it, adding for parity with ZAPI.
+					certificateInstance.SetLabel("svm", adminVserver)
 					my.setCertificateIssuerType(certificateInstance)
 					my.setCertificateValidity(data, certificateInstance)
 				}


### PR DESCRIPTION
Identify by Rahul on cluster 10.236.42.3, 
security_certificate_labels [svm] is missing svm in rest vs zapi.


Without the change:
<img width="1770" alt="image" src="https://user-images.githubusercontent.com/83282894/178753893-45675293-2d9a-4179-be7e-b37b6b787eda.png">

With this change:
<img width="1770" alt="image" src="https://user-images.githubusercontent.com/83282894/178753930-3773a7da-6438-4676-a2d1-10c1a865d0c6.png">

