### PR TITLE
fix: 7mode zapi cli issue due to max

### DIFF
--- a/cmd/tools/zapi/zapi.go
+++ b/cmd/tools/zapi/zapi.go
@@ -268,7 +268,7 @@ func getInstances(c *client.Client, args *Args) (*node.Node, error) {
 	req = node.NewXMLS("perf-object-instance-list-info-iter")
 	req.NewChildS("objectname", args.Object)
 
-	if args.MaxRecords != 0 {
+	if c.IsClustered() && args.MaxRecords != 0 {
 		req.NewChildS("max-records", strconv.Itoa(args.MaxRecords))
 	}
 
@@ -290,7 +290,7 @@ func getData(c *client.Client, args *Args) (*node.Node, error) {
 	// requested data is for an Zapi query
 	if args.API != "" {
 		req = node.NewXMLS(args.API)
-		if args.MaxRecords != 0 {
+		if c.IsClustered() && args.MaxRecords != 0 {
 			req.NewChildS("max-records", strconv.Itoa(args.MaxRecords))
 		}
 		// requested data is for a ZapiPerf object
@@ -299,11 +299,11 @@ func getData(c *client.Client, args *Args) (*node.Node, error) {
 			req = node.NewXMLS("perf-object-get-instances")
 			instances := req.NewChildS("instances", "")
 			instances.NewChildS("instance", "*")
+			if args.MaxRecords != 0 {
+				req.NewChildS("max", strconv.Itoa(args.MaxRecords))
+			}
 		} else {
 			req = node.NewXMLS("perf-object-get-instances")
-		}
-		if args.MaxRecords != 0 {
-			req.NewChildS("max", strconv.Itoa(args.MaxRecords))
 		}
 		req.NewChildS("objectname", args.Object)
 	}


### PR DESCRIPTION
Prior:
```
hardikl@hardikl-mac-2 harvest % ./bin/zapi -p cluster-51 show data --object nic_common 
connected to fas2240-2 (NetApp Release 8.2.5P5 7-Mode: Thu Jan  7 04:22:14 PST 2021)
2022/09/29 19:37:16 API request rejected => Extra input: max
```


With change:
```
hardikl@hardikl-mac-2 harvest % ./bin/zapi -p cluster-51 show data --object nic_common       
connected to fas2240-2 (NetApp Release 8.2.5P5 7-Mode: Thu Jan  7 04:22:14 PST 2021)
<root>
<timestamp>1664461153</timestamp><instances><instance-data><name>e0a</name><counters><counter-data><name>instance_name</name><value>e0a</value></counter-data><counter-data><name>instance_uuid</name><value></value></counter-data><counter-data><name>node_name</name><value></value></counter-data><counter-data><name>node_uuid</name><value></value></counter-data><counter-data><name>process_name</name><value></value></counter-data><counter-data><name>nic_type</name><value>nic_e1000</value></counter-data><counter-data><name>rx_frames_per_sec</name><value>562661695</value></counter-data><counter-data><name>rx_frames</name><value>562661695</value></counter-data><counter-data><name>rx_bytes_per_sec</name
...
...
```