### PR TITLE
fix: don't add units as metric labels since it breaks InfluxDB exporter

### DIFF
--- a/cmd/collectors/restperf/restperf.go
+++ b/cmd/collectors/restperf/restperf.go
@@ -751,12 +751,6 @@ func (r *RestPerf) PollData() (map[string]*matrix.Matrix, error) {
 		if metric.GetName() != "timestamp" {
 			counter := r.counterLookup(metric, key)
 			if counter != nil {
-				if !isWorkloadDetailObject(r.Prop.Query) {
-					// set metric unit
-					if counter.unit != "none" {
-						metric.SetLabel("unit", counter.unit)
-					}
-				}
 				if counter.denominator == "" {
 					// does not require base counter
 					orderedNonDenominatorMetrics = append(orderedNonDenominatorMetrics, metric)


### PR DESCRIPTION
Fixes: #1375

The sensor and shelf plugins need a separate fix.