### PR TITLE
fix: collapse all but highlights

### DIFF
--- a/grafana/dashboards/cmode/svm.json
+++ b/grafana/dashboards/cmode/svm.json
@@ -1486,7 +1486,7 @@
       "type": "row"
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
@@ -2895,7 +2895,7 @@
               "exemplar": true,
               "expr": "svm_vscan_dispatch_latency{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\"}",
               "interval": "",
-              "legendFormat": "{{cluster}} - {{svm}}",
+              "legendFormat": "{{cluster}} - {{svm}} - dispatch latency",
               "refId": "A"
             },
             {
@@ -12013,7 +12013,7 @@
       "type": "row"
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,


### PR DESCRIPTION
fix: include `dispatch latency` in legend name for `svm_vscan_dispatch_latency`

Fixes #1538
Fixes #1534