### PR TITLE
fix: cluster dashboard panel changes

### DIFF
--- a/grafana/dashboards/cmode/cluster.json
+++ b/grafana/dashboards/cmode/cluster.json
@@ -986,7 +986,8 @@
       },
       "id": 79,
       "panels": [],
-      "title": "Nodes & Subsystems",
+      "repeat": "Cluster",
+      "title": "Nodes & Subsystems - $Cluster",
       "type": "row"
     },
     {
@@ -1124,8 +1125,6 @@
         "sortBy": []
       },
       "pluginVersion": "8.1.8",
-      "repeat": "Cluster",
-      "repeatDirection": "v",
       "targets": [
         {
           "exemplar": false,
@@ -1312,8 +1311,6 @@
         "textMode": "value"
       },
       "pluginVersion": "8.1.8",
-      "repeat": null,
-      "repeatDirection": "h",
       "targets": [
         {
           "exemplar": false,
@@ -1397,7 +1394,6 @@
         "text": {}
       },
       "pluginVersion": "8.1.8",
-      "repeatDirection": "h",
       "targets": [
         {
           "exemplar": false,
@@ -1475,7 +1471,6 @@
         "text": {}
       },
       "pluginVersion": "8.1.8",
-      "repeatDirection": "h",
       "targets": [
         {
           "exemplar": false,
@@ -1662,7 +1657,6 @@
         "sortBy": []
       },
       "pluginVersion": "8.1.8",
-      "repeatDirection": "v",
       "targets": [
         {
           "exemplar": false,
@@ -1699,7 +1693,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "$Cluster - subsystems",
+      "title": "subsystems",
       "transformations": [
         {
           "id": "organize",
@@ -1808,7 +1802,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Max Disk Utilization by Cluster",
+      "title": "Avg Disk Utilization by Cluster",
       "type": "bargauge"
     },
     {
@@ -1873,7 +1867,6 @@
         "text": {}
       },
       "pluginVersion": "8.1.8",
-      "repeatDirection": "h",
       "targets": [
         {
           "exemplar": false,


### PR DESCRIPTION
With this changes,
- based on the clusters selected, `Nodes & Sybsystems` rows will be added for each cluster. all details inside the row are cluster scoped.
If all clusters:
<img width="1724" alt="image" src="https://user-images.githubusercontent.com/83282894/199451655-edf0a0d5-cac9-441e-8a4e-40fd6c383b19.png">

If one cluster:
<img width="1742" alt="image" src="https://user-images.githubusercontent.com/83282894/199452018-77967247-3ab4-4d4d-bb19-f05878f23fc6.png">


complete view:
<img width="1756" alt="image" src="https://user-images.githubusercontent.com/83282894/199452227-4179a477-c048-408e-90a3-e150f277603f.png">
