### PR TITLE
fix: filter from client to server to avoid spam warning

### DIFF
--- a/conf/rest/9.12.0/security_certificate.yaml
+++ b/conf/rest/9.12.0/security_certificate.yaml
@@ -12,13 +12,12 @@ counters:
   - ^public_certificate      => certificatePEM
   - ^serial_number           => serial_number
   - expiry_time(timestamp)   => expiry_time
+  - filter:
+      - scope=!"svm"
+      - type="server"
 
 plugins:
   - LabelAgent:
-      exclude_equals:
-        - scope `svm`
-      include_equals:
-        - type `server`
       value_to_num:
         - status name - - `0`
   - Certificate:


### PR DESCRIPTION
REST don't have svm name for cluster scoped certificates which causes warning in logs for missing svm labels.

And out of all the certificates, we do care about only adminSvm's certificate and ignore all of them. So, instead of client side filter, doing server side REST filter to get limited records only.

These logs earlier
```
hardikl@hardikl-mac-0 harvest % ./bin/poller --poller cluster-28 --promPort 12991 -o SecurityCert --config harvest.yml
8:23PM INF ./poller.go:184 > log level used: info Poller=cluster-28
8:23PM INF ./poller.go:185 > options config: harvest.yml Poller=cluster-28
8:23PM INF ./poller.go:222 > started in foreground [pid=18137] Poller=cluster-28
8:23PM INF collector/helpers.go:133 > best-fit template Poller=cluster-28 collector=Zapi:SecurityCert path=conf/zapi/cdot/9.8.0/security_certificate.yaml v=9.12.1
8:23PM INF rest/rest.go:177 > Using default timeout Poller=cluster-28 collector=Rest:SecurityCert timeout=30s
8:23PM INF collector/helpers.go:133 > best-fit template Poller=cluster-28 collector=Rest:SecurityCert path=conf/rest/9.12.0/security_certificate.yaml v=9.12.1
8:23PM INF rest/rest.go:118 > initialized cache Poller=cluster-28 collector=Rest:SecurityCert numMetrics=1 timeout=30s
8:23PM INF ./poller.go:345 > Autosupport scheduled. Poller=cluster-28 asupSchedule=24h
8:23PM INF ./poller.go:354 > poller start-up complete Poller=cluster-28
8:23PM INF ./poller.go:502 > updated status, up collectors: 2 (of 2), up exporters: 1 (of 1) Poller=cluster-28
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8be00d80-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8bf93205-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c0937e8-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c194508-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c1cddbc-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c20c02f-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c243a01-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c281f15-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c2bfcf8-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c2fcb91-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c341ffe-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c371613-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c3ddaaf-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c4a5823-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c5157d8-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c608df6-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c689556-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c6c8117-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c700146-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c7cd075-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c8a2c30-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c9596d7-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8c99b780-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8ca3b36c-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8caf8c0c-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8cbe68b8-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8cc1ba37-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8cced5cb-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8cd4256e-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8ce5bacf-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8cea0bf9-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8ceda243-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8cfee569-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d10c700-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d1abcd7-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d2cab48-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d30c673-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d34eec6-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d38ff94-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d3cdde8-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d40e75f-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d452e20-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d498d4e-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d4e2a9c-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d52f21c-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d56da1e-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d5a82d2-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d5ec663-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d629339-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d66669a-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d6a56f6-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d6e7c6e-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d725b29-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d7721df-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d7af4a5-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d7f16ca-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d834aea-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d87834f-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d8c15ef-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d90a7a9-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d952596-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d993a81-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8d9db835-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8da26112-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8da67965-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8daa7fc5-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8daee80b-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8db30bc0-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8db7af67-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8dbc292e-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8dc04b7e-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8dc90eb8-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8dcec18a-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8dd3eaf4-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8ddb55b6-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8de0b90f-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8de64d86-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8deb8e59-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8df22c3f-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8df81eff-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8dfe077d-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8e0379e9-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8e08e344-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8e0e5ce1-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8e144ce6-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8e1a38a1-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8e21728d-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8e2745b1-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8e2c8d35-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8e32642d-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8e41f33e-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=8e47ea84-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM WRN rest/rest.go:445 > Missing label value Instance key=90d5faf1-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
8:23PM INF rest/rest.go:304 > Collected Poller=cluster-28 apiD=4.603s collector=Rest:SecurityCert instances=94 metrics=659 parseD=11ms
8:23PM INF collector/zapi.go:443 > Collected Poller=cluster-28 apiD=288ms collector=Zapi:SecurityCert instances=94 metrics=564 parseD=6ms
cluster-28 collector=Rest:SecurityCert label=svm.name
```

With this change, now only warning for one record which we are interested
```
hardikl@hardikl-mac-0 harvest % ./bin/poller --poller cluster-28 --promPort 12991 -o SecurityCert --config harvest.yml
9:19PM INF ./poller.go:184 > log level used: info Poller=cluster-28
9:19PM INF ./poller.go:185 > options config: harvest.yml Poller=cluster-28
9:19PM INF ./poller.go:222 > started in foreground [pid=20118] Poller=cluster-28
9:19PM INF collector/helpers.go:133 > best-fit template Poller=cluster-28 collector=Zapi:SecurityCert path=conf/zapi/cdot/9.8.0/security_certificate.yaml v=9.12.1
9:19PM INF rest/rest.go:177 > Using default timeout Poller=cluster-28 collector=Rest:SecurityCert timeout=30s
9:19PM INF collector/helpers.go:133 > best-fit template Poller=cluster-28 collector=Rest:SecurityCert path=conf/rest/9.12.0/security_certificate.yaml v=9.12.1
9:19PM INF rest/rest.go:118 > initialized cache Poller=cluster-28 collector=Rest:SecurityCert numMetrics=1 timeout=30s
9:19PM INF ./poller.go:345 > Autosupport scheduled. Poller=cluster-28 asupSchedule=24h
9:19PM INF ./poller.go:354 > poller start-up complete Poller=cluster-28
9:19PM INF ./poller.go:502 > updated status, up collectors: 2 (of 2), up exporters: 1 (of 1) Poller=cluster-28
9:19PM WRN rest/rest.go:445 > Missing label value Instance key=90d5faf1-e719-11ec-85cd-005056a732ac Poller=cluster-28 collector=Rest:SecurityCert label=svm.name
9:19PM INF rest/rest.go:304 > Collected Poller=cluster-28 apiD=1.009s collector=Rest:SecurityCert instances=1 metrics=7 parseD=0s
9:19PM INF collector/zapi.go:443 > Collected Poller=cluster-28 apiD=282ms collector=Zapi:SecurityCert instances=94 metrics=564 parseD=7ms
```


