### PR TITLE
fix: Top Latency units should be microseconds not milliseconds

### DIFF
--- a/grafana/dashboards/cmode/cluster.json
+++ b/grafana/dashboards/cmode/cluster.json
@@ -4270,7 +4270,7 @@
                   }
                 ]
               },
-              "unit": "ms"
+              "unit": "µs"
             },
             "overrides": []
           },


### PR DESCRIPTION
Thanks to @faguayot and jf38800 for reporting