### PR TITLE
ci: bump golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,7 +25,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.47.0
+          version: v1.47.3
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 linters:
   disable-all: true
   enable:
-#    - bodyclose
+    - bodyclose
     - deadcode
     - errcheck
     - errname
@@ -12,11 +12,12 @@ linters:
     - govet
     - ineffassign
     - makezero
+    - nilerr
     - nolintlint
     - nonamedreturns
     - nosprintfhostport
     - staticcheck
-    - structcheck
+#    - structcheck
     - stylecheck
     - tenv
     - thelper

--- a/cmd/collectors/unix/process.go
+++ b/cmd/collectors/unix/process.go
@@ -229,7 +229,7 @@ func (me *Process) loadSmaps() error {
 	// this may fail see https://github.com/NetApp/harvest/issues/249
 	// when it does, ignore so the other /proc checks are given a chance to run
 	if data, err = os.ReadFile(path.Join(me.dirpath, "smaps")); err != nil {
-		return nil
+		return nil //nolint:nilerr
 	}
 
 	me.mem = make(map[string]uint64)
@@ -266,7 +266,7 @@ func (me *Process) loadIo() error {
 	// this may fail see https://github.com/NetApp/harvest/issues/249
 	// when it does, ignore so the other /proc checks are given a chance to run
 	if data, err = os.ReadFile(path.Join(me.dirpath, "io")); err != nil {
-		return nil
+		return nil //nolint:nilerr
 	}
 
 	for _, line = range strings.Split(string(data), "\n") {
@@ -333,7 +333,7 @@ func (me *Process) loadFdinfo() error {
 	// when it does, ignore so the other /proc checks are given a chance to run
 	files, err := os.ReadDir(path.Join(me.dirpath, "fdinfo"))
 	if err != nil {
-		return nil
+		return nil //nolint:nilerr
 	}
 	me.numFds = uint64(len(files))
 	return nil

--- a/cmd/exporters/influxdb/influxdb.go
+++ b/cmd/exporters/influxdb/influxdb.go
@@ -212,9 +212,9 @@ func (e *InfluxDB) Emit(data [][]byte) error {
 	if response, err = e.client.Do(request); err != nil {
 		return err
 	}
-
+	//goland:noinspection GoUnhandledErrorResult
+	defer response.Body.Close()
 	if response.StatusCode != expectedResponseCode {
-		defer func(Body io.ReadCloser) { _ = Body.Close() }(response.Body)
 		if body, err := io.ReadAll(response.Body); err != nil {
 			return errs.New(errs.ErrAPIResponse, err.Error())
 		} else {

--- a/cmd/harvest/version/version.go
+++ b/cmd/harvest/version/version.go
@@ -120,5 +120,7 @@ func latestRelease() (string, error) {
 			return location.String()[lastSlash+1:], nil
 		}
 	}
+	//goland:noinspection GoUnhandledErrorResult
+	defer resp.Body.Close()
 	return "", fmt.Errorf(" error checking GitHub")
 }

--- a/cmd/poller/poller.go
+++ b/cmd/poller/poller.go
@@ -978,7 +978,8 @@ func (p *Poller) publishDetails() {
 		event.Err(rErr).Str("admin", conf.Config.Admin.Httpsd.Listen).Msg("Failed connecting to admin node")
 		return
 	}
-	defer func(Body io.ReadCloser) { _ = Body.Close() }(resp.Body)
+	//goland:noinspection GoUnhandledErrorResult
+	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Err(err).Msg("failed to read publishDetails response to admin")

--- a/cmd/tools/doctor/restZapiDiff.go
+++ b/cmd/tools/doctor/restZapiDiff.go
@@ -674,6 +674,8 @@ func getResponse(url string) (string, error) {
 	if err != nil {
 		log.Fatalln(err)
 	}
+	//goland:noinspection GoUnhandledErrorResult
+	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatalln(err)

--- a/cmd/tools/grafana/grafana.go
+++ b/cmd/tools/grafana/grafana.go
@@ -998,13 +998,10 @@ func doRequest(opts *options, method, url string, query map[string]interface{}) 
 	status = response.Status
 	code = response.StatusCode
 
-	defer silentClose(response.Body)
+	//goland:noinspection GoUnhandledErrorResult
+	defer response.Body.Close()
 	data, err = io.ReadAll(response.Body)
 	return data, status, code, err
-}
-
-func silentClose(body io.ReadCloser) {
-	_ = body.Close()
 }
 
 var opts = &options{}

--- a/cmd/tools/rest/client.go
+++ b/cmd/tools/rest/client.go
@@ -203,7 +203,8 @@ func (c *Client) invoke() ([]byte, error) {
 	if response, err = c.client.Do(c.request); err != nil {
 		return nil, fmt.Errorf("connection error %w", err)
 	}
-	defer func(Body io.ReadCloser) { _ = Body.Close() }(response.Body)
+	//goland:noinspection GoUnhandledErrorResult
+	defer response.Body.Close()
 
 	if response.StatusCode != 200 {
 		if body, err = io.ReadAll(response.Body); err == nil {
@@ -257,7 +258,8 @@ func downloadSwagger(poller *conf.Poller, path string, url string) (int64, error
 	if err != nil {
 		return 0, err
 	}
-	defer func(Body io.ReadCloser) { _ = Body.Close() }(response.Body)
+	//goland:noinspection GoUnhandledErrorResult
+	defer response.Body.Close()
 
 	n, err := io.Copy(out, response.Body)
 	if err != nil {

--- a/pkg/api/ontapi/zapi/client.go
+++ b/pkg/api/ontapi/zapi/client.go
@@ -191,7 +191,8 @@ func parseClientTimeout(clientTimeout string) (time.Duration, error) {
 	}
 	t, err := strconv.Atoi(clientTimeout)
 	if err != nil {
-		return time.Duration(DefaultTimeout) * time.Second, nil
+		// when there is an error return the default timeout
+		return time.Duration(DefaultTimeout) * time.Second, nil //nolint:nilerr
 	}
 	return time.Duration(t) * time.Second, nil
 }
@@ -386,7 +387,8 @@ func (c *Client) InvokeRaw() ([]byte, error) {
 	if response, err = c.client.Do(c.request); err != nil {
 		return body, errs.New(errs.ErrConnection, err.Error())
 	}
-	defer func(Body io.ReadCloser) { _ = Body.Close() }(response.Body)
+	//goland:noinspection GoUnhandledErrorResult
+	defer response.Body.Close()
 	if response.StatusCode != 200 {
 		return body, errs.New(errs.ErrAPIResponse, response.Status)
 	}
@@ -425,7 +427,8 @@ func (c *Client) invoke(withTimers bool) (*node.Node, time.Duration, time.Durati
 	if response, err = c.client.Do(c.request); err != nil {
 		return result, responseT, parseT, errs.New(errs.ErrConnection, err.Error())
 	}
-	defer func(Body io.ReadCloser) { _ = Body.Close() }(response.Body)
+	//goland:noinspection GoUnhandledErrorResult
+	defer response.Body.Close()
 	if withTimers {
 		responseT = time.Since(start)
 	}


### PR DESCRIPTION
- enable linters: bodyclose, nilerr
- disable linters: structcheck until it works with 1.18+
- fix all lint warnings