### PR TITLE
fix: handle LS relationships + handle dashboard

### DIFF
--- a/cmd/collectors/rest/plugins/snapmirror/snapmirror.go
+++ b/cmd/collectors/rest/plugins/snapmirror/snapmirror.go
@@ -20,7 +20,6 @@ type SnapMirror struct {
 	*plugin.AbstractPlugin
 	data           *matrix.Matrix
 	client         *rest.Client
-	query          string
 	currentVal     int
 	svmPeerDataMap map[string]Peer // [peer SVM alias name] -> [peer detail] map
 }
@@ -52,7 +51,6 @@ func (my *SnapMirror) Init() error {
 		return err
 	}
 
-	my.query = "api/private/cli/volume"
 	my.svmPeerDataMap = make(map[string]Peer)
 
 	my.data = matrix.New(my.Parent+".SnapMirror", "snapmirror", "snapmirror")

--- a/cmd/collectors/rest/rest.go
+++ b/cmd/collectors/rest/rest.go
@@ -415,13 +415,20 @@ func (r *Rest) HandleResults(result []gjson.Result, prop *prop, isEndPoint bool)
 			continue
 		}
 
-		// extract instance key(s)
-		for _, k := range prop.InstanceKeys {
-			value := instanceData.Get(k)
-			if value.Exists() {
-				instanceKey += value.String()
-			} else {
-				r.Logger.Warn().Str("key", k).Msg("missing key")
+		if len(prop.InstanceKeys) != 0 {
+			// extract instance key(s)
+			for _, k := range prop.InstanceKeys {
+				value := instanceData.Get(k)
+				if value.Exists() {
+					instanceKey += value.String()
+				} else {
+					r.Logger.Warn().Str("key", k).Msg("missing key")
+				}
+			}
+
+			if instanceKey == "" {
+				r.Logger.Trace().Msg("Instance key is empty, skipping")
+				continue
 			}
 		}
 

--- a/cmd/collectors/rest/rest.go
+++ b/cmd/collectors/rest/rest.go
@@ -421,8 +421,7 @@ func (r *Rest) HandleResults(result []gjson.Result, prop *prop, isEndPoint bool)
 			if value.Exists() {
 				instanceKey += value.String()
 			} else {
-				r.Logger.Warn().Str("key", k).Msg("skip instance, missing key")
-				break
+				r.Logger.Warn().Str("key", k).Msg("missing key")
 			}
 		}
 

--- a/cmd/collectors/restperf/restperf.go
+++ b/cmd/collectors/restperf/restperf.go
@@ -510,8 +510,7 @@ func (r *RestPerf) PollData() (map[string]*matrix.Matrix, error) {
 				if value.Exists() {
 					instanceKey += value.String()
 				} else {
-					r.Logger.Warn().Str("key", k).Msg("skip instance, missing key")
-					break
+					r.Logger.Warn().Str("key", k).Msg("missing key")
 				}
 			}
 

--- a/cmd/collectors/restperf/restperf.go
+++ b/cmd/collectors/restperf/restperf.go
@@ -504,13 +504,20 @@ func (r *RestPerf) PollData() (map[string]*matrix.Matrix, error) {
 				return true
 			}
 
-			// extract instance key(s)
-			for _, k := range instanceKeys {
-				value := parseProperties(instanceData, k)
-				if value.Exists() {
-					instanceKey += value.String()
-				} else {
-					r.Logger.Warn().Str("key", k).Msg("missing key")
+			if len(instanceKeys) != 0 {
+				// extract instance key(s)
+				for _, k := range instanceKeys {
+					value := instanceData.Get(k)
+					if value.Exists() {
+						instanceKey += value.String()
+					} else {
+						r.Logger.Warn().Str("key", k).Msg("missing key")
+					}
+				}
+
+				if instanceKey == "" {
+					r.Logger.Trace().Msg("Instance key is empty, skipping")
+					return true
 				}
 			}
 

--- a/conf/rest/9.12.0/snapmirror.yaml
+++ b/conf/rest/9.12.0/snapmirror.yaml
@@ -6,7 +6,7 @@ object:                       snapmirror
 
 counters:
   - ^^relationship_id                        => relationship_id
-  - ^destination_path                        => destination_location
+  - ^^destination_path                       => destination_location
   - ^destination_volume_node                 => destination_node
   - ^destination_vserver                     => destination_vserver
   - ^destination_volume                      => destination_volume
@@ -41,6 +41,7 @@ endpoints:
   - query: api/snapmirror/relationships
     counters:
       - ^^uuid                               => relationship_id
+      - ^^destination.path                   => destination_location
       - ^source.cluster.name                 => source_cluster
 
 plugins:
@@ -55,6 +56,8 @@ export_options:
     - source_volume
     - source_vserver
     - source_node
+    - source_cluster
+    - destination_location
   instance_labels:
     - healthy
     - unhealthy_reason
@@ -62,13 +65,9 @@ export_options:
     - relationship_status
     - relationship_type
     - schedule
-#    - destination_node_limit
-#    - source_node_limit
     - group_type
-    - destination_location
     - protectedBy
     - protectionSourceType
     - policy_type
-    - source_cluster
     - derived_relationship_type
     - local

--- a/conf/zapi/cdot/9.8.0/snapmirror.yaml
+++ b/conf/zapi/cdot/9.8.0/snapmirror.yaml
@@ -30,7 +30,7 @@ counters:
     - ^unhealthy-reason
     - update-failed-count
     - update-successful-count
-    - ^destination-location
+    - ^^destination-location
     - ^policy-type
 
 plugins:
@@ -45,6 +45,7 @@ export_options:
     - source_vserver
     - source_node
     - source_cluster
+    - destination_location
   instance_labels:
     - healthy
     - unhealthy_reason
@@ -55,7 +56,6 @@ export_options:
     - destination_node_limit
     - source_node_limit
     - group_type
-    - destination_location
     - protectedBy
     - protectionSourceType
     - policy_type

--- a/grafana/dashboards/cmode/snapmirror.json
+++ b/grafana/dashboards/cmode/snapmirror.json
@@ -158,7 +158,7 @@
       "pluginVersion": "8.1.8",
       "targets": [
         {
-          "expr": "count (count by (relationship_id) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\"}))",
+          "expr": "count (count by (relationship_id) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",relationship_id!=\"\"}))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -230,7 +230,7 @@
       "pluginVersion": "8.1.8",
       "targets": [
         {
-          "expr": "count (count by (relationship_id) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",group_type=\"none\"}))",
+          "expr": "count (count by (relationship_id) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",group_type=\"none\",relationship_id!=\"\"}))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -302,7 +302,7 @@
       "pluginVersion": "8.1.8",
       "targets": [
         {
-          "expr": "count (count by (relationship_id) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",group_type=\"vserver\"}))",
+          "expr": "count (count by (relationship_id) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",group_type=\"vserver\",relationship_id!=\"\"}))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -374,7 +374,7 @@
       "pluginVersion": "8.1.8",
       "targets": [
         {
-          "expr": "count (count by (relationship_id) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",relationship_status=\"insync\"}))",
+          "expr": "count (count by (relationship_id) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",relationship_status=\"insync\",relationship_id!=\"\"}))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -447,7 +447,7 @@
       "pluginVersion": "8.1.8",
       "targets": [
         {
-          "expr": "count (count by (relationship_id) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",healthy=\"false\"}))",
+          "expr": "count (count by (relationship_id) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",healthy=\"false\",relationship_id!=\"\"}))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1109,7 +1109,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "expr": "count by (destination_node, relationship_status) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",destination_node=~\"$DestinationNode\",destination_node!=\"\"})",
+          "expr": "count by (destination_node, relationship_status) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",destination_node=~\"$DestinationNode\",destination_node!=\"\",relationship_id!=\"\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{destination_node}} - {{relationship_status}}",
@@ -1523,7 +1523,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "expr": "count by (source_node, relationship_status) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\"} * on (source_volume, source_vserver, source_cluster) group_left(source_node)  label_replace( label_replace( label_replace( label_replace (volume_labels{datacenter=~\"$Datacenter\",cluster=~\"$SourceCluster\",node=~\"$SourceNode\",node!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_node\", \"$1\", \"node\", \"(.*)\") , \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ) ",
+          "expr": "count by (source_node, relationship_status) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",relationship_id!=\"\"} * on (source_volume, source_vserver, source_cluster) group_left(source_node)  label_replace( label_replace( label_replace( label_replace (volume_labels{datacenter=~\"$Datacenter\",cluster=~\"$SourceCluster\",node=~\"$SourceNode\",node!=\"\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_node\", \"$1\", \"node\", \"(.*)\") , \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ) ",
           "hide": false,
           "interval": "",
           "legendFormat": "{{source_node}} - {{relationship_status}}",
@@ -1954,7 +1954,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "expr": "count by (source_vserver, relationship_status) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",source_vserver=~\"$SourceSVM\",source_vserver!=\"\"})",
+          "expr": "count by (source_vserver, relationship_status) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",source_vserver=~\"$SourceSVM\",source_vserver!=\"\",relationship_id!=\"\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{source_vserver}} - {{relationship_status}}",
@@ -2050,7 +2050,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "expr": "count by (destination_vserver, relationship_status) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",destination_vserver=~\"$DestinationSVM\",destination_vserver!=\"\"})",
+          "expr": "count by (destination_vserver, relationship_status) (snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",destination_vserver=~\"$DestinationSVM\",destination_vserver!=\"\",relationship_id!=\"\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{destination_vserver}} - {{relationship_status}}",
@@ -2188,7 +2188,7 @@
         },
         {
           "exemplar": true,
-          "expr": "count(volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"} unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\"} , \"volume\", \"$1\", \"source_volume\", \"(.*)\") , \"svm\", \"$1\", \"source_vserver\", \"(.*)\") unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\"} , \"volume\", \"$1\", \"destination_volume\", \"(.*)\") , \"svm\", \"$1\", \"destination_vserver\", \"(.*)\") ) or vector (0)",
+          "expr": "count(volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"} unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",relationship_id!=\"\"} , \"volume\", \"$1\", \"source_volume\", \"(.*)\") , \"svm\", \"$1\", \"source_vserver\", \"(.*)\") unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",relationship_id!=\"\"} , \"volume\", \"$1\", \"destination_volume\", \"(.*)\") , \"svm\", \"$1\", \"destination_vserver\", \"(.*)\") ) or vector (0)",
           "hide": false,
           "interval": "",
           "legendFormat": "Unprotected",
@@ -2712,7 +2712,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"} unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\"} , \"volume\", \"$1\", \"source_volume\", \"(.*)\") , \"svm\", \"$1\", \"source_vserver\", \"(.*)\") unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\"} , \"volume\", \"$1\", \"destination_volume\", \"(.*)\") , \"svm\", \"$1\", \"destination_vserver\", \"(.*)\") ) or vector (0)",
+          "expr": "count(volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"} unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",relationship_id!=\"\"} , \"volume\", \"$1\", \"source_volume\", \"(.*)\") , \"svm\", \"$1\", \"source_vserver\", \"(.*)\") unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",relationship_id!=\"\"} , \"volume\", \"$1\", \"destination_volume\", \"(.*)\") , \"svm\", \"$1\", \"destination_vserver\", \"(.*)\") ) or vector (0)",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -3327,7 +3327,7 @@
       },
       "targets": [
         {
-          "expr": "volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"} unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\"} , \"volume\", \"$1\", \"source_volume\", \"(.*)\") , \"svm\", \"$1\", \"source_vserver\", \"(.*)\") unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\"} , \"volume\", \"$1\", \"destination_volume\", \"(.*)\") , \"svm\", \"$1\", \"destination_vserver\", \"(.*)\") ",
+          "expr": "volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\",snapshot_policy!=\"\"} unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",relationship_id!=\"\"} , \"volume\", \"$1\", \"source_volume\", \"(.*)\") , \"svm\", \"$1\", \"source_vserver\", \"(.*)\") unless on (volume,svm)  label_replace( label_replace( snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",relationship_id!=\"\"} , \"volume\", \"$1\", \"destination_volume\", \"(.*)\") , \"svm\", \"$1\", \"destination_vserver\", \"(.*)\") ",
           "legendFormat": "",
           "interval": "",
           "exemplar": false,
@@ -3731,7 +3731,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count((snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\", healthy=\"true\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\", type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )) or vector (0)",
+          "expr": "count((snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\", healthy=\"true\",relationship_id!=\"\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\", type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )) or vector (0)",
           "instant": true,
           "interval": "",
           "legendFormat": "Healthy",
@@ -3740,7 +3740,7 @@
         },
         {
           "exemplar": true,
-          "expr": "count(group by (source_volume,source_vserver,source_cluster)(snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\", healthy=\"false\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\", type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ) ) or vector (0)",
+          "expr": "count(group by (source_volume,source_vserver,source_cluster)(snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\", healthy=\"false\",relationship_id!=\"\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\", type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ) ) or vector (0)",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -3802,7 +3802,7 @@
       "pluginVersion": "8.1.2",
       "targets": [
         {
-          "expr": "count((snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",healthy=\"true\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\", type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )) or vector (0)",
+          "expr": "count((snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",healthy=\"true\",relationship_id!=\"\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\", type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )) or vector (0)",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -4000,7 +4000,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(group by (source_volume,source_vserver,source_cluster)(snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\", healthy=\"false\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\", type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ) ) or vector (0)",
+          "expr": "count(group by (source_volume,source_vserver,source_cluster)(snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\", healthy=\"false\",relationship_id!=\"\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\", type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ) ) or vector (0)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -4139,7 +4139,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ",
+          "expr": "snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",relationship_id!=\"\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -4281,7 +4281,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\", type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ",
+          "expr": "snapmirror_labels{datacenter=~\"$Datacenter\",source_cluster=~\"$SourceCluster\",relationship_id!=\"\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\", type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ",
           "format": "table",
           "instant": true,
           "interval": "",


### PR DESCRIPTION
LS(load sharing) relationships don't have `relationship_id` field in ZAPI/REST response, due to this, we either skip them or wrongly populate in Harvest.

Changes made:
- added instancekey as `relationship_id`+`destination_path`
- make sure ZAPI and REST collector would parse as expected
- make sure no impact in dashboard due to this

With this, We can now monitor LS relationships as well and can show in dashboard if required.