### PR TITLE
fix: Harvest should use template display name when exporting histograms

### DIFF
--- a/cmd/collectors/zapiperf/zapiperf.go
+++ b/cmd/collectors/zapiperf/zapiperf.go
@@ -1056,8 +1056,6 @@ func (z *ZapiPerf) PollCounter() (map[string]*matrix.Matrix, error) {
 					display = strings.TrimSpace(x[1])
 				}
 				z.qosLabels[label] = display
-				//me.instanceLabels[label] = display
-				//oldLabels.Remove(label)
 			}
 		}
 	}
@@ -1169,7 +1167,7 @@ func (z *ZapiPerf) addCounter(counter *node.Node, name, display string, enabled 
 		// if a counter is a histogram
 		isHistogram = false
 		if len(labels) > 0 && strings.Contains(description, "histogram") {
-			key := name + "." + "bucket"
+			key := name + ".bucket"
 			histogramMetric = mat.GetMetric(key)
 			if histogramMetric != nil {
 				z.Logger.Trace().Str("metric", key).Msg("Updating array metric attributes")
@@ -1216,6 +1214,8 @@ func (z *ZapiPerf) addCounter(counter *node.Node, name, display string, enabled 
 				if isHistogram {
 					// Save the index of this label so the labels can be exported in order
 					m.SetLabel("comment", strconv.Itoa(i))
+					// Save the bucket name so the flattened metrics can find their bucket when exported
+					m.SetLabel("bucket", name+".bucket")
 					m.SetHistogram(true)
 				}
 			}

--- a/cmd/exporters/prometheus/prometheus.go
+++ b/cmd/exporters/prometheus/prometheus.go
@@ -411,7 +411,7 @@ func (p *Prometheus) render(data *matrix.Matrix) ([][]byte, error) {
 					if metric.IsHistogram() {
 						// metric is histogram. Create a new metric to accumulate
 						// the flattened metrics and export them in order
-						bucketMetric := data.GetMetric(metric.GetName() + ".bucket")
+						bucketMetric := data.GetMetric(metric.GetLabel("bucket"))
 						if bucketMetric == nil {
 							p.Logger.Debug().
 								Str("metric", metric.GetName()).


### PR DESCRIPTION
Fixes #1309

Before this change a template with a display name would fail to export.

After this change a template like this:

```yaml
name:                     CIFSvserver
query:                    cifs:vserver
object:                   svm_cifs
counters:
  - cifs_ops                => ops     # type=array
  - cifs_latency_hist       => foople  # type=histogram
```

will export like so

```
svm_cifs_foople_bucket{cluster="umeng-aff300-05-06",datacenter="dc-1",svm="vs_test4",le="6000"} 10
svm_cifs_op_count{cluster="umeng-aff300-05-06",datacenter="dc-1",svm="vs_test4",metric="GetAttr"} 0
```