### PR TITLE
feat: added dashboard tests for legends details

### DIFF
--- a/cmd/tools/grafana/dashboard_test.go
+++ b/cmd/tools/grafana/dashboard_test.go
@@ -653,59 +653,60 @@ func TestLegends(t *testing.T) {
 func checkLegends(t *testing.T, path string, data []byte) {
 	// collect all legends
 	dashPath := shortPath(path)
-	gjson.GetBytes(data, "panels").ForEach(func(key, value gjson.Result) bool {
+
+	visitAllPanels(data, func(path string, key, value gjson.Result) {
 		doLegends(t, value, dashPath)
-		value.Get("panels").ForEach(func(key2, value2 gjson.Result) bool {
-			doLegends(t, value2, dashPath)
-			return true
-		})
-		return true
 	})
 }
 
 func doLegends(t *testing.T, value gjson.Result, dashPath string) {
-	expectedCals := []string{"mean", "lastNotNull", "max"}
-	expectedDisplayMode := "table"
-	expectedPlacement := "bottom"
+	wantDisplayMode := "table"
+	wantPlacement := "bottom"
 
 	kind := value.Get("type").String()
-	if kind == "row" {
+	if kind == "row" || kind == "piechart" {
 		return
 	}
 	optionsData := value.Get("options")
 	if legendData := optionsData.Get("legend"); legendData.Exists() {
-		legendDisplayeMode := legendData.Get("displayMode").String()
+		legendDisplayMode := legendData.Get("displayMode").String()
 		legendPlacementData := legendData.Get("placement").String()
 		title := value.Get("title").String()
-		if calcsData := legendData.Get("calcs"); calcsData.Exists() {
-			var calcsSlice []string
-			calcsData.ForEach(func(key, val gjson.Result) bool {
-				calcsSlice = append(calcsSlice, val.String())
-				return true
-			})
-			checkCalcs(t, calcsSlice, expectedCals, dashPath, title)
+		calcsData := legendData.Get("calcs").Array()
+		var calcsSlice []string
+		for _, result := range calcsData {
+			calcsSlice = append(calcsSlice, result.String())
+		}
+		checkLegendCalculations(t, calcsSlice, dashPath, title)
+
+		// Skip hidden legends
+		if legendDisplayMode == "hidden" {
+			return
+		}
+		if legendDisplayMode != wantDisplayMode {
+			t.Errorf(`dashboard=%s, panel="%s", display mode want=%s got=%s val %v`, dashPath, title, wantDisplayMode, legendDisplayMode, legendData)
 		}
 
-		// Few legends are hidden intentionally, so skipping them for testing
-		if legendDisplayeMode != "hidden" {
-			if legendDisplayeMode != expectedDisplayMode && legendDisplayeMode != "hidden" {
-				t.Errorf("dashboard=%s, panel=%s, display mode want=%s got=%s val %v", dashPath, title, expectedDisplayMode, legendDisplayeMode, legendData)
-			}
-
-			if legendPlacementData != expectedPlacement {
-				t.Errorf("dashboard=%s, panel=%s, legend placement want=%s got=%s val %v", dashPath, title, expectedPlacement, legendPlacementData, legendData)
-			}
+		if legendPlacementData != wantPlacement {
+			t.Errorf(`dashboard=%s, panel="%s", legend placement want=%s got=%s val %v`, dashPath, title, wantPlacement, legendPlacementData, legendData)
 		}
 	}
 }
 
-func checkCalcs(t *testing.T, calcsSlice []string, expected []string, dashPath, title string) {
-	calcsSliceAll := strings.Join(calcsSlice, ",")
-	for _, expectedCal := range expected {
-		// Ignoring when `sum` exist in calculations
-		if !strings.Contains(calcsSliceAll, expectedCal) && !strings.Contains(calcsSliceAll, "sum") {
-			t.Errorf("dashboard=%s, panel=%s, calculation section(s) %s not found", dashPath, title, expectedCal)
+func checkLegendCalculations(t *testing.T, gotLegendCalculations []string, dashPath, title string) {
+	wantLegendNoMin := strings.Join([]string{"mean", "lastNotNull", "max"}, ",")
+	wantLegendWithMin := "min," + wantLegendNoMin
+	got := strings.Join(gotLegendCalculations, ",")
+	if strings.Contains(got, "sum") {
+		return
+	}
+	if strings.Contains(got, "min") {
+		if got != wantLegendWithMin {
+			t.Errorf(`dashboard=%s, panel="%s", got=[%s] want=[%s]`, dashPath, title, got, wantLegendWithMin)
+		}
+	} else {
+		if got != wantLegendNoMin {
+			t.Errorf(`dashboard=%s, panel="%s", got=[%s] want=[%s]`, dashPath, title, got, wantLegendNoMin)
 		}
 	}
-
 }

--- a/cmd/tools/grafana/dashboard_test.go
+++ b/cmd/tools/grafana/dashboard_test.go
@@ -642,3 +642,70 @@ func visitAllPanels(data []byte, handle func(path string, key gjson.Result, valu
 		return true
 	})
 }
+
+func TestLegends(t *testing.T) {
+	dir := "../../../grafana/dashboards/cmode"
+	visitDashboards(dir, func(path string, data []byte) {
+		checkLegends(t, path, data)
+	})
+}
+
+func checkLegends(t *testing.T, path string, data []byte) {
+	// collect all legends
+	dashPath := shortPath(path)
+	gjson.GetBytes(data, "panels").ForEach(func(key, value gjson.Result) bool {
+		doLegends(t, value, dashPath)
+		value.Get("panels").ForEach(func(key2, value2 gjson.Result) bool {
+			doLegends(t, value2, dashPath)
+			return true
+		})
+		return true
+	})
+}
+
+func doLegends(t *testing.T, value gjson.Result, dashPath string) {
+	expectedCals := []string{"mean", "lastNotNull", "max"}
+	expectedDisplayMode := "table"
+	expectedPlacement := "bottom"
+
+	kind := value.Get("type").String()
+	if kind == "row" {
+		return
+	}
+	optionsData := value.Get("options")
+	if legendData := optionsData.Get("legend"); legendData.Exists() {
+		legendDisplayeMode := legendData.Get("displayMode").String()
+		legendPlacementData := legendData.Get("placement").String()
+		title := value.Get("title").String()
+		if calcsData := legendData.Get("calcs"); calcsData.Exists() {
+			var calcsSlice []string
+			calcsData.ForEach(func(key, val gjson.Result) bool {
+				calcsSlice = append(calcsSlice, val.String())
+				return true
+			})
+			checkCalcs(t, calcsSlice, expectedCals, dashPath, title)
+		}
+
+		// Few legends are hidden intentionally, so skipping them for testing
+		if legendDisplayeMode != "hidden" {
+			if legendDisplayeMode != expectedDisplayMode && legendDisplayeMode != "hidden" {
+				t.Errorf("dashboard=%s, panel=%s, display mode want=%s got=%s val %v", dashPath, title, expectedDisplayMode, legendDisplayeMode, legendData)
+			}
+
+			if legendPlacementData != expectedPlacement {
+				t.Errorf("dashboard=%s, panel=%s, legend placement want=%s got=%s val %v", dashPath, title, expectedPlacement, legendPlacementData, legendData)
+			}
+		}
+	}
+}
+
+func checkCalcs(t *testing.T, calcsSlice []string, expected []string, dashPath, title string) {
+	calcsSliceAll := strings.Join(calcsSlice, ",")
+	for _, expectedCal := range expected {
+		// Ignoring when `sum` exist in calculations
+		if !strings.Contains(calcsSliceAll, expectedCal) && !strings.Contains(calcsSliceAll, "sum") {
+			t.Errorf("dashboard=%s, panel=%s, calculation section(s) %s not found", dashPath, title, expectedCal)
+		}
+	}
+
+}

--- a/grafana/dashboards/cmode/cdot.json
+++ b/grafana/dashboards/cmode/cdot.json
@@ -1649,7 +1649,8 @@
             "legend": {
               "calcs": [
                 "mean",
-                "lastNotNull"
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"
@@ -1670,7 +1671,7 @@
               "refId": "A"
             }
           ],
-          "title": "Top Average Throughput by Volumes ",
+          "title": "Top Average Throughput by Volumes",
           "transformations": [],
           "type": "timeseries"
         },

--- a/grafana/dashboards/cmode/cluster.json
+++ b/grafana/dashboards/cmode/cluster.json
@@ -2889,9 +2889,9 @@
           "options": {
             "legend": {
               "calcs": [
-                "max",
                 "mean",
-                "last"
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"
@@ -2980,9 +2980,9 @@
           "options": {
             "legend": {
               "calcs": [
-                "max",
                 "mean",
-                "last"
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"

--- a/grafana/dashboards/cmode/lun.json
+++ b/grafana/dashboards/cmode/lun.json
@@ -3299,7 +3299,9 @@
           "options": {
             "legend": {
               "calcs": [
-                "lastNotNull"
+                "mean",
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"
@@ -3387,7 +3389,9 @@
           "options": {
             "legend": {
               "calcs": [
-                "lastNotNull"
+                "mean",
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"
@@ -3850,9 +3854,9 @@
           "options": {
             "legend": {
               "calcs": [
-                "max",
                 "mean",
-                "last"
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"
@@ -3944,9 +3948,9 @@
           "options": {
             "legend": {
               "calcs": [
-                "max",
                 "mean",
-                "last"
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"
@@ -4038,9 +4042,9 @@
           "options": {
             "legend": {
               "calcs": [
-                "max",
                 "mean",
-                "last"
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"
@@ -4145,9 +4149,9 @@
           "options": {
             "legend": {
               "calcs": [
-                "max",
                 "mean",
-                "last"
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"
@@ -4239,9 +4243,9 @@
           "options": {
             "legend": {
               "calcs": [
-                "max",
                 "mean",
-                "last"
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"
@@ -4375,9 +4379,9 @@
           "options": {
             "legend": {
               "calcs": [
-                "max",
                 "mean",
-                "last"
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"

--- a/grafana/dashboards/cmode/node.json
+++ b/grafana/dashboards/cmode/node.json
@@ -2796,9 +2796,9 @@
           "options": {
             "legend": {
               "calcs": [
-                "max",
                 "mean",
-                "last"
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"
@@ -2891,9 +2891,9 @@
           "options": {
             "legend": {
               "calcs": [
-                "max",
                 "mean",
-                "last"
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"
@@ -2987,9 +2987,9 @@
           "options": {
             "legend": {
               "calcs": [
-                "max",
                 "mean",
-                "last"
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"

--- a/grafana/dashboards/cmode/power.json
+++ b/grafana/dashboards/cmode/power.json
@@ -562,9 +562,9 @@
       "options": {
         "legend": {
           "calcs": [
-            "max",
             "mean",
-            "last"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -669,9 +669,9 @@
       "options": {
         "legend": {
           "calcs": [
-            "max",
             "mean",
-            "last"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -760,9 +760,9 @@
       "options": {
         "legend": {
           "calcs": [
-            "max",
             "mean",
-            "last"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -850,9 +850,9 @@
       "options": {
         "legend": {
           "calcs": [
-            "max",
             "mean",
-            "last"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -941,9 +941,9 @@
       "options": {
         "legend": {
           "calcs": [
-            "max",
             "mean",
-            "last"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"

--- a/grafana/dashboards/cmode/qtree.json
+++ b/grafana/dashboards/cmode/qtree.json
@@ -520,8 +520,8 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"
@@ -607,8 +607,8 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"

--- a/grafana/dashboards/cmode/qtree.json
+++ b/grafana/dashboards/cmode/qtree.json
@@ -519,6 +519,7 @@
             "legend": {
               "calcs": [
                 "min",
+                "mean",
                 "max",
                 "lastNotNull"
               ],
@@ -605,6 +606,7 @@
             "legend": {
               "calcs": [
                 "min",
+                "mean",
                 "max",
                 "lastNotNull"
               ],

--- a/grafana/dashboards/cmode/shelf.json
+++ b/grafana/dashboards/cmode/shelf.json
@@ -1440,9 +1440,9 @@
       "options": {
         "legend": {
           "calcs": [
-            "max",
             "mean",
-            "last"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1531,9 +1531,9 @@
       "options": {
         "legend": {
           "calcs": [
-            "max",
             "mean",
-            "last"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"

--- a/grafana/dashboards/cmode/snapmirror.json
+++ b/grafana/dashboards/cmode/snapmirror.json
@@ -1096,8 +1096,8 @@
           "calcs": [
             "min",
             "mean",
-            "max",
-            "lastNotNull"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1194,8 +1194,8 @@
           "calcs": [
             "min",
             "mean",
-            "max",
-            "lastNotNull"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1302,8 +1302,8 @@
           "calcs": [
             "min",
             "mean",
-            "max",
-            "lastNotNull"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1409,8 +1409,8 @@
           "calcs": [
             "min",
             "mean",
-            "max",
-            "lastNotNull"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1514,8 +1514,8 @@
           "calcs": [
             "min",
             "mean",
-            "max",
-            "lastNotNull"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1612,8 +1612,8 @@
           "calcs": [
             "min",
             "mean",
-            "max",
-            "lastNotNull"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1719,8 +1719,8 @@
           "calcs": [
             "min",
             "mean",
-            "max",
-            "lastNotNull"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1826,8 +1826,8 @@
           "calcs": [
             "min",
             "mean",
-            "max",
-            "lastNotNull"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1949,8 +1949,8 @@
           "calcs": [
             "min",
             "mean",
-            "max",
-            "lastNotNull"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -2046,8 +2046,8 @@
           "calcs": [
             "min",
             "mean",
-            "max",
-            "lastNotNull"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"

--- a/grafana/dashboards/cmode/snapmirror.json
+++ b/grafana/dashboards/cmode/snapmirror.json
@@ -1094,9 +1094,10 @@
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull",
+            "min",
+            "mean",
             "max",
-            "min"
+            "lastNotNull"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1191,9 +1192,10 @@
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull",
+            "min",
+            "mean",
             "max",
-            "min"
+            "lastNotNull"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1298,9 +1300,10 @@
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull",
+            "min",
+            "mean",
             "max",
-            "min"
+            "lastNotNull"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1404,9 +1407,10 @@
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull",
+            "min",
+            "mean",
             "max",
-            "min"
+            "lastNotNull"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1508,9 +1512,10 @@
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull",
+            "min",
+            "mean",
             "max",
-            "min"
+            "lastNotNull"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1605,9 +1610,10 @@
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull",
+            "min",
+            "mean",
             "max",
-            "min"
+            "lastNotNull"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1711,9 +1717,10 @@
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull",
+            "min",
+            "mean",
             "max",
-            "min"
+            "lastNotNull"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1817,9 +1824,10 @@
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull",
+            "min",
+            "mean",
             "max",
-            "min"
+            "lastNotNull"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1939,9 +1947,10 @@
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull",
+            "min",
+            "mean",
             "max",
-            "min"
+            "lastNotNull"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -2035,9 +2044,10 @@
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull",
+            "min",
+            "mean",
             "max",
-            "min"
+            "lastNotNull"
           ],
           "displayMode": "table",
           "placement": "bottom"

--- a/grafana/dashboards/cmode/svm.json
+++ b/grafana/dashboards/cmode/svm.json
@@ -6269,7 +6269,9 @@
           "options": {
             "legend": {
               "calcs": [
-                "mean"
+                "mean",
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"

--- a/grafana/dashboards/cmode/volume.json
+++ b/grafana/dashboards/cmode/volume.json
@@ -436,7 +436,8 @@
         "legend": {
           "calcs": [
             "mean",
-            "lastNotNull"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -526,7 +527,8 @@
         "legend": {
           "calcs": [
             "mean",
-            "lastNotNull"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom"


### PR DESCRIPTION
This PR covers these:
- calcs: should be minimum of `{mean, lastNotNull, max}`, exception: when `sum` exist, other calculation may not be exist
- displayMode: should be `table`, exception: `hidden`
- placement: `bottom`


Case1 for calculation missing:
```
    dashboard_test.go:704: dashboard=cmode/snapmirror.json, panel=Destination Relationships per Node, calculation section(s) mean not found
    dashboard_test.go:704: dashboard=cmode/snapmirror.json, panel=Destination - Break Operations, calculation section(s) mean not found
    dashboard_test.go:704: dashboard=cmode/snapmirror.json, panel=Destination - Resync Operations, calculation section(s) mean not found
    dashboard_test.go:704: dashboard=cmode/snapmirror.json, panel=Destination - Update Operations, calculation section(s) mean not found
    dashboard_test.go:704: dashboard=cmode/snapmirror.json, panel=Source Relationships per Node, calculation section(s) mean not found
    dashboard_test.go:704: dashboard=cmode/snapmirror.json, panel=Source - Break Operations, calculation section(s) mean not found
    dashboard_test.go:704: dashboard=cmode/snapmirror.json, panel=Source - Resync Operations, calculation section(s) mean not found
    dashboard_test.go:704: dashboard=cmode/snapmirror.json, panel=Source - Update Operations, calculation section(s) mean not found
    dashboard_test.go:704: dashboard=cmode/snapmirror.json, panel=Source Relationships per SVM, calculation section(s) mean not found
    dashboard_test.go:704: dashboard=cmode/snapmirror.json, panel=Destination Relationships per SVM, calculation section(s) mean not found

```

Case2 and 3 for DisplayMode and Placement:
```
    dashboard_test.go:696: dashboard=cmode/snapmirror.json, panel=Volume relationship count by relationship health, legend placement want=bottom got=right val {
                  "displayMode": "hidden",
                  "placement": "right",
                  "values": [
                    "value"
                  ]
                }

```