### PR TITLE
fix: harvest should keep same volume name during upgrade in docker-compose workflow

### DIFF
--- a/prom-stack.tmpl
+++ b/prom-stack.tmpl
@@ -1,9 +1,10 @@
 version: '3.7'
 
 volumes:
-    prometheus_data: {}
-    grafana_data: {}
-    harvest: {}
+    prometheus_data:
+        name: harvest_prometheus_data
+    grafana_data:
+        name: harvest_grafana_data
 
 networks:
     frontend:


### PR DESCRIPTION
…pose workflow