### PR TITLE
fix: shelf child obj - status ok to normal

### DIFF
--- a/cmd/collectors/rest/plugins/shelf/shelf.go
+++ b/cmd/collectors/rest/plugins/shelf/shelf.go
@@ -245,7 +245,12 @@ func (my *Shelf) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 											}
 											shelfChildInstance.SetLabel(labelDisplay, strings.Join(labelArray, ","))
 										} else {
-											shelfChildInstance.SetLabel(labelDisplay, value.String())
+											valueString := value.String()
+											// For shelf child level objects' status field, Rest `ok` value maps Zapi `normal` value.
+											if labelDisplay == "status" {
+												valueString = strings.ReplaceAll(valueString, "ok", "normal")
+											}
+											shelfChildInstance.SetLabel(labelDisplay, valueString)
 										}
 									} else {
 										// spams a lot currently due to missing label mappings. Moved to debug for now till rest gaps are filled


### PR DESCRIPTION
In my system, datacenter `DC-01` is zapi collector and `DC` is rest collector. 
<img width="1778" alt="image" src="https://user-images.githubusercontent.com/83282894/201324544-9180273b-54d4-4095-a8a7-487243bee2e9.png">

<img width="1779" alt="image" src="https://user-images.githubusercontent.com/83282894/201324599-f22a9885-cb1e-4ff8-8df9-daa7d0f1dc67.png">
