### PR TITLE
fix: exclude node svms and vol0 volumes in cdot dash

### DIFF
--- a/conf/rest/9.12.0/svm.yaml
+++ b/conf/rest/9.12.0/svm.yaml
@@ -9,6 +9,7 @@ counters:
   - ^vserver                                => svm
   - ^anti_ransomware_default_volume_state   => anti_ransomware_state
   - ^operational_state                      => state
+  - ^type                                   => type
 
 endpoints:
   - query: api/svm/svms
@@ -72,6 +73,7 @@ export_options:
     - svm
   instance_labels:
     - state
+    - type
     - anti_ransomware_state
     - ciphers
     - cifs_protocol_enabled

--- a/conf/zapi/cdot/9.8.0/svm.yaml
+++ b/conf/zapi/cdot/9.8.0/svm.yaml
@@ -8,6 +8,7 @@ counters:
     - ^^uuid                                  => svm_uuid
     - ^vserver-name                           => svm
     - ^state                                  => state
+    - ^vserver-type                           => type
     - ^anti-ransomware-default-volume-state   => anti_ransomware_state
     - name-server-switch:
         - ^nsswitch                           => nameservice_switch
@@ -29,6 +30,7 @@ export_options:
     - svm
   instance_labels:
     - state
+    - type
     - anti_ransomware_state
     - nis_authentication_enabled
     - audit_protocol_enabled

--- a/grafana/dashboards/cmode/cdot.json
+++ b/grafana/dashboards/cmode/cdot.json
@@ -2176,14 +2176,14 @@
       },
       {
         "current": {},
-        "definition": "query_result(topk($TopResources,(100 * sum by (cluster, svm) (volume_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\"}) /   sum by (cluster, svm) (volume_size_total{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\"}))))",
+        "definition": "query_result(topk($TopResources,(100 * sum by (cluster, svm) (volume_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\"}) /   sum by (cluster, svm) (volume_size_total{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\"})) * on (cluster, svm) svm_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",type!=\"node\"}))",
         "hide": 2,
         "includeAll": true,
         "multi": true,
         "name": "TopSVMUsed",
         "options": [],
         "query": {
-          "query": "query_result(topk($TopResources,(100 * sum by (cluster, svm) (volume_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\"}) /   sum by (cluster, svm) (volume_size_total{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\"}))))",
+          "query": "query_result(topk($TopResources,(100 * sum by (cluster, svm) (volume_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\"}) /   sum by (cluster, svm) (volume_size_total{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\"})) * on (cluster, svm) svm_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",type!=\"node\"}))",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -2194,14 +2194,14 @@
       },
       {
         "current": {},
-        "definition": "query_result(topk($TopResources, (100 * volume_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"} / volume_size_total{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"})))",
+        "definition": "query_result(topk($TopResources, (100 * volume_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"} / volume_size_total{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"}) * on (cluster, svm, volume) volume_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\",volume!=\"vol0\"}))",
         "hide": 2,
         "includeAll": true,
         "multi": true,
         "name": "TopVolumeUsed",
         "options": [],
         "query": {
-          "query": "query_result(topk($TopResources, (100 * volume_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"} / volume_size_total{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"})))",
+          "query": "query_result(topk($TopResources, (100 * volume_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"} / volume_size_total{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\",volume=~\"$Volume\"}) * on (cluster, svm, volume) volume_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\",volume!=\"vol0\"}))",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
**SVM capacity:**
Previous:
![image](https://user-images.githubusercontent.com/83282894/204533976-184ae16c-15b2-43d4-8066-ba4d25c3038f.png)



Now:
![image](https://user-images.githubusercontent.com/83282894/204534025-fcc98cf0-0d72-484e-81c1-f21c999c9a1d.png)

**Volume capacity:** (right side table)
previous:
![image](https://user-images.githubusercontent.com/83282894/204534619-4d83a2d2-5bf2-4c83-a2cf-59583fb7b9dc.png)

now:
![image](https://user-images.githubusercontent.com/83282894/204534741-debd49a6-a005-4ce9-8723-b643dd2f98ca.png)


