### PR TITLE
feat: export ONTAP histograms as Prometheus histograms

### DIFF
--- a/cmd/collectors/zapiperf/zapiperf.go
+++ b/cmd/collectors/zapiperf/zapiperf.go
@@ -1219,7 +1219,7 @@ func (z *ZapiPerf) addCounter(counter *node.Node, name, display string, enabled 
 				if isHistogram {
 					// Save the index of this label so the labels can be exported in order
 					m.SetLabel("comment", strconv.Itoa(i))
-					m.SetArray(true)
+					m.SetHistogram(true)
 				}
 			}
 		}

--- a/cmd/collectors/zapiperf/zapiperf.go
+++ b/cmd/collectors/zapiperf/zapiperf.go
@@ -1130,8 +1130,15 @@ func (z *ZapiPerf) addCounter(counter *node.Node, name, display string, enabled 
 	// counter type is array, each element will be converted to a metric instance
 	if counter.GetChildContentS("type") == "array" {
 
-		var labels, baseLabels []string
-		var e string
+		var (
+			labels, baseLabels []string
+			e                  string
+			description        string
+			isHistogram        bool
+			histogramMetric    matrix.Metric
+		)
+
+		description = strings.ToLower(counter.GetChildContentS("desc"))
 
 		if labels, e = parseHistogramLabels(counter); e != "" {
 			z.Logger.Warn().Msgf("skipping [%s] of type array: %s", name, e)
@@ -1156,15 +1163,39 @@ func (z *ZapiPerf) addCounter(counter *node.Node, name, display string, enabled 
 			}
 		}
 
-		for _, label := range labels {
+		baseKey := baseCounter
+		if baseCounter != "" && len(baseLabels) != 0 {
+			baseKey += "." + baseLabels[0]
+		}
+
+		// ONTAP does not have a `type` for histogram. Harvest tests the `desc` field to determine
+		// if a counter is a histogram
+		isHistogram = false
+		if len(labels) > 0 && strings.Contains(description, "histogram") {
+			key := name + "." + "bucket"
+			histogramMetric = mat.GetMetric(key)
+			if histogramMetric != nil {
+				z.Logger.Trace().Str("metric", key).Msg("Updating array metric attributes")
+			} else {
+				histogramMetric, err = mat.NewMetricFloat64(key)
+				if err != nil {
+					z.Logger.Error().Err(err).Str("key", key).Msg("unable to create histogram metric")
+					return ""
+				}
+			}
+			histogramMetric.SetName(display)
+			histogramMetric.SetProperty(property)
+			histogramMetric.SetComment(baseKey)
+			histogramMetric.SetExportable(enabled)
+			histogramMetric.SetBuckets(&labels)
+			isHistogram = true
+		}
+
+		for i, label := range labels {
 
 			var m matrix.Metric
 
 			key := name + "." + label
-			baseKey := baseCounter
-			if baseCounter != "" && len(baseLabels) != 0 {
-				baseKey += "." + baseLabels[0]
-			}
 
 			if m = mat.GetMetric(key); m != nil {
 				z.Logger.Trace().Msgf("updating array metric [%s] attributes", key)
@@ -1185,6 +1216,11 @@ func (z *ZapiPerf) addCounter(counter *node.Node, name, display string, enabled 
 				m.SetLabel("submetric", x[1])
 			} else {
 				m.SetLabel("metric", label)
+				if isHistogram {
+					// Save the index of this label so the labels can be exported in order
+					m.SetLabel("comment", strconv.Itoa(i))
+					m.SetArray(true)
+				}
 			}
 		}
 		// cache labels only when parsing counter was success

--- a/pkg/matrix/metric.go
+++ b/pkg/matrix/metric.go
@@ -36,6 +36,8 @@ type Metric interface {
 	SetComment(string)
 	IsArray() bool
 	SetArray(bool)
+	IsHistogram() bool
+	SetHistogram(bool)
 	Clone(bool) Metric
 	SetBuckets(*[]string)
 	Buckets() *[]string
@@ -93,6 +95,7 @@ type AbstractMetric struct {
 	property   string
 	comment    string
 	array      bool
+	histogram  bool
 	exportable bool
 	labels     *dict.Dict
 	buckets    *[]string
@@ -108,6 +111,7 @@ func (m *AbstractMetric) Clone(deep bool) *AbstractMetric {
 		comment:    m.comment,
 		exportable: m.exportable,
 		array:      m.array,
+		histogram:  m.histogram,
 		buckets:    m.buckets,
 	}
 	if m.labels != nil {
@@ -175,6 +179,14 @@ func (m *AbstractMetric) SetLabel(key, value string) {
 		m.labels = dict.New()
 	}
 	m.labels.Set(key, value)
+}
+
+func (m *AbstractMetric) SetHistogram(b bool) {
+	m.histogram = b
+}
+
+func (m *AbstractMetric) IsHistogram() bool {
+	return m.histogram
 }
 
 func (m *AbstractMetric) Buckets() *[]string {

--- a/pkg/matrix/metric.go
+++ b/pkg/matrix/metric.go
@@ -37,6 +37,8 @@ type Metric interface {
 	IsArray() bool
 	SetArray(bool)
 	Clone(bool) Metric
+	SetBuckets(*[]string)
+	Buckets() *[]string
 
 	// methods for resizing metric storage
 
@@ -93,6 +95,7 @@ type AbstractMetric struct {
 	array      bool
 	exportable bool
 	labels     *dict.Dict
+	buckets    *[]string
 	record     []bool
 	pass       []bool
 }
@@ -105,6 +108,7 @@ func (m *AbstractMetric) Clone(deep bool) *AbstractMetric {
 		comment:    m.comment,
 		exportable: m.exportable,
 		array:      m.array,
+		buckets:    m.buckets,
 	}
 	if m.labels != nil {
 		clone.labels = m.labels.Copy()
@@ -171,6 +175,14 @@ func (m *AbstractMetric) SetLabel(key, value string) {
 		m.labels = dict.New()
 	}
 	m.labels.Set(key, value)
+}
+
+func (m *AbstractMetric) Buckets() *[]string {
+	return m.buckets
+}
+
+func (m *AbstractMetric) SetBuckets(buckets *[]string) {
+	m.buckets = buckets
 }
 
 func (m *AbstractMetric) SetLabels(labels *dict.Dict) {


### PR DESCRIPTION
Fixes #1309

Converting ONTAP histograms to Prometheus histograms requires making sense of ONTAP's counter labels since those labels need to be normalized into a bucket interval for Prometheus. It is not always possible to generically convert ONTAP labels, since differnt counter subsystems use different free-form text. There is no standard or schema for these label names.

Harvest currently handles histograms that use this form of labels:

- `<20us   6`
- `<6ms    1`
- `<10s    0`
- `>=120s  4`

In this example, if these metrics are from the `svm` object and the `cifs_latency_hist` counter they will be exported as shown below. Since microseconds are the smallest unit, all latencies will be normalized to microseconds.

```
svm_cifs_cifs_latency_hist_bucket{cluster="cluster1",datacenter="dc",svm="vs4",le="20"} 6
svm_cifs_cifs_latency_hist_bucket{cluster="cluster1",datacenter="dc",svm="vs4",le="6000"} 1
svm_cifs_cifs_latency_hist_bucket{cluster="cluster1",datacenter="dc",svm="vs4",le="10000000"} 0
svm_cifs_cifs_latency_hist_bucket{cluster="cluster1",datacenter="dc",svm="vs4",le="+Inf"} 4
```

Currently, Harvest only understands how to parse units named: `us`, `ms|msec`, `s|sec`. If all labels are parsable, the histogram will be exported as a Prometheus histogram, otherwise Harvest will export the ONTAP histogram as a flattened set of metrics where the `metric` label equals the ONTAP metric.