### PR TITLE
fix: snapmirror relationships from source side 

### DIFF
--- a/cmd/collectors/commonutils.go
+++ b/cmd/collectors/commonutils.go
@@ -77,9 +77,9 @@ func UpdateProtectedFields(instance *matrix.Instance) {
 		destinationLocation := instance.GetLabel("destination_location")
 
 		isSvmDr := groupType == "vserver" && destinationVolume == "" && sourceVolume == ""
-		isCg := groupType == "CONSISTENCYGROUP" && strings.Contains(destinationLocation, ":/cg/")
+		isCg := groupType == "consistencygroup" && strings.Contains(destinationLocation, ":/cg/")
 		isConstituentVolumeRelationshipWithinSvmDr := groupType == "vserver" && !strings.HasSuffix(destinationLocation, ":")
-		isConstituentVolumeRelationshipWithinCG := groupType == "CONSISTENCYGROUP" && !strings.Contains(destinationLocation, ":/cg/")
+		isConstituentVolumeRelationshipWithinCG := groupType == "consistencygroup" && !strings.Contains(destinationLocation, ":/cg/")
 
 		// Update protectedBy label
 		if isSvmDr || isConstituentVolumeRelationshipWithinSvmDr {

--- a/cmd/collectors/commonutils_test.go
+++ b/cmd/collectors/commonutils_test.go
@@ -77,7 +77,7 @@ func testConstituentVolumeWithinSvmdr(t *testing.T, instance *matrix.Instance) {
 }
 
 func testCg(t *testing.T, instance *matrix.Instance) {
-	instance.SetLabel("group_type", "CONSISTENCYGROUP")
+	instance.SetLabel("group_type", "consistencygroup")
 	instance.SetLabel("destination_location", "test123:/cg/")
 	UpdateProtectedFields(instance)
 
@@ -89,7 +89,7 @@ func testCg(t *testing.T, instance *matrix.Instance) {
 }
 
 func testConstituentVolumeWithinCg(t *testing.T, instance *matrix.Instance) {
-	instance.SetLabel("group_type", "CONSISTENCYGROUP")
+	instance.SetLabel("group_type", "consistencygroup")
 	instance.SetLabel("destination_location", "test123")
 	UpdateProtectedFields(instance)
 

--- a/cmd/collectors/rest/plugins/snapmirror/snapmirror.go
+++ b/cmd/collectors/rest/plugins/snapmirror/snapmirror.go
@@ -10,6 +10,7 @@ import (
 	"github.com/netapp/harvest/v2/pkg/conf"
 	"github.com/netapp/harvest/v2/pkg/matrix"
 	"github.com/tidwall/gjson"
+	"strings"
 	"time"
 )
 
@@ -21,6 +22,7 @@ type SnapMirror struct {
 	query          string
 	nodeUpdCounter int
 	svmVolToNode   map[string]string
+	svmPeerDataMap map[string]string // [peer SVM alias name] -> [peer SVM actual name] - [peer cluster name] map
 }
 
 func New(p *plugin.AbstractPlugin) plugin.Plugin {
@@ -47,6 +49,7 @@ func (my *SnapMirror) Init() error {
 
 	my.query = "api/private/cli/volume"
 	my.svmVolToNode = make(map[string]string)
+	my.svmPeerDataMap = make(map[string]string)
 
 	// Assigned the value to nodeUpdCounter so that plugin would be invoked first time to populate cache.
 	my.nodeUpdCounter = PluginInvocationRate
@@ -62,6 +65,12 @@ func (my *SnapMirror) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 			return nil, err
 		}
 		my.Logger.Debug().Msg("updated node cache")
+
+		cluster, _ := data.GetGlobalLabels().GetHas("cluster")
+		if err := my.getSVMPeerData(cluster); err != nil {
+			return nil, err
+		}
+		my.Logger.Debug().Msg("updated svm peer")
 	}
 
 	// update volume instance labels
@@ -99,7 +108,35 @@ func (my *SnapMirror) updateNodeCache() error {
 	return nil
 }
 
+func (my *SnapMirror) getSVMPeerData(cluster string) error {
+	// Clean svmPeerMap map
+	my.svmPeerDataMap = make(map[string]string)
+	fields := []string{"name", "peer.svm.name", "peer.cluster.name"}
+	query := "api/svm/peers"
+	href := rest.BuildHref("", strings.Join(fields, ","), []string{"peer.cluster.name=!" + cluster}, "", "", "", "", query)
+
+	result, err := rest.Fetch(my.client, href)
+	if err != nil {
+		my.Logger.Error().Err(err).Str("href", href).Msg("Failed to fetch data")
+		return err
+	}
+
+	if len(result) == 0 {
+		my.Logger.Debug().Msg("No svm peer found")
+		return nil
+	}
+
+	for _, peerData := range result {
+		localSvmName := peerData.Get("name").String()
+		actualSvmName := peerData.Get("peer.svm.name").String()
+		peerClusterName := peerData.Get("peer.cluster.name").String()
+		my.svmPeerDataMap[localSvmName] = actualSvmName + ":" + peerClusterName
+	}
+	return nil
+}
+
 func (my *SnapMirror) updateSMLabels(data *matrix.Matrix) {
+	cluster, _ := data.GetGlobalLabels().GetHas("cluster")
 	for _, instance := range data.GetInstances() {
 		volumeName := instance.GetLabel("source_volume")
 		vserverName := instance.GetLabel("source_vserver")
@@ -107,6 +144,17 @@ func (my *SnapMirror) updateSMLabels(data *matrix.Matrix) {
 		// Update source_node label in snapmirror
 		if node, ok := my.svmVolToNode[vserverName+volumeName]; ok {
 			instance.SetLabel("source_node", node)
+		}
+
+		// Update source_vserver in snapmirror (In case of inter-cluster SM- vserver name may differ)
+		if peerDetail, ok := my.svmPeerDataMap[vserverName]; ok {
+			peerData := strings.Split(peerDetail, ":")
+			instance.SetLabel("source_vserver", peerData[0])
+			instance.SetLabel("source_cluster", peerData[1])
+		}
+
+		if sourceCluster := instance.GetLabel("source_cluster"); sourceCluster == "" {
+			instance.SetLabel("source_cluster", cluster)
 		}
 
 		// update the protectedBy and protectionSourceType fields and derivedRelationshipType in snapmirror_labels

--- a/cmd/collectors/rest/plugins/volume/volume.go
+++ b/cmd/collectors/rest/plugins/volume/volume.go
@@ -22,15 +22,10 @@ const DefaultDataPollDuration = 3 * time.Minute
 
 type Volume struct {
 	*plugin.AbstractPlugin
-	data                 *matrix.Matrix
 	pluginInvocationRate int
 	currentVal           int
 	client               *rest.Client
 	query                string
-	snapmirrorFields     []string
-	outgoingSM           map[string][]string
-	incomingSM           map[string]string
-	isHealthySM          map[string]bool
 	aggrsMap             map[string]string // aggregate-uuid -> aggregate-name map
 }
 
@@ -41,8 +36,6 @@ func New(p *plugin.AbstractPlugin) plugin.Plugin {
 func (my *Volume) Init() error {
 
 	var err error
-	my.snapmirrorFields = []string{"relationship_id", "relationship_group_type", "destination_volume",
-		"source_volume", "destination_path", "type", "healthy", "source_vserver", "destination_vserver"}
 
 	if err = my.InitAbc(); err != nil {
 		return err
@@ -58,12 +51,6 @@ func (my *Volume) Init() error {
 		return err
 	}
 
-	my.query = "api/private/cli/snapmirror"
-	my.data = matrix.New(my.Parent+".Volume", "volume", "volume")
-
-	my.outgoingSM = make(map[string][]string)
-	my.incomingSM = make(map[string]string)
-	my.isHealthySM = make(map[string]bool)
 	my.aggrsMap = make(map[string]string)
 
 	// Assigned the value to currentVal so that plugin would be invoked first time to populate cache.
@@ -76,28 +63,8 @@ func (my *Volume) Init() error {
 }
 
 func (my *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
-
-	// Purge and reset data
-	my.data.PurgeInstances()
-	my.data.Reset()
-
-	// Set all global labels from zapi.go if already not exist
-	my.data.SetGlobalLabels(data.GetGlobalLabels())
-
 	if my.currentVal >= my.pluginInvocationRate {
 		my.currentVal = 0
-
-		// invoke snapmirror rest and populate info in source and destination snapmirror maps
-		if smSourceMap, smDestinationMap, err := my.GetSnapMirrors(); err != nil {
-			if errs.IsAPINotFound(err) {
-				my.Logger.Debug().Err(err).Msg("Failed to collect snapmirror data")
-			} else {
-				my.Logger.Error().Err(err).Msg("Failed to collect snapmirror data")
-			}
-		} else {
-			// update internal cache based on volume and SM maps
-			my.updateMaps(data, smSourceMap, smDestinationMap)
-		}
 
 		// invoke disk rest and populate info in aggrsMap
 		if disks, err := my.getEncryptedDisks(); err != nil {
@@ -119,169 +86,13 @@ func (my *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 	return nil, nil
 }
 
-func (my *Volume) GetSnapMirrors() (map[string][]*matrix.Instance, map[string]*matrix.Instance, error) {
-	var (
-		result []gjson.Result
-		err    error
-	)
-
-	smSourceMap := make(map[string][]*matrix.Instance)
-	smDestinationMap := make(map[string]*matrix.Instance)
-
-	snapmirrorData := matrix.New(my.Parent+".SnapMirror", "sm", "sm")
-	href := rest.BuildHref("", strings.Join(my.snapmirrorFields, ","), nil, "", "", "", "", my.query)
-
-	if result, err = collectors.InvokeRestCall(my.client, my.query, href, my.Logger); err != nil {
-		return nil, nil, err
-	}
-
-	for _, snapMirror := range result {
-		var instanceKey string
-		relationshipID := snapMirror.Get("relationship_id").String()
-		groupType := snapMirror.Get("relationship_group_type").String()
-		destinationVolume := snapMirror.Get("destination_volume").String()
-		sourceVolume := snapMirror.Get("source_volume").String()
-		destinationLocation := snapMirror.Get("destination_path").String()
-		relationshipType := snapMirror.Get("type").String()
-		isHealthy := snapMirror.Get("healthy").String()
-		sourceSvm := snapMirror.Get("source_vserver").String()
-		destinationSvm := snapMirror.Get("destination_vserver").String()
-
-		if instanceKey = relationshipID; instanceKey == "" {
-			my.Logger.Trace().Msg("Instance key is empty, skipping")
-			continue
-		}
-
-		instance, err := snapmirrorData.NewInstance(instanceKey)
-
-		if err != nil {
-			my.Logger.Error().Err(err).Stack().Str("relationshipID", relationshipID).Msg("Failed to create snapmirror cache instance")
-			return nil, nil, err
-		}
-
-		instance.SetLabel("relationship_id", relationshipID)
-		instance.SetLabel("group_type", groupType)
-		instance.SetLabel("destination_volume", destinationVolume)
-		instance.SetLabel("source_volume", sourceVolume)
-		instance.SetLabel("destination_location", destinationLocation)
-		instance.SetLabel("relationship_type", relationshipType)
-		instance.SetLabel("is_healthy", isHealthy)
-		instance.SetLabel("source_svm", sourceSvm)
-		instance.SetLabel("destination_svm", destinationSvm)
-
-		// Update the protectedBy and protectionSourceType fields in snapmirror
-		collectors.UpdateProtectedFields(instance)
-
-		// Update source snapmirror and destination snapmirror info in maps
-		if relationshipType == "data_protection" || relationshipType == "extended_data_protection" || relationshipType == "vault" || relationshipType == "xdp" {
-			sourceKey := sourceVolume + "-" + sourceSvm
-			destinationKey := destinationVolume + "-" + destinationSvm
-			if instance.GetLabel("protectionSourceType") == "volume" {
-				smSourceMap[sourceKey] = append(smSourceMap[sourceKey], instance)
-			}
-			smDestinationMap[destinationKey] = instance
-		}
-	}
-
-	return smSourceMap, smDestinationMap, nil
-}
-
-func (my *Volume) updateMaps(data *matrix.Matrix, smSourceMap map[string][]*matrix.Instance, smDestinationMap map[string]*matrix.Instance) {
-	// Clean all the snapmirror maps
-	my.outgoingSM = make(map[string][]string)
-	my.incomingSM = make(map[string]string)
-	my.isHealthySM = make(map[string]bool)
-
-	for _, volume := range data.GetInstances() {
-		volumeName := volume.GetLabel("volume")
-		svmName := volume.GetLabel("svm")
-		volumeType := volume.GetLabel("type")
-		key := volumeName + "-" + svmName
-
-		protectedByMap := make(map[string]string)
-		var protectedByValue []string
-		healthStatus := true
-		for _, smRelationship := range smSourceMap[key] {
-			/* Example: If 3 relationships belongs to a volume, and out of 3, 2 are at snapmirror and one is svmdr,
-			   So, protectedByMap map has 2 records, and outgoingSM map value would be snapmirror, svmdr
-			*/
-			protectedByMap[smRelationship.GetLabel("protectedBy")] = ""
-
-			// Update isHealthySM map based on the source snapmirror info
-			if volumeType == "rw" {
-				/* Example: If 3 relationships belongs to a volume, and out of 3, 2 are healthy and one is not,
-				   So, isHealthySM map value would be unhealthy - false
-				*/
-				currentVal, _ := strconv.ParseBool(smRelationship.GetLabel("is_healthy"))
-				healthStatus = healthStatus && currentVal
-				my.isHealthySM[key] = healthStatus
-			}
-		}
-
-		// Update outgoingSM map based on the protectedByMap
-		protectedByValue = nil
-		for protectedByKey := range protectedByMap {
-			protectedByValue = append(protectedByValue, protectedByKey)
-		}
-		if protectedByValue != nil {
-			my.outgoingSM[key] = protectedByValue
-		}
-
-		// Update incomingSM map based on the destination snapmirror info
-		if smDestinationMap[key] != nil {
-			my.incomingSM[key] = "destination"
-		}
-	}
-}
-
 func (my *Volume) updateVolumeLabels(data *matrix.Matrix) {
 	for _, volume := range data.GetInstances() {
-		volumeName := volume.GetLabel("volume")
-		svmName := volume.GetLabel("svm")
-		volumeType := volume.GetLabel("type")
-
 		// For flexgroup, aggrUuid in Rest should be empty for parity with Zapi response
 		if volumeStyle := volume.GetLabel("style"); volumeStyle == "flexgroup" {
 			volume.SetLabel("aggrUuid", "")
 		}
 		aggrUUID := volume.GetLabel("aggrUuid")
-
-		key := volumeName + "-" + svmName
-
-		// Update protectionRole label in volume
-		if volumeType == "rw" && my.incomingSM[key] == "" && my.outgoingSM[key] == nil {
-			volume.SetLabel("protectionRole", "unprotected")
-		} else if volumeType == "rw" && my.outgoingSM[key] != nil {
-			volume.SetLabel("protectionRole", "protected")
-		} else if volumeType == "dp" || (volumeType == "rw" && my.incomingSM[key] != "") {
-			volume.SetLabel("protectionRole", "destination")
-		} else {
-			volume.SetLabel("protectionRole", "not_applicable")
-		}
-
-		// Update protectedBy label in volume
-		if outgoing, ok := my.outgoingSM[key]; ok {
-			outgoingJoinStr := strings.Join(outgoing, ",")
-			if outgoingJoinStr == "volume,storage_vm" || outgoingJoinStr == "storage_vm,volume" {
-				volume.SetLabel("protectedBy", "svmdr_and_snapmirror")
-			} else if outgoingJoinStr == "cg,volume" || outgoingJoinStr == "volume,cg" {
-				volume.SetLabel("protectedBy", "cg_and_snapmirror")
-			} else if outgoingJoinStr == "cg" {
-				volume.SetLabel("protectedBy", "consistency_group")
-			} else if outgoingJoinStr == "storage_vm" {
-				volume.SetLabel("protectedBy", "storage_vm_dr")
-			} else if outgoingJoinStr == "volume" {
-				volume.SetLabel("protectedBy", "snapmirror")
-			}
-		} else {
-			volume.SetLabel("protectedBy", "not_applicable")
-		}
-
-		// Update the all_sm_healthy label in volume
-		// When all relationships belong to this volume are healthy then true, otherwise false
-		if healthy, ok := my.isHealthySM[key]; ok {
-			volume.SetLabel("all_sm_healthy", strconv.FormatBool(healthy))
-		}
 
 		_, exist := my.aggrsMap[aggrUUID]
 		volume.SetLabel("isHardwareEncrypted", strconv.FormatBool(exist))

--- a/cmd/collectors/rest/plugins/volume/volume.go
+++ b/cmd/collectors/rest/plugins/volume/volume.go
@@ -25,7 +25,6 @@ type Volume struct {
 	pluginInvocationRate int
 	currentVal           int
 	client               *rest.Client
-	query                string
 	aggrsMap             map[string]string // aggregate-uuid -> aggregate-name map
 }
 

--- a/cmd/collectors/zapi/plugins/snapmirror/snapmirror_test.go
+++ b/cmd/collectors/zapi/plugins/snapmirror/snapmirror_test.go
@@ -69,7 +69,7 @@ func testConstituentVolumeWithinSvmdr(t *testing.T, instance *matrix.Instance) {
 }
 
 func testCg(t *testing.T, instance *matrix.Instance) {
-	instance.SetLabel("group_type", "CONSISTENCYGROUP")
+	instance.SetLabel("group_type", "consistencygroup")
 	instance.SetLabel("destination_location", "test123:/cg/")
 	collectors.UpdateProtectedFields(instance)
 
@@ -81,7 +81,7 @@ func testCg(t *testing.T, instance *matrix.Instance) {
 }
 
 func testConstituentVolumeWithinCg(t *testing.T, instance *matrix.Instance) {
-	instance.SetLabel("group_type", "CONSISTENCYGROUP")
+	instance.SetLabel("group_type", "consistencygroup")
 	instance.SetLabel("destination_location", "test123")
 	collectors.UpdateProtectedFields(instance)
 

--- a/conf/rest/9.12.0/snapmirror.yaml
+++ b/conf/rest/9.12.0/snapmirror.yaml
@@ -33,7 +33,14 @@ counters:
   - update_failed_count                      => update_failed_count
   - break_successful_count                   => break_successful_count
   - break_failed_count                       => break_failed_count
+  - filter:
+      - expand=true
 
+endpoints:
+  - query: api/snapmirror/relationships
+    counters:
+      - ^^uuid                               => relationship_id
+      - ^source.cluster.name                 => source_cluster
 
 plugins:
   - Snapmirror
@@ -61,4 +68,5 @@ export_options:
     - protectedBy
     - protectionSourceType
     - policy_type
+    - source_cluster
     - derived_relationship_type

--- a/conf/rest/9.12.0/snapmirror.yaml
+++ b/conf/rest/9.12.0/snapmirror.yaml
@@ -33,6 +33,7 @@ counters:
   - update_failed_count                      => update_failed_count
   - break_successful_count                   => break_successful_count
   - break_failed_count                       => break_failed_count
+  - ^cg_item_mappings                        => cg_item_mappings
   - filter:
       - expand=true
 

--- a/grafana/dashboards/cmode/harvest_dashboard_snapmirror.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_snapmirror.json
@@ -2250,7 +2250,7 @@
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "count"
           ],
           "fields": "",
           "values": false
@@ -2262,8 +2262,8 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(group by (source_volume,source_vserver,source_cluster)(snapmirror_labels{protectedBy=~\"volume.*|cg.*\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ))",
-          "format": "time_series",
+          "expr": "count(group by (source_volume,source_vserver,source_cluster,protectedBy)(snapmirror_labels{source_cluster=~\"$Cluster\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ))",
+          "format": "table",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -2274,6 +2274,79 @@
       ],
       "timeFrom": null,
       "timeShift": null,
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "protectedBy",
+                "source_cluster",
+                "source_volume",
+                "source_vserver"
+              ]
+            }
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "protectedBy": {
+                "aggregations": [
+                  "allValues"
+                ],
+                "operation": "aggregate"
+              },
+              "source_cluster": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "source_volume": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "source_vserver": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": ".*storage_vm.*"
+                  }
+                },
+                "fieldName": "protectedBy (allValues)"
+              }
+            ],
+            "match": "any",
+            "type": "exclude"
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "mode": "reduceRow",
+            "reduce": {
+              "include": [
+                "source_cluster",
+                "source_volume",
+                "source_vserver"
+              ],
+              "reducer": "count"
+            },
+            "replaceFields": false
+          }
+        }
+      ],
       "title": "Volume Snapmirror",
       "type": "stat"
     },
@@ -2410,7 +2483,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "group by (source_volume,source_vserver,source_cluster,protectedBy)(snapmirror_labels{} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
+          "expr": "group by (source_volume,source_vserver,source_cluster,protectedBy)(snapmirror_labels{source_cluster=~\"$Cluster\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -2716,7 +2789,7 @@
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "count"
           ],
           "fields": "",
           "values": false
@@ -2728,8 +2801,8 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(group by (source_volume,source_vserver,source_cluster)(snapmirror_labels{protectedBy=~\"storage_vm.*\"} * on (source_volume, source_vserver,source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ))",
-          "format": "time_series",
+          "expr": "count(group by (source_volume,source_vserver,source_cluster,protectedBy)(snapmirror_labels{source_cluster=~\"$Cluster\"} * on (source_volume, source_vserver,source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ))",
+          "format": "table",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -2740,6 +2813,79 @@
       ],
       "timeFrom": null,
       "timeShift": null,
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "source_cluster",
+                "source_volume",
+                "source_vserver",
+                "protectedBy"
+              ]
+            }
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "protectedBy": {
+                "aggregations": [
+                  "allValues"
+                ],
+                "operation": "aggregate"
+              },
+              "source_cluster": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "source_volume": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "source_vserver": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": "storage_vm"
+                  }
+                },
+                "fieldName": "protectedBy (allValues)"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "mode": "reduceRow",
+            "reduce": {
+              "include": [
+                "source_cluster",
+                "source_volume",
+                "source_vserver"
+              ],
+              "reducer": "count"
+            },
+            "replaceFields": false
+          }
+        }
+      ],
       "title": "Storage VM Snapmirror",
       "type": "stat"
     },
@@ -3051,6 +3197,48 @@
                 ]
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Remote (last)"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "1": {
+                        "index": 0,
+                        "text": "Local"
+                      },
+                      "2": {
+                        "index": 1,
+                        "text": "Remote"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
+                "id": "custom.filterable",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Source SVM"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
           }
         ]
       },
@@ -3069,7 +3257,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "snapmirror_labels{protectedBy=~\"volume.*|cg.*|storage_vm.*\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ",
+          "expr": "snapmirror_labels{source_cluster=~\"$Cluster\",protectedBy=~\"volume.*|cg.*|storage_vm.*\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -3084,11 +3272,13 @@
           "options": {
             "include": {
               "names": [
+                "destination_volume",
                 "protectedBy",
                 "source_volume",
+                "destination_vserver",
                 "source_vserver",
-                "destination_volume",
-                "destination_vserver"
+                "source_cluster",
+                "cluster"
               ]
             }
           }
@@ -3097,8 +3287,8 @@
           "id": "organize",
           "options": {
             "excludeByName": {
-              "protectedBy": false,
-              "destination_vserver": true
+              "destination_vserver": true,
+              "protectedBy": false
             },
             "indexByName": {
               "destination_volume": 2,
@@ -3117,14 +3307,31 @@
           }
         },
         {
+          "id": "calculateField",
+          "options": {
+            "alias": "Remote",
+            "binary": {
+              "left": "Source Volume",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "Destination Volume"
+            },
+            "mode": "reduceRow",
+            "reduce": {
+              "include": [
+                "cluster",
+                "source_cluster"
+              ],
+              "reducer": "distinctCount"
+            },
+            "replaceFields": false
+          }
+        },
+        {
           "id": "groupBy",
           "options": {
             "fields": {
-              "Source Volume": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "Source SVM": {
+              "Destination Volume": {
                 "aggregations": [],
                 "operation": "groupby"
               },
@@ -3133,6 +3340,46 @@
                   "allValues"
                 ],
                 "operation": "aggregate"
+              },
+              "Remote": {
+                "aggregations": [
+                  "last"
+                ],
+                "operation": "aggregate"
+              },
+              "Source SVM": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "Source Volume": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "cluster": {
+                "aggregations": []
+              },
+              "destination_volume": {
+                "aggregations": []
+              },
+              "destination_vserver": {
+                "aggregations": []
+              },
+              "protectedBy": {
+                "aggregations": [
+                  "allValues"
+                ],
+                "operation": "aggregate"
+              },
+              "source_cluster": {
+                "aggregations": []
+              },
+              "source_volume": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "source_vserver": {
+                "aggregations": [],
+                "operation": "groupby"
               }
             }
           }
@@ -3140,13 +3387,13 @@
         {
           "id": "convertFieldType",
           "options": {
-            "fields": {},
             "conversions": [
               {
-                "targetField": "Protected By (allValues)",
-                "destinationType": "string"
+                "destinationType": "string",
+                "targetField": "Protected By (allValues)"
               }
-            ]
+            ],
+            "fields": {}
           }
         }
       ],
@@ -3497,7 +3744,7 @@
       },
       "targets": [
         {
-          "expr": "volume_labels{cluster=~\"$Cluster\",volume!~\"MDV.*\",protectionRole=\"unprotected\",snapshot_policy!=\"\"} unless on (volume,svm)  label_replace( label_replace(  label_replace( snapmirror_labels{} , \"volume\", \"$1\", \"source_volume\", \"(.*)\") , \"svm\", \"$1\", \"source_vserver\", \"(.*)\") , \"cluster\", \"$1\", \"source_cluster\", \"(.*)\") ",
+          "expr": "volume_labels{cluster=~\"$Cluster\",volume!~\"MDV.*\",protectionRole=\"unprotected\",snapshot_policy!=\"\"} unless on (volume,svm)  label_replace( label_replace(  label_replace( snapmirror_labels{source_cluster=~\"$Cluster\"} , \"volume\", \"$1\", \"source_volume\", \"(.*)\") , \"svm\", \"$1\", \"source_vserver\", \"(.*)\") , \"cluster\", \"$1\", \"source_cluster\", \"(.*)\") ",
           "legendFormat": "",
           "interval": "",
           "exemplar": false,
@@ -3676,7 +3923,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(snapmirror_labels{derived_relationship_type=\"extended_data_protection\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
+          "expr": "count(snapmirror_labels{source_cluster=~\"$Cluster\",derived_relationship_type=\"extended_data_protection\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -3742,7 +3989,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(snapmirror_labels{derived_relationship_type=\"mirror_vault\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
+          "expr": "count(snapmirror_labels{source_cluster=~\"$Cluster\",derived_relationship_type=\"mirror_vault\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -3808,7 +4055,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(snapmirror_labels{derived_relationship_type=\"vault\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
+          "expr": "count(snapmirror_labels{source_cluster=~\"$Cluster\",derived_relationship_type=\"vault\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -4042,7 +4289,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(snapmirror_labels{derived_relationship_type=\"sync_mirror_strict\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
+          "expr": "count(snapmirror_labels{source_cluster=~\"$Cluster\",derived_relationship_type=\"sync_mirror_strict\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -4108,7 +4355,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(snapmirror_labels{derived_relationship_type=\"sync_mirror\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
+          "expr": "count(snapmirror_labels{source_cluster=~\"$Cluster\",derived_relationship_type=\"sync_mirror\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -4313,7 +4560,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "snapmirror_labels{} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ",
+          "expr": "snapmirror_labels{source_cluster=~\"$Cluster\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -4455,7 +4702,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "snapmirror_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",all_sm_healthy != \"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\") ",
+          "expr": "snapmirror_labels{source_cluster=~\"$Cluster\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",all_sm_healthy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ",
           "format": "table",
           "instant": true,
           "interval": "",

--- a/grafana/dashboards/cmode/harvest_dashboard_snapmirror.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_snapmirror.json
@@ -2262,7 +2262,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",protectedBy=~\"snapmirror.*|consistency_group.*|cg_and_snapmirror.*\",protectionRole=\"protected\",snapshot_policy!=\"\"})",
+          "expr": "count(group by (source_volume,source_vserver,source_cluster)(snapmirror_labels{protectedBy=~\"volume.*|cg.*\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ))",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -2309,6 +2309,88 @@
       },
       "id": 122,
       "links": [],
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "source_cluster",
+                "source_volume",
+                "source_vserver",
+                "protectedBy"
+              ]
+            }
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "protectedBy": {
+                "aggregations": [
+                  "allValues"
+                ],
+                "operation": "aggregate"
+              },
+              "source_volume": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "source_vserver": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "source_cluster": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": "volume,storage_vm"
+                  }
+                },
+                "fieldName": "protectedBy (allValues)"
+              },
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": "storage_vm,volume"
+                  }
+                },
+                "fieldName": "protectedBy (allValues)"
+              }
+            ],
+            "type": "include",
+            "match": "any"
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "mode": "reduceRow",
+            "reduce": {
+              "include": [
+                "source_volume",
+                "source_vserver",
+                "source_cluster"
+              ],
+              "reducer": "count"
+            },
+            "replaceFields": false
+          }
+        }
+      ],
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -2316,7 +2398,7 @@
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "count"
           ],
           "fields": "",
           "values": false
@@ -2328,8 +2410,8 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",protectedBy=~\"svmdr_and_snapmirror\",protectionRole=\"protected\",snapshot_policy!=\"\"})",
-          "format": "time_series",
+          "expr": "group by (source_volume,source_vserver,source_cluster,protectedBy)(snapmirror_labels{} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
+          "format": "table",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -2646,7 +2728,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",protectedBy=~\"storage_vm_dr\",protectionRole=\"protected\",snapshot_policy!=\"\"})",
+          "expr": "count(group by (source_volume,source_vserver,source_cluster)(snapmirror_labels{protectedBy=~\"storage_vm.*\"} * on (source_volume, source_vserver,source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ))",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -2723,7 +2805,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",protectionRole=\"unprotected\",snapshot_policy!=\"\"})",
+          "expr": "count(volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",protectionRole=\"unprotected\",snapshot_policy!=\"\"} unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{source_cluster=~\"$Cluster\"} , \"volume\", \"$1\", \"source_volume\", \"(.*)\") , \"svm\", \"$1\", \"source_vserver\", \"(.*)\") )",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -2898,39 +2980,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "volume"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Volume"
-              },
-              {
-                "id": "custom.width",
-                "value": 300
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "svm"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "SVM"
-              },
-              {
-                "id": "custom.width",
-                "value": 280
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "protectedBy"
+              "options": "Protected By (allValues)"
             },
             "properties": [
               {
@@ -2942,38 +2992,63 @@
                 "value": 190
               },
               {
+                "id": "displayName",
+                "value": "Protected By"
+              },
+              {
                 "id": "mappings",
                 "value": [
                   {
+                    "type": "regex",
                     "options": {
-                      "not_applicable": {
-                        "index": 1,
-                        "text": "Unprotected"
-                      },
-                      "snapmirror": {
-                        "index": 0,
-                        "text": "SnapMirror"
+                      "pattern": ".*volume,storage_vm.*",
+                      "result": {
+                        "text": "SnapMirror and SVM DR",
+                        "index": 0
                       }
-                    },
-                    "type": "value"
+                    }
+                  },
+                  {
+                    "type": "regex",
+                    "options": {
+                      "pattern": ".*storage_vm,volume.*",
+                      "result": {
+                        "text": "SnapMirror and SVM DR",
+                        "index": 1
+                      }
+                    }
+                  },
+                  {
+                    "type": "regex",
+                    "options": {
+                      "pattern": ".*storage_vm.*",
+                      "result": {
+                        "text": "SVM DR",
+                        "index": 2
+                      }
+                    }
+                  },
+                  {
+                    "type": "regex",
+                    "options": {
+                      "pattern": ".*volume.*",
+                      "result": {
+                        "text": "SnapMirror",
+                        "index": 3
+                      }
+                    }
+                  },
+                  {
+                    "type": "regex",
+                    "options": {
+                      "pattern": ".*cg.*",
+                      "result": {
+                        "text": "CG",
+                        "index": 4
+                      }
+                    }
                   }
                 ]
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "cluster"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Cluster"
-              },
-              {
-                "id": "custom.width",
-                "value": 200
               }
             ]
           }
@@ -2994,7 +3069,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", protectionRole != \"destination\",snapshot_policy!=\"\"}",
+          "expr": "snapmirror_labels{protectedBy=~\"volume.*|cg.*|storage_vm.*\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -3002,17 +3077,18 @@
           "refId": "A"
         }
       ],
-      "title": "SnapMirror Volumes (local and remote) Protected by",
+      "title": "SnapMirror (local and remote) Protected by",
       "transformations": [
         {
           "id": "filterFieldsByName",
           "options": {
             "include": {
               "names": [
-                "cluster",
                 "protectedBy",
-                "svm",
-                "volume"
+                "source_volume",
+                "source_vserver",
+                "destination_volume",
+                "destination_vserver"
               ]
             }
           }
@@ -3020,15 +3096,57 @@
         {
           "id": "organize",
           "options": {
-            "excludeByName": {},
-            "indexByName": {
-              "cluster": 2,
-              "protectedBy": 4,
-              "protectionRole": 3,
-              "svm": 1,
-              "volume": 0
+            "excludeByName": {
+              "protectedBy": false,
+              "destination_vserver": true
             },
-            "renameByName": {}
+            "indexByName": {
+              "destination_volume": 2,
+              "destination_vserver": 3,
+              "protectedBy": 4,
+              "source_volume": 0,
+              "source_vserver": 1
+            },
+            "renameByName": {
+              "destination_volume": "Destination Volume",
+              "destination_vserver": "Destination SVM",
+              "protectedBy": "Protected By",
+              "source_volume": "Source Volume",
+              "source_vserver": "Source SVM"
+            }
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Source Volume": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "Source SVM": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "Protected By": {
+                "aggregations": [
+                  "allValues"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "fields": {},
+            "conversions": [
+              {
+                "targetField": "Protected By (allValues)",
+                "destinationType": "string"
+              }
+            ]
           }
         }
       ],
@@ -3249,13 +3367,160 @@
       "type": "table"
     },
     {
+      "id": 133,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 70
+      },
+      "type": "table",
+      "title": "Unprotected Volumes",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "cluster",
+                "protectionRole",
+                "svm",
+                "volume"
+              ]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "cluster": 2,
+              "protectionRole": 3,
+              "svm": 1,
+              "volume": 0
+            },
+            "renameByName": {
+              "cluster": "Cluster",
+              "destination_volume": "Destination Volume",
+              "destination_vserver": "Destination SVM",
+              "protectedBy": "Protected By",
+              "protectionRole": "Protection Role",
+              "snapshot_policy": "Snapshot",
+              "source_volume": "Source Volume",
+              "source_vserver": "Source SVM",
+              "svm": "SVM",
+              "volume": "Volume"
+            }
+          }
+        }
+      ],
+      "pluginVersion": "8.4.3",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "left",
+            "displayMode": "auto",
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "fixedColor": "transparent",
+            "mode": "fixed"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Protected By"
+            },
+            "properties": [
+              {
+                "id": "custom.filterable",
+                "value": true
+              },
+              {
+                "id": "custom.width",
+                "value": 190
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "cg": {
+                        "index": 2,
+                        "text": "CG"
+                      },
+                      "not_applicable": {
+                        "index": 3,
+                        "text": "Unprotected"
+                      },
+                      "storage_vm": {
+                        "index": 1,
+                        "text": "SVM DR"
+                      },
+                      "volume": {
+                        "index": 0,
+                        "text": "SnapMirror"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        },
+        "sortBy": []
+      },
+      "targets": [
+        {
+          "expr": "volume_labels{cluster=~\"$Cluster\",volume!~\"MDV.*\",protectionRole=\"unprotected\",snapshot_policy!=\"\"} unless on (volume,svm)  label_replace( label_replace(  label_replace( snapmirror_labels{} , \"volume\", \"$1\", \"source_volume\", \"(.*)\") , \"svm\", \"$1\", \"source_vserver\", \"(.*)\") , \"cluster\", \"$1\", \"source_cluster\", \"(.*)\") ",
+          "legendFormat": "",
+          "interval": "",
+          "exemplar": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "3yh3ZeZ4k"
+          },
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "datasource": null
+    },
+    {
       "collapsed": false,
       "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 70
+        "y": 80
       },
       "id": 42,
       "panels": [],
@@ -3280,44 +3545,13 @@
           "decimals": 0,
           "mappings": []
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Volume Snapmirror"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Unprotected"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 12,
         "w": 5,
         "x": 0,
-        "y": 71
+        "y": 81
       },
       "id": 128,
       "options": {
@@ -3344,7 +3578,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(snapmirror_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", derived_relationship_type=\"extended_data_protection\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\") )  ",
+          "expr": "count(snapmirror_labels{source_cluster=~\"$Cluster\", derived_relationship_type=\"extended_data_protection\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
           "instant": true,
           "interval": "",
           "legendFormat": "Asynchronous Mirror",
@@ -3352,7 +3586,7 @@
         },
         {
           "exemplar": true,
-          "expr": "count(snapmirror_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", derived_relationship_type=\"mirror_vault\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\") )  ",
+          "expr": "count(snapmirror_labels{source_cluster=~\"$Cluster\", derived_relationship_type=\"mirror_vault\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -3361,7 +3595,7 @@
         },
         {
           "exemplar": true,
-          "expr": "count(snapmirror_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", derived_relationship_type=\"vault\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\") )  ",
+          "expr": "count(snapmirror_labels{source_cluster=~\"$Cluster\", derived_relationship_type=\"vault\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -3370,7 +3604,7 @@
         },
         {
           "exemplar": true,
-          "expr": "count(snapmirror_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", derived_relationship_type=\"sync_mirror_strict\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\") )  ",
+          "expr": "count(snapmirror_labels{source_cluster=~\"$Cluster\", derived_relationship_type=\"sync_mirror_strict\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -3379,7 +3613,7 @@
         },
         {
           "exemplar": true,
-          "expr": "count(snapmirror_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", derived_relationship_type=\"sync_mirror\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\") )  ",
+          "expr": "count(snapmirror_labels{source_cluster=~\"$Cluster\", derived_relationship_type=\"sync_mirror\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -3419,7 +3653,7 @@
         "h": 6,
         "w": 3,
         "x": 5,
-        "y": 71
+        "y": 81
       },
       "id": 109,
       "links": [],
@@ -3442,7 +3676,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(snapmirror_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", derived_relationship_type=\"extended_data_protection\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\") )  ",
+          "expr": "count(snapmirror_labels{derived_relationship_type=\"extended_data_protection\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -3485,7 +3719,7 @@
         "h": 6,
         "w": 3,
         "x": 8,
-        "y": 71
+        "y": 81
       },
       "id": 110,
       "links": [],
@@ -3508,7 +3742,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(snapmirror_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", derived_relationship_type=\"mirror_vault\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\") )  ",
+          "expr": "count(snapmirror_labels{derived_relationship_type=\"mirror_vault\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -3551,7 +3785,7 @@
         "h": 6,
         "w": 3,
         "x": 11,
-        "y": 71
+        "y": 81
       },
       "id": 111,
       "links": [],
@@ -3574,7 +3808,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(snapmirror_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", derived_relationship_type=\"vault\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\") )  ",
+          "expr": "count(snapmirror_labels{derived_relationship_type=\"vault\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -3644,7 +3878,7 @@
         "h": 12,
         "w": 5,
         "x": 14,
-        "y": 71
+        "y": 81
       },
       "id": 130,
       "options": {
@@ -3719,7 +3953,7 @@
         "h": 6,
         "w": 5,
         "x": 19,
-        "y": 71
+        "y": 81
       },
       "id": 114,
       "links": [],
@@ -3785,7 +4019,7 @@
         "h": 6,
         "w": 3,
         "x": 5,
-        "y": 77
+        "y": 87
       },
       "id": 113,
       "links": [],
@@ -3808,7 +4042,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(snapmirror_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", derived_relationship_type=\"sync_mirror_strict\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\") )  ",
+          "expr": "count(snapmirror_labels{derived_relationship_type=\"sync_mirror_strict\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -3851,7 +4085,7 @@
         "h": 6,
         "w": 3,
         "x": 8,
-        "y": 77
+        "y": 87
       },
       "id": 112,
       "links": [],
@@ -3874,7 +4108,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(snapmirror_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", derived_relationship_type=\"sync_mirror\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\") )  ",
+          "expr": "count(snapmirror_labels{derived_relationship_type=\"sync_mirror\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -3917,7 +4151,7 @@
         "h": 6,
         "w": 5,
         "x": 19,
-        "y": 77
+        "y": 87
       },
       "id": 115,
       "links": [],
@@ -4068,7 +4302,7 @@
         "h": 14,
         "w": 14,
         "x": 0,
-        "y": 83
+        "y": 93
       },
       "id": 129,
       "options": {
@@ -4079,7 +4313,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "snapmirror_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\") ",
+          "expr": "snapmirror_labels{} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -4210,7 +4444,7 @@
         "h": 14,
         "w": 10,
         "x": 14,
-        "y": 83
+        "y": 93
       },
       "id": 131,
       "options": {

--- a/grafana/dashboards/cmode/harvest_dashboard_snapmirror.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_snapmirror.json
@@ -2175,36 +2175,40 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",protectedBy=~\"snapmirror.*|consistency_group.*|cg_and_snapmirror.*\",protectionRole=\"protected\", snapshot_policy!=\"\"})",
+          "expr": "count(group by (source_volume,source_vserver,source_cluster)(snapmirror_labels{source_cluster=~\"$Cluster\",protectedBy=~\"volume.*|cg.*\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ) unless on (source_volume,source_vserver,source_cluster) snapmirror_labels{source_cluster=~\"$Cluster\",protectedBy=\"storage_vm\"} ) or vector (0)",
           "instant": true,
           "interval": "",
           "legendFormat": "Volume Snapmirror",
-          "refId": "A"
+          "refId": "A",
+          "format": "time_series"
         },
         {
           "exemplar": true,
-          "expr": "count(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",protectedBy=\"storage_vm_dr\",protectionRole=\"protected\",snapshot_policy!=\"\"})",
+          "expr": "count(group by (source_volume,source_vserver,source_cluster)(snapmirror_labels{source_cluster=~\"$Cluster\",protectedBy=\"storage_vm\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ) unless on (source_volume,source_vserver,source_cluster) snapmirror_labels{source_cluster=~\"$Cluster\",protectedBy=\"volume\"} ) or vector (0)",
           "hide": false,
           "instant": true,
           "interval": "",
           "legendFormat": "Storage VM Snapmirror",
-          "refId": "B"
+          "refId": "B",
+          "format": "time_series"
         },
         {
           "exemplar": true,
-          "expr": "count(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",protectedBy=\"svmdr_and_snapmirror\",protectionRole=\"protected\",snapshot_policy!=\"\"})",
+          "expr": "count(group by (source_volume,source_vserver,source_cluster) (snapmirror_labels{source_cluster=~\"$Cluster\",protectedBy=\"volume\"}) * on(source_volume,source_vserver,source_cluster) group_left() group by (source_volume,source_vserver,source_cluster) (snapmirror_labels{source_cluster=~\"$Cluster\",protectedBy=\"storage_vm\"} )) or vector (0)",
           "hide": false,
           "interval": "",
           "legendFormat": "Volume and Storage VM Snapmirror",
-          "refId": "C"
+          "refId": "C",
+          "format": "time_series"
         },
         {
           "exemplar": true,
-          "expr": "count(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",protectionRole=\"unprotected\",snapshot_policy!=\"\"})",
+          "expr": "count(volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"} unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{source_cluster=~\"$Cluster\"} , \"volume\", \"$1\", \"source_volume\", \"(.*)\") , \"svm\", \"$1\", \"source_vserver\", \"(.*)\") unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{source_cluster=~\"$Cluster\"} , \"volume\", \"$1\", \"destination_volume\", \"(.*)\") , \"svm\", \"$1\", \"destination_vserver\", \"(.*)\") ) or vector (0)",
           "hide": false,
           "interval": "",
           "legendFormat": "Unprotected",
-          "refId": "D"
+          "refId": "D",
+          "format": "time_series"
         }
       ],
       "title": "Protected By Status",
@@ -2250,7 +2254,7 @@
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
-            "count"
+            "last"
           ],
           "fields": "",
           "values": false
@@ -2262,7 +2266,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(group by (source_volume,source_vserver,source_cluster,protectedBy)(snapmirror_labels{source_cluster=~\"$Cluster\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ))",
+          "expr": "count(group by (source_volume,source_vserver,source_cluster)(snapmirror_labels{source_cluster=~\"$Cluster\",protectedBy=~\"volume.*|cg.*\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ) unless on (source_volume,source_vserver,source_cluster) snapmirror_labels{source_cluster=~\"$Cluster\",protectedBy=\"storage_vm\"} ) or vector (0)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -2274,79 +2278,6 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "protectedBy",
-                "source_cluster",
-                "source_volume",
-                "source_vserver"
-              ]
-            }
-          }
-        },
-        {
-          "id": "groupBy",
-          "options": {
-            "fields": {
-              "protectedBy": {
-                "aggregations": [
-                  "allValues"
-                ],
-                "operation": "aggregate"
-              },
-              "source_cluster": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "source_volume": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "source_vserver": {
-                "aggregations": [],
-                "operation": "groupby"
-              }
-            }
-          }
-        },
-        {
-          "id": "filterByValue",
-          "options": {
-            "filters": [
-              {
-                "config": {
-                  "id": "regex",
-                  "options": {
-                    "value": ".*storage_vm.*"
-                  }
-                },
-                "fieldName": "protectedBy (allValues)"
-              }
-            ],
-            "match": "any",
-            "type": "exclude"
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "mode": "reduceRow",
-            "reduce": {
-              "include": [
-                "source_cluster",
-                "source_volume",
-                "source_vserver"
-              ],
-              "reducer": "count"
-            },
-            "replaceFields": false
-          }
-        }
-      ],
       "title": "Volume Snapmirror",
       "type": "stat"
     },
@@ -2382,88 +2313,6 @@
       },
       "id": 122,
       "links": [],
-      "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "source_cluster",
-                "source_volume",
-                "source_vserver",
-                "protectedBy"
-              ]
-            }
-          }
-        },
-        {
-          "id": "groupBy",
-          "options": {
-            "fields": {
-              "protectedBy": {
-                "aggregations": [
-                  "allValues"
-                ],
-                "operation": "aggregate"
-              },
-              "source_volume": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "source_vserver": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "source_cluster": {
-                "aggregations": [],
-                "operation": "groupby"
-              }
-            }
-          }
-        },
-        {
-          "id": "filterByValue",
-          "options": {
-            "filters": [
-              {
-                "config": {
-                  "id": "equal",
-                  "options": {
-                    "value": "volume,storage_vm"
-                  }
-                },
-                "fieldName": "protectedBy (allValues)"
-              },
-              {
-                "config": {
-                  "id": "equal",
-                  "options": {
-                    "value": "storage_vm,volume"
-                  }
-                },
-                "fieldName": "protectedBy (allValues)"
-              }
-            ],
-            "type": "include",
-            "match": "any"
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "mode": "reduceRow",
-            "reduce": {
-              "include": [
-                "source_volume",
-                "source_vserver",
-                "source_cluster"
-              ],
-              "reducer": "count"
-            },
-            "replaceFields": false
-          }
-        }
-      ],
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -2471,7 +2320,7 @@
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
-            "count"
+            "last"
           ],
           "fields": "",
           "values": false
@@ -2483,7 +2332,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "group by (source_volume,source_vserver,source_cluster,protectedBy)(snapmirror_labels{source_cluster=~\"$Cluster\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
+          "expr": "count(group by (source_volume,source_vserver,source_cluster) (snapmirror_labels{source_cluster=~\"$Cluster\",protectedBy=\"volume\"}) * on(source_volume,source_vserver,source_cluster) group_left() group by (source_volume,source_vserver,source_cluster) (snapmirror_labels{source_cluster=~\"$Cluster\",protectedBy=\"storage_vm\"} )) or vector (0)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -2500,7 +2349,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "Volumes Experiencing Lag",
+      "description": "Volume Relationships Experiencing Lag",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2580,7 +2429,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(group by (source_volume) (1 < snapmirror_lag_time{datacenter=\"$Datacenter\",cluster=~\"$Cluster\", source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\")  <= 900))",
+          "expr": "count((1 < snapmirror_lag_time{datacenter=\"$Datacenter\",cluster=~\"$Cluster\", source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\")  <= 900))",
           "instant": true,
           "interval": "",
           "legendFormat": "<=15 minutes",
@@ -2588,7 +2437,7 @@
         },
         {
           "exemplar": true,
-          "expr": "count(group by (source_volume) (900 < snapmirror_lag_time{datacenter=\"$Datacenter\",cluster=~\"$Cluster\", source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\")  <= 1800))",
+          "expr": "count((900 < snapmirror_lag_time{datacenter=\"$Datacenter\",cluster=~\"$Cluster\", source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\")  <= 1800))",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -2597,7 +2446,7 @@
         },
         {
           "exemplar": true,
-          "expr": "count(group by (source_volume) (1800 < snapmirror_lag_time{datacenter=\"$Datacenter\",cluster=~\"$Cluster\", source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\")  <= 3600))",
+          "expr": "count((1800 < snapmirror_lag_time{datacenter=\"$Datacenter\",cluster=~\"$Cluster\", source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\")  <= 3600))",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -2606,7 +2455,7 @@
         },
         {
           "exemplar": true,
-          "expr": "count(group by (source_volume) (snapmirror_lag_time{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\") > 3600))",
+          "expr": "count((snapmirror_lag_time{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\") > 3600))",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -2669,7 +2518,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(group by (source_volume) (1 < snapmirror_lag_time{datacenter=\"$Datacenter\",cluster=~\"$Cluster\", source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\")  <= 900))",
+          "expr": "count((1 < snapmirror_lag_time{datacenter=\"$Datacenter\",cluster=~\"$Cluster\", source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\")  <= 900))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -2735,7 +2584,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(group by (source_volume) (900 < snapmirror_lag_time{datacenter=\"$Datacenter\",cluster=~\"$Cluster\", source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\")  <= 1800))",
+          "expr": "count((900 < snapmirror_lag_time{datacenter=\"$Datacenter\",cluster=~\"$Cluster\", source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\")  <= 1800))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -2789,7 +2638,7 @@
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
-            "count"
+            "last"
           ],
           "fields": "",
           "values": false
@@ -2801,7 +2650,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(group by (source_volume,source_vserver,source_cluster,protectedBy)(snapmirror_labels{source_cluster=~\"$Cluster\"} * on (source_volume, source_vserver,source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ))",
+          "expr": "count(group by (source_volume,source_vserver,source_cluster)(snapmirror_labels{source_cluster=~\"$Cluster\",protectedBy=\"storage_vm\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ) unless on (source_volume,source_vserver,source_cluster) snapmirror_labels{source_cluster=~\"$Cluster\",protectedBy=\"volume\"} ) or vector (0)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -2813,79 +2662,6 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "source_cluster",
-                "source_volume",
-                "source_vserver",
-                "protectedBy"
-              ]
-            }
-          }
-        },
-        {
-          "id": "groupBy",
-          "options": {
-            "fields": {
-              "protectedBy": {
-                "aggregations": [
-                  "allValues"
-                ],
-                "operation": "aggregate"
-              },
-              "source_cluster": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "source_volume": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "source_vserver": {
-                "aggregations": [],
-                "operation": "groupby"
-              }
-            }
-          }
-        },
-        {
-          "id": "filterByValue",
-          "options": {
-            "filters": [
-              {
-                "config": {
-                  "id": "equal",
-                  "options": {
-                    "value": "storage_vm"
-                  }
-                },
-                "fieldName": "protectedBy (allValues)"
-              }
-            ],
-            "match": "any",
-            "type": "include"
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "mode": "reduceRow",
-            "reduce": {
-              "include": [
-                "source_cluster",
-                "source_volume",
-                "source_vserver"
-              ],
-              "reducer": "count"
-            },
-            "replaceFields": false
-          }
-        }
-      ],
       "title": "Storage VM Snapmirror",
       "type": "stat"
     },
@@ -2939,7 +2715,7 @@
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "last"
           ],
           "fields": "",
           "values": false
@@ -2951,7 +2727,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",protectionRole=\"unprotected\",snapshot_policy!=\"\"} unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{source_cluster=~\"$Cluster\"} , \"volume\", \"$1\", \"source_volume\", \"(.*)\") , \"svm\", \"$1\", \"source_vserver\", \"(.*)\") )",
+          "expr": "count(volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"} unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{source_cluster=~\"$Cluster\"} , \"volume\", \"$1\", \"source_volume\", \"(.*)\") , \"svm\", \"$1\", \"source_vserver\", \"(.*)\") unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{source_cluster=~\"$Cluster\"} , \"volume\", \"$1\", \"destination_volume\", \"(.*)\") , \"svm\", \"$1\", \"destination_vserver\", \"(.*)\") ) or vector (0)",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -3017,7 +2793,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(group by (source_volume) (1800 < snapmirror_lag_time{datacenter=\"$Datacenter\",cluster=~\"$Cluster\", source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\")  <= 3600))",
+          "expr": "count((1800 < snapmirror_lag_time{datacenter=\"$Datacenter\",cluster=~\"$Cluster\", source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\")  <= 3600))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -3083,7 +2859,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(group by (source_volume) (snapmirror_lag_time{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\") > 3600))",
+          "expr": "count((snapmirror_lag_time{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\") > 3600))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -3126,7 +2902,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Protected By (allValues)"
+              "options": "Protected By"
             },
             "properties": [
               {
@@ -3135,7 +2911,7 @@
               },
               {
                 "id": "custom.width",
-                "value": 190
+                "value": 150
               },
               {
                 "id": "displayName",
@@ -3145,54 +2921,21 @@
                 "id": "mappings",
                 "value": [
                   {
-                    "type": "regex",
                     "options": {
-                      "pattern": ".*volume,storage_vm.*",
-                      "result": {
-                        "text": "SnapMirror and SVM DR",
-                        "index": 0
+                      "cg": {
+                        "index": 2,
+                        "text": "CG"
+                      },
+                      "storage_vm": {
+                        "index": 0,
+                        "text": "SVM DR"
+                      },
+                      "volume": {
+                        "index": 1,
+                        "text": "SnapMirror"
                       }
-                    }
-                  },
-                  {
-                    "type": "regex",
-                    "options": {
-                      "pattern": ".*storage_vm,volume.*",
-                      "result": {
-                        "text": "SnapMirror and SVM DR",
-                        "index": 1
-                      }
-                    }
-                  },
-                  {
-                    "type": "regex",
-                    "options": {
-                      "pattern": ".*storage_vm.*",
-                      "result": {
-                        "text": "SVM DR",
-                        "index": 2
-                      }
-                    }
-                  },
-                  {
-                    "type": "regex",
-                    "options": {
-                      "pattern": ".*volume.*",
-                      "result": {
-                        "text": "SnapMirror",
-                        "index": 3
-                      }
-                    }
-                  },
-                  {
-                    "type": "regex",
-                    "options": {
-                      "pattern": ".*cg.*",
-                      "result": {
-                        "text": "CG",
-                        "index": 4
-                      }
-                    }
+                    },
+                    "type": "value"
                   }
                 ]
               }
@@ -3201,7 +2944,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Remote (last)"
+              "options": "Remote"
             },
             "properties": [
               {
@@ -3225,18 +2968,10 @@
               {
                 "id": "custom.filterable",
                 "value": true
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Source SVM"
-            },
-            "properties": [
+              },
               {
-                "id": "custom.hidden",
-                "value": true
+                "id": "custom.width",
+                "value": 130
               }
             ]
           }
@@ -3272,50 +3007,18 @@
           "options": {
             "include": {
               "names": [
+                "cluster",
                 "destination_volume",
                 "protectedBy",
-                "source_volume",
-                "destination_vserver",
-                "source_vserver",
                 "source_cluster",
-                "cluster"
+                "source_volume"
               ]
-            }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "destination_vserver": true,
-              "protectedBy": false
-            },
-            "indexByName": {
-              "destination_volume": 2,
-              "destination_vserver": 3,
-              "protectedBy": 4,
-              "source_volume": 0,
-              "source_vserver": 1
-            },
-            "renameByName": {
-              "destination_volume": "Destination Volume",
-              "destination_vserver": "Destination SVM",
-              "protectedBy": "Protected By",
-              "source_volume": "Source Volume",
-              "source_vserver": "Source SVM"
             }
           }
         },
         {
           "id": "calculateField",
           "options": {
-            "alias": "Remote",
-            "binary": {
-              "left": "Source Volume",
-              "operator": "*",
-              "reducer": "sum",
-              "right": "Destination Volume"
-            },
             "mode": "reduceRow",
             "reduce": {
               "include": [
@@ -3324,76 +3027,37 @@
               ],
               "reducer": "distinctCount"
             },
+            "alias": "Remote",
+            "binary": {
+              "left": "Source Volume",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "Destination Volume"
+            },
             "replaceFields": false
           }
         },
         {
-          "id": "groupBy",
+          "id": "organize",
           "options": {
-            "fields": {
-              "Destination Volume": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "Protected By": {
-                "aggregations": [
-                  "allValues"
-                ],
-                "operation": "aggregate"
-              },
-              "Remote": {
-                "aggregations": [
-                  "last"
-                ],
-                "operation": "aggregate"
-              },
-              "Source SVM": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "Source Volume": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "cluster": {
-                "aggregations": []
-              },
-              "destination_volume": {
-                "aggregations": []
-              },
-              "destination_vserver": {
-                "aggregations": []
-              },
-              "protectedBy": {
-                "aggregations": [
-                  "allValues"
-                ],
-                "operation": "aggregate"
-              },
-              "source_cluster": {
-                "aggregations": []
-              },
-              "source_volume": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "source_vserver": {
-                "aggregations": [],
-                "operation": "groupby"
-              }
+            "excludeByName": {
+              "cluster": true,
+              "destination_vserver": true,
+              "protectedBy": false,
+              "source_cluster": true,
+              "source_vserver": true
+            },
+            "indexByName": {
+              "destination_volume": 1,
+              "protectedBy": 2,
+              "source_volume": 0
+            },
+            "renameByName": {
+              "destination_volume": "Destination Volume",
+              "protectedBy": "Protected By",
+              "source_volume": "Source Volume",
+              "Remote": "Local/Remote"
             }
-          }
-        },
-        {
-          "id": "convertFieldType",
-          "options": {
-            "conversions": [
-              {
-                "destinationType": "string",
-                "targetField": "Protected By (allValues)"
-              }
-            ],
-            "fields": {}
           }
         }
       ],
@@ -3501,7 +3165,7 @@
               },
               {
                 "id": "custom.width",
-                "value": 300
+                "value": 270
               }
             ]
           },
@@ -3550,7 +3214,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "snapmirror_lag_time{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\")",
+          "expr": "snapmirror_lag_time{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",source_volume!=\"\"} * on (source_volume, source_vserver, cluster) group_left() label_replace( label_replace(volume_labels{datacenter=\"$Datacenter\",cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\") > 0",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -3558,7 +3222,7 @@
           "refId": "A"
         }
       ],
-      "title": "Volumes Experiencing Lag",
+      "title": "Volume Relationships Experiencing Lag",
       "transformations": [
         {
           "id": "filterFieldsByName",
@@ -3616,7 +3280,7 @@
     {
       "id": 133,
       "gridPos": {
-        "h": 10,
+        "h": 13,
         "w": 12,
         "x": 0,
         "y": 70
@@ -3630,7 +3294,6 @@
             "include": {
               "names": [
                 "cluster",
-                "protectionRole",
                 "svm",
                 "volume"
               ]
@@ -3643,19 +3306,11 @@
             "excludeByName": {},
             "indexByName": {
               "cluster": 2,
-              "protectionRole": 3,
               "svm": 1,
               "volume": 0
             },
             "renameByName": {
               "cluster": "Cluster",
-              "destination_volume": "Destination Volume",
-              "destination_vserver": "Destination SVM",
-              "protectedBy": "Protected By",
-              "protectionRole": "Protection Role",
-              "snapshot_policy": "Snapshot",
-              "source_volume": "Source Volume",
-              "source_vserver": "Source SVM",
               "svm": "SVM",
               "volume": "Volume"
             }
@@ -3686,50 +3341,7 @@
             "mode": "fixed"
           }
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Protected By"
-            },
-            "properties": [
-              {
-                "id": "custom.filterable",
-                "value": true
-              },
-              {
-                "id": "custom.width",
-                "value": 190
-              },
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "cg": {
-                        "index": 2,
-                        "text": "CG"
-                      },
-                      "not_applicable": {
-                        "index": 3,
-                        "text": "Unprotected"
-                      },
-                      "storage_vm": {
-                        "index": 1,
-                        "text": "SVM DR"
-                      },
-                      "volume": {
-                        "index": 0,
-                        "text": "SnapMirror"
-                      }
-                    },
-                    "type": "value"
-                  }
-                ]
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "options": {
         "showHeader": true,
@@ -3744,7 +3356,7 @@
       },
       "targets": [
         {
-          "expr": "volume_labels{cluster=~\"$Cluster\",volume!~\"MDV.*\",protectionRole=\"unprotected\",snapshot_policy!=\"\"} unless on (volume,svm)  label_replace( label_replace(  label_replace( snapmirror_labels{source_cluster=~\"$Cluster\"} , \"volume\", \"$1\", \"source_volume\", \"(.*)\") , \"svm\", \"$1\", \"source_vserver\", \"(.*)\") , \"cluster\", \"$1\", \"source_cluster\", \"(.*)\") ",
+          "expr": "volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"} unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{source_cluster=~\"$Cluster\"} , \"volume\", \"$1\", \"source_volume\", \"(.*)\") , \"svm\", \"$1\", \"source_vserver\", \"(.*)\") unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{source_cluster=~\"$Cluster\"} , \"volume\", \"$1\", \"destination_volume\", \"(.*)\") , \"svm\", \"$1\", \"destination_vserver\", \"(.*)\") ",
           "legendFormat": "",
           "interval": "",
           "exemplar": false,
@@ -3767,7 +3379,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 80
+        "y": 83
       },
       "id": 42,
       "panels": [],
@@ -3798,7 +3410,7 @@
         "h": 12,
         "w": 5,
         "x": 0,
-        "y": 81
+        "y": 84
       },
       "id": 128,
       "options": {
@@ -3868,7 +3480,7 @@
           "refId": "E"
         }
       ],
-      "title": "Volume count by relationship type",
+      "title": "Volume relationship count by relationship type",
       "transformations": [],
       "type": "piechart"
     },
@@ -3900,7 +3512,7 @@
         "h": 6,
         "w": 3,
         "x": 5,
-        "y": 81
+        "y": 84
       },
       "id": 109,
       "links": [],
@@ -3966,7 +3578,7 @@
         "h": 6,
         "w": 3,
         "x": 8,
-        "y": 81
+        "y": 84
       },
       "id": 110,
       "links": [],
@@ -4032,7 +3644,7 @@
         "h": 6,
         "w": 3,
         "x": 11,
-        "y": 81
+        "y": 84
       },
       "id": 111,
       "links": [],
@@ -4092,7 +3704,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Volume Snapmirror"
+              "options": "Healthy"
             },
             "properties": [
               {
@@ -4107,13 +3719,13 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Unprotected"
+              "options": "Unhealthy"
             },
             "properties": [
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "yellow",
+                  "fixedColor": "dark-yellow",
                   "mode": "fixed"
                 }
               }
@@ -4125,7 +3737,7 @@
         "h": 12,
         "w": 5,
         "x": 14,
-        "y": 81
+        "y": 84
       },
       "id": 130,
       "options": {
@@ -4152,24 +3764,25 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(group by (volume)(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\", volume!~\"MDV.*\", all_sm_healthy=\"true\"}))",
+          "expr": "count((snapmirror_labels{source_cluster=~\"$Cluster\", healthy=\"true\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )) or vector (0)",
           "instant": true,
           "interval": "",
           "legendFormat": "Healthy",
-          "refId": "A"
+          "refId": "A",
+          "format": "time_series"
         },
         {
           "exemplar": true,
-          "expr": "count(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", all_sm_healthy=\"false\"})",
+          "expr": "count(group by (source_volume,source_vserver,source_cluster)(snapmirror_labels{source_cluster=~\"$Cluster\", healthy=\"false\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ) ) or vector (0)",
           "hide": false,
           "instant": true,
           "interval": "",
           "legendFormat": "Unhealthy",
-          "refId": "B"
+          "refId": "B",
+          "format": "time_series"
         }
       ],
-      "title": "Volume count by relationship health",
-      "transformations": [],
+      "title": "Volume relationship count by relationship health",
       "type": "piechart"
     },
     {
@@ -4200,7 +3813,7 @@
         "h": 6,
         "w": 5,
         "x": 19,
-        "y": 81
+        "y": 84
       },
       "id": 114,
       "links": [],
@@ -4211,7 +3824,7 @@
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "last"
           ],
           "fields": "",
           "values": false
@@ -4222,15 +3835,14 @@
       "pluginVersion": "8.1.2",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "count(group by (volume)(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\", volume!~\"MDV.*\", all_sm_healthy=\"true\"}))",
-          "format": "table",
+          "expr": "count((snapmirror_labels{source_cluster=~\"$Cluster\",healthy=\"true\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )) or vector (0)",
           "hide": false,
           "instant": true,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "",
-          "refId": "A"
+          "legendFormat": "Healthy",
+          "refId": "A",
+          "format": "time_series"
         }
       ],
       "timeFrom": null,
@@ -4266,7 +3878,7 @@
         "h": 6,
         "w": 3,
         "x": 5,
-        "y": 87
+        "y": 90
       },
       "id": 113,
       "links": [],
@@ -4332,7 +3944,7 @@
         "h": 6,
         "w": 3,
         "x": 8,
-        "y": 87
+        "y": 90
       },
       "id": 112,
       "links": [],
@@ -4398,7 +4010,7 @@
         "h": 6,
         "w": 5,
         "x": 19,
-        "y": 87
+        "y": 90
       },
       "id": 115,
       "links": [],
@@ -4409,7 +4021,7 @@
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "last"
           ],
           "fields": "",
           "values": false
@@ -4421,7 +4033,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(volume_labels{datacenter=\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", all_sm_healthy=\"false\"})",
+          "expr": "count(group by (source_volume,source_vserver,source_cluster)(snapmirror_labels{source_cluster=~\"$Cluster\", healthy=\"false\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ) ) or vector (0)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -4549,7 +4161,7 @@
         "h": 14,
         "w": 14,
         "x": 0,
-        "y": 93
+        "y": 96
       },
       "id": 129,
       "options": {
@@ -4568,7 +4180,7 @@
           "refId": "A"
         }
       ],
-      "title": "Volume count by relationship type",
+      "title": "Volume relationship count by relationship type",
       "transformations": [
         {
           "id": "filterFieldsByName",
@@ -4630,7 +4242,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "HealthyStatus"
+              "options": "Healthy Status"
             },
             "properties": [
               {
@@ -4669,7 +4281,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 320
+                "value": 310
               }
             ]
           },
@@ -4681,7 +4293,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 320
+                "value": 310
               }
             ]
           }
@@ -4691,7 +4303,7 @@
         "h": 14,
         "w": 10,
         "x": 14,
-        "y": 93
+        "y": 96
       },
       "id": 131,
       "options": {
@@ -4702,7 +4314,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "snapmirror_labels{source_cluster=~\"$Cluster\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\",type=\"rw\",all_sm_healthy!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ",
+          "expr": "snapmirror_labels{source_cluster=~\"$Cluster\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$Cluster\",volume!~\"MDV.*\", type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -4710,7 +4322,7 @@
           "refId": "A"
         }
       ],
-      "title": "Volume count by relationship health",
+      "title": "Volume relationship count by relationship health",
       "transformations": [
         {
           "id": "filterFieldsByName",
@@ -4735,15 +4347,9 @@
               "source_volume": 0
             },
             "renameByName": {
-              "Value": "Lag Duration (seconds)",
-              "all_sm_healthy": "HealthyStatus",
               "destination_volume": "Destination Volume",
-              "destination_vserver": "Destination SVM",
-              "healthy": "HealthyStatus",
-              "source_volume": "Source Volume",
-              "source_vserver": "Source SVM",
-              "svm": "",
-              "volume": ""
+              "healthy": "Healthy Status",
+              "source_volume": "Source Volume"
             }
           }
         }

--- a/grafana/dashboards/cmode/harvest_dashboard_snapmirror.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_snapmirror.json
@@ -3511,7 +3511,7 @@
           "refId": "A"
         }
       ],
-      "datasource": null
+      "datasource": "${DS_PROMETHEUS}"
     },
     {
       "collapsed": false,


### PR DESCRIPTION
Changes covered in REST:
1. SVM peer call:
To handle special case where peer svm name can be any alias 

Here, `vs4` is exist in both the clusters, so while svm peer operation, destination cluster has renamed svm to other alias name to make unique identification, Which could cause issue while we do join snapmirrors and volumes in PromQL.
```
ocum-mobility-01-02::> vserver peer show -vserver vs_test
            Peer        Peer                           Peering        Remote
Vserver     Vserver     State        Peer Cluster      Applications   Vserver
----------- ----------- ------------ ----------------- -------------- ---------
vs_test     vs4.1       peered       AFFA200-206-76-78 snapmirror     vs4
```
2. To pass extra field `expand` to get child level snapmirros when svmdr has initiated.
```
C2_sti103-vsim-ucs553s_cluster::> snapmirror show
                                                                       Progress
Source            Destination Mirror  Relationship   Total             Last
Path        Type  Path        State   Status         Progress  Healthy Updated
----------- ---- ------------ ------- -------------- --------- ------- --------
svmsrc:     XDP  svmdst:      Snapmirrored
                                      Idle           -         true    -

C2_sti103-vsim-ucs553s_cluster::> snapmirror show -expand
                                                                       Progress
Source            Destination Mirror  Relationship   Total             Last
Path        Type  Path        State   Status         Progress  Healthy Updated
----------- ---- ------------ ------- -------------- --------- ------- --------
svmsrc:     XDP  svmdst:      Snapmirrored
                                      Idle           -         true    -
svmsrc:vol11
            XDP  svmdst:vol11 Snapmirrored
                                      Idle           -         true    -
2 entries were displayed.
```

UI changes are in-progress.

**Pending:**
ZAPI changes for this would be tricky, would need discussion for this(`expand` field).