### PR TITLE
fix: clarify Harvest's precedence order when reading flags, env vars,…

### DIFF
--- a/pkg/constant/configconstant.go
+++ b/pkg/constant/configconstant.go
@@ -1,4 +1,0 @@
-package constant
-
-//TODO move constants across project inside this package to avoid hard codings
-const ConfigFileName = "harvest.yml"


### PR DESCRIPTION
… and defaults

Each item takes precedence over the item below it:
1. --config command line flag
2. HARVEST_CONFIG environment variable
3. no command line argument and no environment variable, use the default path (HarvestYML)