### PR TITLE
fix: dont export constituents relationships in SM

### DIFF
--- a/cmd/collectors/zapi/plugins/snapmirror/snapmirror.go
+++ b/cmd/collectors/zapi/plugins/snapmirror/snapmirror.go
@@ -31,6 +31,8 @@ type Peer struct {
 	cluster string
 }
 
+var flexgroupConstituentName = regexp.MustCompile(`^(.*)__(\d{4})$`)
+
 func New(p *plugin.AbstractPlugin) plugin.Plugin {
 	return &SnapMirror{AbstractPlugin: p}
 }
@@ -70,7 +72,6 @@ func (my *SnapMirror) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 	destUpdCount := 0
 	srcUpdCount := 0
 	limitUpdCount := 0
-	re := regexp.MustCompile(`^(.*)__(\d{4})$`)
 
 	if cluster, ok := data.GetGlobalLabels().GetHas("cluster"); ok {
 		if err := my.getSVMPeerData(cluster); err != nil {
@@ -81,7 +82,7 @@ func (my *SnapMirror) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 
 	for _, instance := range data.GetInstances() {
 		// Zapi call with `expand=true` would gives all the constituent's relationships as well, which we don't want to export.
-		if match := re.FindStringSubmatch(instance.GetLabel("destination_volume")); len(match) == 3 {
+		if match := flexgroupConstituentName.FindStringSubmatch(instance.GetLabel("destination_volume")); len(match) == 3 {
 			instance.SetExportable(false)
 			continue
 		}

--- a/cmd/collectors/zapi/plugins/snapmirror/snapmirror.go
+++ b/cmd/collectors/zapi/plugins/snapmirror/snapmirror.go
@@ -12,6 +12,7 @@ import (
 	"github.com/netapp/harvest/v2/pkg/dict"
 	"github.com/netapp/harvest/v2/pkg/matrix"
 	"github.com/netapp/harvest/v2/pkg/tree/node"
+	"regexp"
 	"strings"
 )
 
@@ -69,6 +70,7 @@ func (my *SnapMirror) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 	destUpdCount := 0
 	srcUpdCount := 0
 	limitUpdCount := 0
+	re := regexp.MustCompile(`^(.*)__(\d{4})$`)
 
 	if cluster, ok := data.GetGlobalLabels().GetHas("cluster"); ok {
 		if err := my.getSVMPeerData(cluster); err != nil {
@@ -78,6 +80,12 @@ func (my *SnapMirror) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 	}
 
 	for _, instance := range data.GetInstances() {
+		// Zapi call with `expand=true` would gives all the constituent's relationships as well, which we don't want to export.
+		if match := re.FindStringSubmatch(instance.GetLabel("destination_volume")); len(match) == 3 {
+			instance.SetExportable(false)
+			continue
+		}
+
 		if my.client.IsClustered() {
 			vserverName := instance.GetLabel("source_vserver")
 			// Update source_vserver in snapmirror (In case of inter-cluster SM - vserver name may differ)


### PR DESCRIPTION
Zapi With `expand=false`
<img width="1323" alt="image" src="https://user-images.githubusercontent.com/83282894/199981427-227c5b9b-cc4f-4b3a-80ce-6da165f167db.png">



Zapi With `expand=true` --> got added 16 constituent's relationships here
<img width="1349" alt="image" src="https://user-images.githubusercontent.com/83282894/199981592-b036eaec-2783-41a6-b0db-e9f794ec6dc5.png">


Rest with `expand=false`
<img width="1165" alt="image" src="https://user-images.githubusercontent.com/83282894/199981752-cce7fac5-eb04-493b-83f0-4d52e38149f6.png">


Rest with `expand=true`
<img width="1140" alt="image" src="https://user-images.githubusercontent.com/83282894/199981814-b54070f5-fd23-4d0b-9e88-7d1b01468133.png">
