### PR TITLE
docs: Prometheus 2.26.0 is required for EMS based Prometheus alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Hardware requirements depend on how many clusters you monitor and the number of 
 - Disk: 500 MB (mostly used by log files)
 
 Harvest is compatible with:
-- Prometheus: `2.24` or higher
+- Prometheus: `2.26` or higher
 - InfluxDB: `v2`
 - Grafana: `8.1.X` or higher
 - Docker: `20.10.0` or higher


### PR DESCRIPTION
`ems_alert_rules.yml` uses `last_over_time` introduced in [Prometheus 2.26.0](https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md#2260--2021-03-31)