### PR TITLE
fix: skipped bookend ems whose key is node-name

### DIFF
--- a/integration/test/alert/alert.go
+++ b/integration/test/alert/alert.go
@@ -85,10 +85,9 @@ func GetEmsAlerts(dir string, fileName string) ([]EmsData, []EmsData) {
 func GenerateEvents(emsNames []EmsData, nodeScopedEms []string) []string {
 	supportedEms := make([]string, 0)
 	var jsonValue []byte
-	addr, user, pass := GetPollerDetail()
+	addr, user, pass, nodeName := GetPollerDetail()
 	url := "https://" + addr + "/api/private/cli/event/generate"
 	method := "POST"
-	node_name := "umeng-aff300-06"
 
 	volumeArwCount := 0
 	vserverArwCount := 0
@@ -109,7 +108,7 @@ func GenerateEvents(emsNames []EmsData, nodeScopedEms []string) []string {
 
 		// Handle for node-scoped ems, Passing node-name as input
 		if utils.Contains(nodeScopedEms, ems) {
-			jsonValue = []byte(fmt.Sprintf(`{"message-name": "%s", "values": [%s,2,3,4,5,6,7,8,9]}, "node": "%s"`, ems, value, node_name))
+			jsonValue = []byte(fmt.Sprintf(`{"message-name": "%s", "values": [%s,2,3,4,5,6,7,8,9]}, "node": "%s"`, ems, value, nodeName))
 		}
 
 		jsonValue = []byte(fmt.Sprintf(`{"message-name": "%s", "values": [%s,2,3,4,5,6,7,8,9]}`, ems, value))
@@ -130,7 +129,7 @@ func GenerateEvents(emsNames []EmsData, nodeScopedEms []string) []string {
 	return supportedEms
 }
 
-func GetPollerDetail() (string, string, string) {
+func GetPollerDetail() (string, string, string, string) {
 	var (
 		err    error
 		poller *conf.Poller
@@ -144,5 +143,5 @@ func GetPollerDetail() (string, string, string) {
 		utils.PanicIfNotNil(err)
 	}
 
-	return poller.Addr, "admin", poller.Password
+	return poller.Addr, "admin", poller.Password, "umeng-aff300-06"
 }

--- a/integration/test/alert/alert.go
+++ b/integration/test/alert/alert.go
@@ -82,11 +82,13 @@ func GetEmsAlerts(dir string, fileName string) ([]EmsData, []EmsData) {
 	return totalEms, bookendEms
 }
 
-func GenerateEvents(emsNames []EmsData) []string {
+func GenerateEvents(emsNames []EmsData, nodeScopedEms []string) []string {
 	supportedEms := make([]string, 0)
+	var jsonValue []byte
 	addr, user, pass := GetPollerDetail()
 	url := "https://" + addr + "/api/private/cli/event/generate"
 	method := "POST"
+	node_name := "umeng-aff300-06"
 
 	volumeArwCount := 0
 	vserverArwCount := 0
@@ -105,7 +107,12 @@ func GenerateEvents(emsNames []EmsData) []string {
 			vserverArwCount++
 		}
 
-		jsonValue := []byte(fmt.Sprintf(`{"message-name": "%s", "values": [%s,2,3,4,5,6,7,8,9]}`, ems, value))
+		// Handle for node-scoped ems, Passing node-name as input
+		if utils.Contains(nodeScopedEms, ems) {
+			jsonValue = []byte(fmt.Sprintf(`{"message-name": "%s", "values": [%s,2,3,4,5,6,7,8,9]}, "node": "%s"`, ems, value, node_name))
+		}
+
+		jsonValue = []byte(fmt.Sprintf(`{"message-name": "%s", "values": [%s,2,3,4,5,6,7,8,9]}`, ems, value))
 		var data map[string]interface{}
 		data = utils.SendPostReqAndGetRes(url, method, jsonValue, user, pass)
 		if response := data["error"]; response != nil {

--- a/integration/test/all_ems_test.go
+++ b/integration/test/all_ems_test.go
@@ -44,7 +44,7 @@ func (suite *AlertRulesTestSuite) SetupSuite() {
 	totalEmsNames, _ = promAlerts.GetEmsAlerts(emsConfigDir, "ems.yaml")
 
 	// Identify supported ems names for the given cluster
-	supportedEms = promAlerts.GenerateEvents(totalEmsNames)
+	supportedEms = promAlerts.GenerateEvents(totalEmsNames, skippedEmsList)
 	log.Info().Msgf("Total supported ems: %d", len(supportedEms))
 
 	// Fetch prometheus alerts
@@ -60,7 +60,7 @@ func (suite *AlertRulesTestSuite) TestEmsAlerts() {
 	notFoundEms := make([]string, 0)
 
 	for _, emsName := range supportedEms {
-		if !(alertsData[emsName] != 0 || utils.Contains(skippedEmsList, emsName)) {
+		if alertsData[emsName] == 0 {
 			notFoundEms = append(notFoundEms, emsName)
 		}
 	}

--- a/integration/test/all_ems_test.go
+++ b/integration/test/all_ems_test.go
@@ -31,6 +31,13 @@ var skippedEmsList = []string{
 	"scsitarget.fct.port.full",
 }
 
+// These bookend issuing ems are node scoped and have bookendKey as node-name only.
+var nodeScopedIssuingEmsList = []string{
+	"callhome.battery.low",
+	"sp.ipmi.lost.shutdown",
+	"sp.notConfigured",
+}
+
 type AlertRulesTestSuite struct {
 	suite.Suite
 }
@@ -44,7 +51,7 @@ func (suite *AlertRulesTestSuite) SetupSuite() {
 	totalEmsNames, _ = promAlerts.GetEmsAlerts(emsConfigDir, "ems.yaml")
 
 	// Identify supported ems names for the given cluster
-	supportedEms = promAlerts.GenerateEvents(totalEmsNames, skippedEmsList)
+	supportedEms = promAlerts.GenerateEvents(totalEmsNames, nodeScopedIssuingEmsList)
 	log.Info().Msgf("Total supported ems: %d", len(supportedEms))
 
 	// Fetch prometheus alerts
@@ -60,7 +67,7 @@ func (suite *AlertRulesTestSuite) TestEmsAlerts() {
 	notFoundEms := make([]string, 0)
 
 	for _, emsName := range supportedEms {
-		if alertsData[emsName] == 0 {
+		if !(alertsData[emsName] != 0 || utils.Contains(skippedEmsList, emsName)) {
 			notFoundEms = append(notFoundEms, emsName)
 		}
 	}

--- a/integration/test/bookend_ems_test.go
+++ b/integration/test/bookend_ems_test.go
@@ -18,11 +18,10 @@ var supportedEms []string
 var oldAlertsData map[string]int
 var newAlertsData map[string]int
 
-// These bookend ems (both issuing and resolving ems) are node scoped and have bookendKey as node-name only. They won't be raised/resolved always from ONTAP even if we simulate via POST call.
-var skippedBookendEmsList = []string{
-	"callhome.battery.low",
-	"sp.ipmi.lost.shutdown",
-	"sp.notConfigured",
+// These bookend resolving ems are node scoped and have bookendKey as node-name only.
+var nodeScopedResolvingEmsList = []string{
+	"nvram.battery.charging.normal",
+	"sp.heartbeat.resumed",
 }
 
 type EmsTestSuite struct {
@@ -41,7 +40,7 @@ func (suite *EmsTestSuite) SetupSuite() {
 	oldAlertsData, _ = promAlerts.GetAlerts()
 
 	// Identify supported ems names for the given cluster
-	supportedEms = promAlerts.GenerateEvents(resolvingEmsNames, skippedBookendEmsList)
+	supportedEms = promAlerts.GenerateEvents(resolvingEmsNames, nodeScopedResolvingEmsList)
 	log.Info().Msgf("Supported Bookend ems:%d", len(supportedEms))
 
 	// Fetch current prometheus alerts

--- a/integration/test/bookend_ems_test.go
+++ b/integration/test/bookend_ems_test.go
@@ -18,6 +18,13 @@ var supportedEms []string
 var oldAlertsData map[string]int
 var newAlertsData map[string]int
 
+// These bookend ems (both issuing and resolving ems) are node scoped and have bookendKey as node-name only. They won't be raised/resolved always from ONTAP even if we simulate via POST call.
+var skippedBookendEmsList = []string{
+	"callhome.battery.low",
+	"sp.ipmi.lost.shutdown",
+	"sp.notConfigured",
+}
+
 type EmsTestSuite struct {
 	suite.Suite
 }
@@ -51,7 +58,7 @@ func (suite *EmsTestSuite) TestBookendEmsAlerts() {
 
 	for _, bookendEmsName := range supportedEms {
 		v := oldAlertsData[bookendEmsName] - newAlertsData[bookendEmsName]
-		if v < 1 {
+		if v < 1 && !utils.Contains(skippedBookendEmsList, bookendEmsName) {
 			foundBookendEms = append(foundBookendEms, bookendEmsName)
 		}
 	}

--- a/integration/test/bookend_ems_test.go
+++ b/integration/test/bookend_ems_test.go
@@ -41,7 +41,7 @@ func (suite *EmsTestSuite) SetupSuite() {
 	oldAlertsData, _ = promAlerts.GetAlerts()
 
 	// Identify supported ems names for the given cluster
-	supportedEms = promAlerts.GenerateEvents(resolvingEmsNames)
+	supportedEms = promAlerts.GenerateEvents(resolvingEmsNames, skippedBookendEmsList)
 	log.Info().Msgf("Supported Bookend ems:%d", len(supportedEms))
 
 	// Fetch current prometheus alerts
@@ -58,7 +58,7 @@ func (suite *EmsTestSuite) TestBookendEmsAlerts() {
 
 	for _, bookendEmsName := range supportedEms {
 		v := oldAlertsData[bookendEmsName] - newAlertsData[bookendEmsName]
-		if v < 1 && !utils.Contains(skippedBookendEmsList, bookendEmsName) {
+		if v < 1 {
 			foundBookendEms = append(foundBookendEms, bookendEmsName)
 		}
 	}


### PR DESCRIPTION
Out of 14 bookend ems, 3 ems are node-scoped. So, when we do POST call of issuing ems and/or resolving ems we are not sure that given ems will be raised by ONTAP as due to node level.