### PR TITLE
feat: StorageGrid collector should be included in autosupport

### DIFF
--- a/cmd/collectors/storagegrid/rest/client.go
+++ b/cmd/collectors/storagegrid/rest/client.go
@@ -309,7 +309,7 @@ func (c *Client) fetch() ([]byte, error) {
 	return body, nil
 }
 
-// Init is responsible for determining the StorageGrid server version, API version, and hostname
+// Init is responsible for determining the StorageGrid server version, API version, hostname, and systemId
 func (c *Client) Init(retries int) error {
 	var (
 		err     error
@@ -338,9 +338,14 @@ func (c *Client) Init(retries int) error {
 		if content, err = c.GetGridRest("grid/config"); err != nil {
 			continue
 		}
-
 		results = gjson.GetManyBytes(content, "data.hostname")
 		c.Cluster.Name = results[0].String()
+
+		if content, err = c.GetGridRest("grid/license"); err != nil {
+			continue
+		}
+		results = gjson.GetManyBytes(content, "data.systemId")
+		c.Cluster.UUID = results[0].String()
 		return nil
 	}
 

--- a/cmd/collectors/storagegrid/storagegrid.go
+++ b/cmd/collectors/storagegrid/storagegrid.go
@@ -12,6 +12,7 @@ import (
 	"github.com/netapp/harvest/v2/pkg/tree/node"
 	"github.com/netapp/harvest/v2/pkg/util"
 	"github.com/tidwall/gjson"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -381,6 +382,59 @@ func (s *StorageGrid) InitAPIPath() {
 			Str("templateAPI", apiVersion).
 			Msg("Use template apiVersion")
 	}
+}
+
+func (s *StorageGrid) CollectAutoSupport(p *collector.Payload) {
+	var exporterTypes []string
+	for _, exporter := range s.Exporters {
+		exporterTypes = append(exporterTypes, exporter.GetClass())
+	}
+
+	var counters = make([]string, 0)
+	for k := range s.Props.Counters {
+		counters = append(counters, k)
+	}
+
+	var schedules = make([]collector.Schedule, 0)
+	tasks := s.Params.GetChildS("schedule")
+	if tasks != nil && len(tasks.GetChildren()) > 0 {
+		for _, task := range tasks.GetChildren() {
+			schedules = append(schedules, collector.Schedule{
+				Name:     task.GetNameS(),
+				Schedule: task.GetContentS(),
+			})
+		}
+	}
+
+	// Add collector information
+	p.AddCollectorAsup(collector.AsupCollector{
+		Name:      s.Name,
+		Query:     s.Props.Query,
+		Exporters: exporterTypes,
+		Counters: collector.Counters{
+			Count: len(counters),
+			List:  counters,
+		},
+		Schedules:     schedules,
+		ClientTimeout: s.client.Timeout.String(),
+	})
+
+	version := s.client.Cluster.Version
+	p.Target.Version = strconv.Itoa(version[0]) + "." + strconv.Itoa(version[1]) + "." + strconv.Itoa(version[2])
+	p.Target.Model = "storagegrid"
+	p.Target.ClusterUUID = s.client.Cluster.UUID
+
+	md := s.GetMetadata()
+	info := collector.InstanceInfo{
+		Count:      md.LazyValueInt64("instances", "data"),
+		DataPoints: md.LazyValueInt64("metrics", "data"),
+		PollTime:   md.LazyValueInt64("poll_time", "data"),
+		APITime:    md.LazyValueInt64("api_time", "data"),
+		ParseTime:  md.LazyValueInt64("parse_time", "data"),
+		PluginTime: md.LazyValueInt64("plugin_time", "data"),
+	}
+
+	p.Nodes = &info
 }
 
 // Interface guards

--- a/cmd/poller/poller.go
+++ b/cmd/poller/poller.go
@@ -83,11 +83,12 @@ var (
 	asupSchedule     = "24h" // send every 24 hours
 	asupFirstWrite   = "4m"  // after this time, write 1st autosupport payload (for testing)
 	isOntapCollector = map[string]struct{}{
-		"ZapiPerf": {},
-		"Zapi":     {},
-		"Rest":     {},
-		"RestPerf": {},
-		"Ems":      {},
+		"ZapiPerf":    {},
+		"Zapi":        {},
+		"Rest":        {},
+		"RestPerf":    {},
+		"Ems":         {},
+		"StorageGrid": {},
 	}
 )
 


### PR DESCRIPTION
Example autosupport
```
{
 "Target": {
  "Version": "11.6.0",
  "Model": "storagegrid",
  "Serial": "",
  "Ping": 0,
  "ClusterUUID": "123456"
 },
 "Harvest": {
  "HostHash": "df62c133cbd0fef8ccda100e3c04c33eb3b2d911",
  "UUID": "7c4a8d09ca3762af61e59520943dc26494f8941b",
  "Version": "2.0.2",
  "Release": "rc2",
  "Commit": "HEAD",
  "BuildDate": "undefined",
  "NumClusters": 1
 },
 "Platform": {
  "OS": "darwin",
  "Arch": "darwin",
  "Memory": {
   "TotalKb": 33554432,
   "AvailableKb": 14977532,
   "UsedKb": 18576900
  },
  "CPUs": 1
 },
 "Nodes": {
  "Count": 537,
  "DataPoints": 2685,
  "PollTime": 73558462,
  "APITime": 2487764,
  "ParseTime": 4853,
  "PluginTime": 71064711
 },
 "Volumes": null,
 "Collectors": [
  {
   "Name": "StorageGrid",
   "Query": "grid/accounts-cache",
   "ClientTimeout": "1m0s",
   "Schedules": [
    {
     "Name": "data",
     "Schedule": "5m"
    }
   ],
   "Exporters": [
    "Prometheus"
   ],
   "Counters": {
    "Count": 5,
    "List": [
     "dataBytes",
     "policy.quotaObjectBytes",
     "id",
     "name",
     "objectCount"
    ]
   }
  }
 ]
}
```