### PR TITLE
fix: disable color console logging

### DIFF
--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -97,6 +97,7 @@ func Configure(config LogConfig) *Logger {
 	if config.ConsoleLoggingEnabled {
 		writers = append(writers, zerolog.ConsoleWriter{
 			Out:        os.Stderr,
+			NoColor:    true,
 			TimeFormat: time.RFC3339,
 		})
 	}


### PR DESCRIPTION
Makes consuming logs more annoying, especially since console logging is the default in nabox