### PR TITLE
docs: docker upgrade instructions

### DIFF
--- a/docs/install/containers.md
+++ b/docs/install/containers.md
@@ -157,5 +157,5 @@ To upgrade Harvest:
 
 ```
 docker pull cr.netapp.io/harvest   # or if using Docker Hub: docker pull rahulguptajss/harvest
-docker-compose -f prom-stack.yml -f harvest-compose.yml restart
+docker-compose -f prom-stack.yml -f harvest-compose.yml up -d --remove-orphans
 ```


### PR DESCRIPTION
Pulled latest nightly and tried to see if commands in doc is working. Reference https://stackoverflow.com/a/56687449

Restart is not upgrading containers to latest image

<img width="813" alt="image" src="https://user-images.githubusercontent.com/25551691/202649983-eacf6101-12ab-4177-b5be-37a78ad1f2e7.png">


simply up does

<img width="904" alt="image" src="https://user-images.githubusercontent.com/25551691/202650041-deb20b05-751c-40fe-8f3e-c85eeea736f9.png">
