### PR TITLE
feat: all dashboards should default to `Shared crosshair`

### DIFF
--- a/grafana/dashboards/7mode/harvest_dashboard_aggregate7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_aggregate7.json
@@ -64,7 +64,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1651154093980,
   "links": [

--- a/grafana/dashboards/7mode/harvest_dashboard_cluster7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_cluster7.json
@@ -69,7 +69,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1660131966678,
   "links": [

--- a/grafana/dashboards/7mode/harvest_dashboard_disk7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_disk7.json
@@ -63,7 +63,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1654863008940,
   "links": [

--- a/grafana/dashboards/7mode/harvest_dashboard_lun7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_lun7.json
@@ -63,7 +63,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1651157130100,
   "links": [

--- a/grafana/dashboards/7mode/harvest_dashboard_network7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_network7.json
@@ -63,7 +63,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1664281595179,
   "links": [

--- a/grafana/dashboards/7mode/harvest_dashboard_node7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_node7.json
@@ -69,7 +69,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1651158530758,
   "links": [

--- a/grafana/dashboards/7mode/harvest_dashboard_shelf7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_shelf7.json
@@ -57,7 +57,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1619514558045,
   "links": [

--- a/grafana/dashboards/7mode/harvest_dashboard_volume7.json
+++ b/grafana/dashboards/7mode/harvest_dashboard_volume7.json
@@ -63,7 +63,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1651159124192,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_aggregate.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_aggregate.json
@@ -63,7 +63,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1666176865129,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_cdot.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_cdot.json
@@ -70,7 +70,7 @@
   "editable": true,
   "gnetId": null,
   "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1665388048905,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_cluster.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_cluster.json
@@ -69,7 +69,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1663774806079,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_compliance.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_compliance.json
@@ -63,7 +63,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": 1496,
   "iteration": 1648624960194,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_data_protection_snapshot.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_data_protection_snapshot.json
@@ -69,7 +69,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1637051731590,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_disk.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_disk.json
@@ -63,7 +63,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1662642076310,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_headroom.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_headroom.json
@@ -51,7 +51,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1664471319262,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_lun.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_lun.json
@@ -69,7 +69,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1664349128957,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_metadata.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_metadata.json
@@ -75,7 +75,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1651151594733,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_network_detail.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_network_detail.json
@@ -63,7 +63,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1664280004316,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_nfs4storePool_detail.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_nfs4storePool_detail.json
@@ -51,7 +51,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1651152950740,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_nfs_clients.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_nfs_clients.json
@@ -69,7 +69,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1665135798398,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_node_details.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_node_details.json
@@ -69,7 +69,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1663832272520,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_power.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_power.json
@@ -63,7 +63,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1663838477750,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_qtree.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_qtree.json
@@ -52,7 +52,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1663838812554,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_quotaReport.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_quotaReport.json
@@ -52,7 +52,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1662734055395,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_security.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_security.json
@@ -63,7 +63,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": 1497,
   "iteration": 1648624965825,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_shelf.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_shelf.json
@@ -69,7 +69,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1663840305837,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_snapmirror.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_snapmirror.json
@@ -63,7 +63,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1651153724854,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_svm_details.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_svm_details.json
@@ -57,7 +57,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1655297827808,
   "links": [

--- a/grafana/dashboards/cmode/harvest_dashboard_volume_details.json
+++ b/grafana/dashboards/cmode/harvest_dashboard_volume_details.json
@@ -69,7 +69,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1664349159212,
   "links": [

--- a/grafana/dashboards/influxdb/harvest_dashboard_aggregate.json
+++ b/grafana/dashboards/influxdb/harvest_dashboard_aggregate.json
@@ -62,7 +62,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1630063184425,
   "links": [],

--- a/grafana/dashboards/influxdb/harvest_dashboard_cluster.json
+++ b/grafana/dashboards/influxdb/harvest_dashboard_cluster.json
@@ -69,7 +69,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1630064292160,
   "links": [],

--- a/grafana/dashboards/influxdb/harvest_dashboard_headroom.json
+++ b/grafana/dashboards/influxdb/harvest_dashboard_headroom.json
@@ -51,7 +51,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1630063514650,
   "links": [],

--- a/grafana/dashboards/influxdb/harvest_dashboard_metadata.json
+++ b/grafana/dashboards/influxdb/harvest_dashboard_metadata.json
@@ -69,7 +69,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1630064144481,
   "links": [],

--- a/grafana/dashboards/influxdb/harvest_dashboard_network.json
+++ b/grafana/dashboards/influxdb/harvest_dashboard_network.json
@@ -63,7 +63,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1630064418892,
   "links": [],

--- a/grafana/dashboards/influxdb/harvest_dashboard_shelf.json
+++ b/grafana/dashboards/influxdb/harvest_dashboard_shelf.json
@@ -63,7 +63,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1630063792993,
   "links": [],

--- a/grafana/dashboards/influxdb/harvest_dashboard_snapmirror.json
+++ b/grafana/dashboards/influxdb/harvest_dashboard_snapmirror.json
@@ -63,7 +63,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1630063864164,
   "links": [],

--- a/grafana/dashboards/influxdb/harvest_dashboard_svm.json
+++ b/grafana/dashboards/influxdb/harvest_dashboard_svm.json
@@ -57,7 +57,7 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1630064009827,
   "links": [],


### PR DESCRIPTION
If you want to revert to the old panel behavior, select the `Dashboard settings` gear icon at the top of the dashboard and in the `Panel options` section select `Default` instead of `Shared crosshair`

Fixes #1356