### PR TITLE
feat: improve poller startup logging

### DIFF
--- a/cmd/poller/poller.go
+++ b/cmd/poller/poller.go
@@ -188,8 +188,11 @@ func (p *Poller) Init() error {
 		MaxAge:             logMaxAge}
 
 	logger = logging.Configure(logConfig)
-	logger.Info().Msgf("log level used: %s", zeroLogLevel.String())
-	logger.Info().Msgf("options config: %s", p.options.Config)
+	logger.Info().
+		Str("logLevel", zeroLogLevel.String()).
+		Str("configPath", p.options.Config).
+		Str("version", version.String()).
+		Msg("Init")
 
 	// if profiling port > 0 start profiling service
 	if p.options.Profiling > 0 {

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/rs/zerolog"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -94,7 +95,10 @@ func Configure(config LogConfig) *Logger {
 	var writers []io.Writer
 
 	if config.ConsoleLoggingEnabled {
-		writers = append(writers, zerolog.ConsoleWriter{Out: os.Stderr})
+		writers = append(writers, zerolog.ConsoleWriter{
+			Out:        os.Stderr,
+			TimeFormat: time.RFC3339,
+		})
 	}
 	if config.FileLoggingEnabled {
 		writers = append(writers, newRollingFile(config))


### PR DESCRIPTION
Before
```
bin/poller --promPort 13009 --collectors ZapiPerf --objects WorkloadVolume --poller u2
1:27PM INF ./poller.go:184 > log level used: info Poller=u2
1:27PM INF ./poller.go:185 > options config: ./harvest.yml Poller=u2
```

After
```
bin/poller --promPort 13009 --collectors ZapiPerf --objects Qtree --poller u2
2022-08-31T13:39:02-04:00 INF ./poller.go:195 > Init Poller=u2 configPath=./harvest.yml logLevel=info version="harvest version 22.08.3113-v22.08.0 (commit ad0bc036) (build date 2022-08-31T13:36:54-0400) darwin/amd64\n"
```