### PR TITLE
feat: envvar `HARVEST_NO_UPGRADE` to skip collector upgrade

### DIFF
--- a/cmd/poller/poller.go
+++ b/cmd/poller/poller.go
@@ -1052,7 +1052,7 @@ func (p *Poller) upgradeCollector(c conf.Collector) (conf.Collector, error) {
 	if !strings.HasPrefix(c.Name, "Zapi") {
 		return c, nil
 	}
-	noUpgrade := os.Getenv("HARVEST_NO_UPGRADE")
+	noUpgrade := os.Getenv("HARVEST_NO_COLLECTOR_UPGRADE")
 	if noUpgrade != "" {
 		logger.Debug().Str("collector", c.Name).Msg("No upgrade due to env var. Use collector")
 		return c, nil


### PR DESCRIPTION
When Harvest talks with `9.12.1+` ONTAP clusters, ZAPI collectors will be replaced with REST ones.

When the `HARVEST_NO_UPGRADE` envvar exists, ZAPI collectors will not upgrade to REST ones.