### PR TITLE
feat: add netstat metrics for packet loss

### DIFF
--- a/conf/zapiperf/cdot/9.8.0/netstat.yaml
+++ b/conf/zapiperf/cdot/9.8.0/netstat.yaml
@@ -1,0 +1,38 @@
+
+name:                     Netstat
+query:                    netstat
+object:                   netstat
+
+instance_key:             uuid
+
+counters:
+  - bytes_recvd
+  - bytes_sent
+  - cong_win
+  - cong_win_th
+  - faddr
+  - fport_hbo                => fport
+  - instance_uuid
+  - laddr
+  - lport_hbo                => lport
+  - node_name                => node
+  - ooorcv_pkts
+  - recv_window
+  - rexmit_pkts
+  - send_window
+
+override:
+  lport_hbo: string
+  fport_hbo: string
+
+plugins:
+  - LabelAgent:
+    join:
+      - faddr `_` faddr,fport
+      - laddr `_` laddr,lport
+
+export_options:
+  instance_keys:
+    - node
+    - faddr
+    - laddr

--- a/conf/zapiperf/default.yaml
+++ b/conf/zapiperf/default.yaml
@@ -17,6 +17,7 @@ objects:
   HeadroomAggr:           resource_headroom_aggr.yaml
   HeadroomCPU:            resource_headroom_cpu.yaml
   HostAdapter:            hostadapter.yaml
+#  Netstat:                netstat.yaml
   NFSv3Node:              nfsv3_node.yaml
   NFSv41Node:             nfsv4_1_node.yaml
   NFSv42Node:             nfsv4_2_node.yaml


### PR DESCRIPTION
Fixes: #1386

REST Perf does not include this object.

```bash
curl -k -n 'https://10.195.15.41/api/cluster/counter/tables/netstat?return_records=true&fields=*'
{
  "error": {
    "message": "Object \"netstat\" was not found.",
    "code": "8585320",
    "target": "name"
  }
}
```