### PR TITLE
fix: changed to private cli for cifs_ntlm_enabled

### DIFF
--- a/conf/rest/9.12.0/svm.yaml
+++ b/conf/rest/9.12.0/svm.yaml
@@ -5,60 +5,63 @@ query:                    api/private/cli/vserver
 object:                   svm
 
 counters:
-  - ^^uuid                                  => svm_uuid
-  - ^vserver                                => svm
+  - ^^vserver                               => svm
   - ^anti_ransomware_default_volume_state   => anti_ransomware_state
   - ^operational_state                      => state
 
 endpoints:
   - query: api/svm/svms
     counters:
-      - ^^uuid                              => svm_uuid
+      - ^^name                              => svm
       - ^nsswitch                           => nameservice_switch
   - query: api/security/ssh/svms
     counters:
-      - ^^svm.uuid                          => svm_uuid
+      - ^^svm.name                          => svm
       - ^ciphers                            => ciphers
   - query: api/protocols/cifs/services
     counters:
-      - ^^svm.uuid                          => svm_uuid
+      - ^^svm.name                          => svm
       - ^enabled                            => cifs_protocol_enabled
       - ^security.smb_encryption            => smb_encryption_required
       - ^security.smb_signing               => smb_signing_required
-      - ^security.lm_compatibility_level    => cifs_ntlm_enabled
   - query: api/protocols/nfs/services
     counters:
-      - ^^svm.uuid                          => svm_uuid
+      - ^^svm.name                          => svm
       - ^enabled                            => nfs_protocol_enabled
   - query: api/protocols/audit
     counters:
-      - ^^svm.uuid                          => svm_uuid
+      - ^^svm.name                          => svm
       - ^enabled                            => audit_protocol_enabled
   - query: api/protocols/fpolicy     # need to test
     counters:
-      - ^^svm.uuid                          => svm_uuid
+      - ^^svm.name                          => svm
       - ^policies.enabled                   => fpolicy_enabled
       - ^policies.name                      => fpolicy_name
   - query: api/name-services/nis
     counters:
-      - ^^svm.uuid                          => svm_uuid
+      - ^^svm.name                          => svm
       - ^domain                             => nis_domain
   - query: api/name-services/ldap
     counters:
-      - ^^svm.uuid                          => svm_uuid
+      - ^^svm.name                          => svm
       - ^session_security                   => ldap_session_security
   - query: api/protocols/nfs/kerberos/interfaces
     counters:
-      - ^^svm.uuid                          => svm_uuid
+      - ^^svm.name                          => svm
       - ^enabled                            => nfs_kerberos_protocol_enabled
   - query: api/protocols/san/iscsi/credentials
     counters:
-      - ^^svm.uuid                          => svm_uuid
+      - ^^svm.name                          => svm
       - ^authentication_type                => iscsi_authentication_type
   - query: api/protocols/san/iscsi/services
     counters:
-      - ^^svm.uuid                          => svm_uuid
+      - ^^svm.name                          => svm
       - ^enabled                            => iscsi_service_enabled
+  - query: api/private/cli/vserver/cifs/server/security
+    counters:
+      - ^^vserver                           => svm
+      - ^lm_compatibility_level             => cifs_ntlm_enabled
+
 plugins:
   - SVM
   - LabelAgent:


### PR DESCRIPTION
All apis are svm scoped and svm is unique in cluster. Changing instance key from svm_uuid to svm.

```
A250-41-42-43::> vserver show
                               Admin      Operational Root
Vserver     Type    Subtype    State      State       Volume     Aggregate
----------- ------- ---------- ---------- ----------- ---------- ----------
A250-41-42-43 
            admin   -          -          -           -          -
A250-42     node    -          -          -           -          -
A250-43     node    -          -          -           -          -
astra_ci_vc_esxi_24_75_data 
            data    default    running    running     astra_ci_  vmware_
                                                      vc_esxi_   aggr
                                                      24_75_
                                                      data_root
nfs_vserver data    default    running    running     nfs_       astra_
                                                      vserver_   aggr2
                                                      root
nvmevs1     data    default    running    running     nvmevs1_   astra_
                                                      root       aggr3
vmware_vm   data    default    running    running     vmware_vm_ astra_
                                                      root       aggr1
7 entries were displayed.

A250-41-42-43::> vserver create -vserver nvmevs1

Error: command failed: The Vserver name is already used by another Vserver. 

```

Prior:
![image](https://user-images.githubusercontent.com/83282894/204573117-9f8613f4-ec7f-4d72-b3fa-2309516f4838.png)


With Changes:
![image](https://user-images.githubusercontent.com/83282894/204573210-176b7dc9-90c7-4045-bb00-76263e888199.png)
