### PR TITLE
docs: change references from Slack to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ curl -L -O https://github.com/NetApp/harvest/releases/download/v21.08.0/harvest-
 
 It's best to run Harvest as a non-root user. Make sure the user running Harvest can write to `/var/log/harvest/` or tell Harvest to write the logs somewhere else with the `HARVEST_LOGS` environment variable.
 
-If something goes wrong, examine the logs files in `/var/log/harvest`, check out the [troubleshooting](https://github.com/NetApp/harvest/wiki/Troubleshooting-Harvest) section of the wiki and jump onto [Slack](https://github.com/NetApp/harvest/blob/main/SUPPORT.md#slack) and ask for help.
+If something goes wrong, examine the logs files in `/var/log/harvest`, check out 
+the [troubleshooting](https://github.com/NetApp/harvest/wiki/Troubleshooting-Harvest) section of the wiki and jump 
+onto [Discord](https://github.com/NetApp/harvest/blob/main/SUPPORT.md#getting-help) and ask for help.
 
 ### Upgrade
 Follow the steps below to upgrade Harvest

--- a/conf/README.md
+++ b/conf/README.md
@@ -270,7 +270,7 @@ export_options:
     - volume
     - svm
     - application
- client_timeout: 5m
+client_timeout: 5m
 ```
 
 To help understand the merging process and the resulting combined template, you can view the result with:
@@ -280,7 +280,8 @@ bin/harvest doctor merge --template conf/zapi/cdot/9.8.0/lun.yaml --with conf/za
 
 ### Replace an existing object template
 
-You can only extend existing templates as explained [above](#extend-an-existing-object-template). If you need to replace one of the existing object templates, let us know more on Slack or GitHub.
+You can only extend existing templates as explained [above](#extend-an-existing-object-template).
+If you need to replace one of the existing object templates, let us on [Discord](https://github.com/NetApp/harvest/blob/main/SUPPORT.md#getting-help) or GitHub.
 
 ## Harvest Versioned Templates
 


### PR DESCRIPTION
With this change the only reference to Slack is the CHANGELOG.md

```bash
rg --files-with-matches --iglob !vendor -i slack
CHANGELOG.md
```