### PR TITLE
fix: handle raidgroup/plex alongwith other changes

### DIFF
--- a/conf/zapiperf/cdot/9.8.0/disk.yaml
+++ b/conf/zapiperf/cdot/9.8.0/disk.yaml
@@ -37,7 +37,7 @@ plugins:
   # any names after the object names will be treated as
   # label names that will be added to instances
     - node
-    - aggr node
+    - aggr ...
     - plex node,aggr,plex
 
   Max:
@@ -45,7 +45,7 @@ plugins:
   # any names after the object names will be treated as
   # label names that will be added to instances
     - node<>node_disk_max
-    - aggr<>aggr_disk_max aggr,node
+    - aggr<>aggr_disk_max ...
 
 # only export node/aggr aggregations from plugin
 # set this true or comment, to get data for each disk

--- a/grafana/dashboards/cmode/aggregate.json
+++ b/grafana/dashboards/cmode/aggregate.json
@@ -3081,7 +3081,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "aggr_disk_busy{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$TopDiskBusy\"}",
+          "expr": "avg by (node, aggr) (aggr_disk_busy{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$TopDiskBusy\"})",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -3187,7 +3187,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "aggr_disk_busy{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$TopDiskBusy\"}",
+          "expr": "avg by (node, aggr) (aggr_disk_busy{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$TopDiskBusy\"})",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -3337,7 +3337,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "query_result(avg_over_time(aggr_disk_busy{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}]))",
+        "definition": "query_result(avg by (aggr) (avg_over_time(aggr_disk_busy{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}])))",
         "description": null,
         "error": null,
         "hide": 2,
@@ -3347,7 +3347,7 @@
         "name": "TopDiskBusy",
         "options": [],
         "query": {
-          "query": "query_result(avg_over_time(aggr_disk_busy{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}]))",
+          "query": "query_result(avg by (aggr) (avg_over_time(aggr_disk_busy{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}])))",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/grafana/dashboards/cmode/disk.json
+++ b/grafana/dashboards/cmode/disk.json
@@ -1033,7 +1033,7 @@
       "pluginVersion": "8.1.8",
       "targets": [
         {
-          "expr": "topk($TopResources, aggr_disk_max_busy{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$TopDiskBusy\"})",
+          "expr": "topk($TopResources, max by (node, aggr) (aggr_disk_max_busy{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$TopDiskBusy\"}))",
           "interval": "",
           "legendFormat": "{{node}} - {{aggr}}",
           "refId": "A"
@@ -1122,7 +1122,7 @@
       "pluginVersion": "8.1.8",
       "targets": [
         {
-          "expr": "topk($TopResources, aggr_disk_max_total_transfers{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$TopDiskTotalTransfers\"})",
+          "expr": "topk($TopResources, max by (node, aggr) (aggr_disk_max_total_transfers{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$TopDiskTotalTransfers\"}))",
           "interval": "",
           "legendFormat": "{{node}} - {{aggr}}",
           "refId": "A"
@@ -1213,7 +1213,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "topk($TopResources, aggr_disk_max_user_read_chain{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$TopDiskUserReadChain\"}) * 4",
+          "expr": "topk($TopResources, max by (node, aggr) (aggr_disk_max_user_read_chain{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$TopDiskUserReadChain\"})) * 4",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1308,7 +1308,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "topk($TopResources, aggr_disk_max_user_write_chain{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$TopDiskUserWriteChain\"}) * 4",
+          "expr": "topk($TopResources, max by (node, aggr)(aggr_disk_max_user_write_chain{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$TopDiskUserWriteChain\"})) * 4",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2537,14 +2537,14 @@
       {
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "query_result(topk($TopResources, avg_over_time(aggr_disk_max_user_read_chain{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}])))",
+        "definition": "query_result(topk($TopResources, max by (aggr) (avg_over_time(aggr_disk_max_user_read_chain{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}]))))",
         "hide": 2,
         "includeAll": true,
         "multi": true,
         "name": "TopDiskUserReadChain",
         "options": [],
         "query": {
-          "query": "query_result(topk($TopResources, avg_over_time(aggr_disk_max_user_read_chain{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}])))",
+          "query": "query_result(topk($TopResources, max by (aggr) (avg_over_time(aggr_disk_max_user_read_chain{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}]))))",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -2556,14 +2556,14 @@
       {
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "query_result(topk($TopResources, avg_over_time(aggr_disk_max_user_write_chain{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}])))",
+        "definition": "query_result(topk($TopResources, max by (aggr) (avg_over_time(aggr_disk_max_user_write_chain{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}]))))",
         "hide": 2,
         "includeAll": true,
         "multi": true,
         "name": "TopDiskUserWriteChain",
         "options": [],
         "query": {
-          "query": "query_result(topk($TopResources, avg_over_time(aggr_disk_max_user_write_chain{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}])))",
+          "query": "query_result(topk($TopResources, max by (aggr) (avg_over_time(aggr_disk_max_user_write_chain{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}]))))",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -2574,14 +2574,14 @@
       },
       {
         "current": {},
-        "definition": "query_result(topk($TopResources, avg_over_time(aggr_disk_max_busy{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}])))",
+        "definition": "query_result(topk($TopResources, max by (aggr) (avg_over_time(aggr_disk_max_busy{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}]))))",
         "hide": 2,
         "includeAll": true,
         "multi": true,
         "name": "TopDiskBusy",
         "options": [],
         "query": {
-          "query": "query_result(topk($TopResources, avg_over_time(aggr_disk_max_busy{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}])))",
+          "query": "query_result(topk($TopResources, max by (aggr) (avg_over_time(aggr_disk_max_busy{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}]))))",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -2593,14 +2593,14 @@
       {
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "query_result(topk($TopResources, avg_over_time(aggr_disk_max_total_transfers{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}])))",
+        "definition": "query_result(topk($TopResources, max by (aggr) (avg_over_time(aggr_disk_max_total_transfers{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}]))))",
         "hide": 2,
         "includeAll": true,
         "multi": true,
         "name": "TopDiskTotalTransfers",
         "options": [],
         "query": {
-          "query": "query_result(topk($TopResources, avg_over_time(aggr_disk_max_total_transfers{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}])))",
+          "query": "query_result(topk($TopResources, max by (aggr) (avg_over_time(aggr_disk_max_total_transfers{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",aggr=~\"$Aggregate\"}[${__range}]))))",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
Reverted the disk.yaml recent changes and handled in aggregate and disk dashboards accordingly.