### PR TITLE
fix: aggr rest diff

### DIFF
--- a/conf/rest/9.12.0/aggr.yaml
+++ b/conf/rest/9.12.0/aggr.yaml
@@ -19,7 +19,7 @@ counters:
   - space.block_storage.inactive_user_data                         => space_performance_tier_inactive_user_data
   - space.block_storage.inactive_user_data_percent                 => space_performance_tier_inactive_user_data_percent
   - space.block_storage.physical_used                              => space_physical_used
-  - space.block_storage.physical_used_percent                      => space_used_percent
+  - space.block_storage.physical_used_percent                      => space_physical_used_percent
   - space.block_storage.volume_deduplication_shared_count          => space_sis_shared_count
   - space.block_storage.volume_deduplication_space_saved           => space_sis_saved
   - space.block_storage.volume_deduplication_space_saved_percent   => space_sis_saved_percent
@@ -39,7 +39,6 @@ counters:
   - inode_attributes.max_files_available                           => inode_maxfiles_available
   - inode_attributes.max_files_possible                            => inode_maxfiles_possible
   - inode_attributes.max_files_used                                => inode_maxfiles_used
-  - inode_attributes.used_percent                                  => snapshot_inode_used_percent
   - space.snapshot.available                                       => snapshot_size_available
   - space.snapshot.used                                            => snapshot_size_used
   - space.snapshot.used_percent                                    => snapshot_used_percent
@@ -57,6 +56,7 @@ counters:
   - space.efficiency_without_snapshots_flexclones.savings          => efficiency_savings_wo_snapshots_flexclones
   - hidden_fields:
       - inode_attributes
+      - block_storage
       - space
 
 plugins:


### PR DESCRIPTION
On Cluster 10.236.41.247,

values are differ for zapi and rest: aggr_physical_used_wo_snapshots, aggr_physical_used_wo_snapshots_flexclones

Out of these:
aggr_space_physical_used_percent --> name change done
aggr_hybrid_cache_size_total  --> not coming from rest response in this cluster, so added block_storage as fields, but metric not coming due to hybrid is disabled.
aggr_space_reserved --> as mentioned in #997, it's deprecated.
aggr_inode_used_percent --> written 2 times, snapshot metric was rejected 
Rejected | aggr-get-iter.aggr-attributes.aggr-snapshot-attributes.percent-inode-used-capacity
-- | --
