### PR TITLE
feat: enable vscan objects by default

### DIFF
--- a/conf/zapiperf/default.yaml
+++ b/conf/zapiperf/default.yaml
@@ -49,8 +49,8 @@ objects:
   Volume:                 volume.yaml
   VolumeSvm:              volume_svm.yaml
   WAFLCompBin:            wafl_comp_aggr_vol_bin.yaml
-#  Vscan:                  vscan.yaml
-#  VscanSVM:               vscan_svm.yaml
+  Vscan:                  vscan.yaml
+  VscanSVM:               vscan_svm.yaml
 
 #  Uncomment to collect workload/QOS counters  
 #  Workload:               workload.yaml


### PR DESCRIPTION
parity with Harvest 1.6