### PR TITLE
fix: pluginInvocationRate fix for plugins

### DIFF
--- a/cmd/collectors/commonutils.go
+++ b/cmd/collectors/commonutils.go
@@ -4,7 +4,6 @@ import (
 	"github.com/netapp/harvest/v2/cmd/tools/rest"
 	"github.com/netapp/harvest/v2/pkg/logging"
 	"github.com/netapp/harvest/v2/pkg/matrix"
-	"github.com/netapp/harvest/v2/pkg/tree/node"
 	"github.com/tidwall/gjson"
 	"strings"
 	"time"
@@ -98,29 +97,6 @@ func SetNameservice(nsDB, nsSource, nisDomain string, instance *matrix.Instance)
 	} else {
 		instance.SetLabel("nis_authentication_enabled", "false")
 	}
-}
-
-func SetPluginInterval(parentParams *node.Node, params *node.Node, logger *logging.Logger, defaultDataPollDuration time.Duration, defaultPluginDuration time.Duration) (int, error) {
-
-	volumeDataInterval := GetDataInterval(parentParams, defaultDataPollDuration)
-	pluginDataInterval := GetDataInterval(params, defaultPluginDuration)
-	logger.Debug().Float64("VolumeDataInterval", volumeDataInterval).Float64("PluginDataInterval", pluginDataInterval).Msg("Poll interval duration")
-	pluginInvocationRate := int(pluginDataInterval / volumeDataInterval)
-
-	return pluginInvocationRate, nil
-}
-
-func GetDataInterval(param *node.Node, defaultInterval time.Duration) float64 {
-	schedule := param.GetChildS("schedule")
-	if schedule != nil {
-		dataInterval := schedule.GetChildContentS("data")
-		if dataInterval != "" {
-			if durationVal, err := time.ParseDuration(dataInterval); err == nil {
-				return durationVal.Seconds()
-			}
-		}
-	}
-	return defaultInterval.Seconds()
 }
 
 // IsTimestampOlderThanDuration - timestamp units are micro seconds

--- a/cmd/collectors/rest/plugins/volume/volume.go
+++ b/cmd/collectors/rest/plugins/volume/volume.go
@@ -17,15 +17,11 @@ import (
 	"time"
 )
 
-const DefaultPluginDuration = 30 * time.Minute
-const DefaultDataPollDuration = 3 * time.Minute
-
 type Volume struct {
 	*plugin.AbstractPlugin
-	pluginInvocationRate int
-	currentVal           int
-	client               *rest.Client
-	aggrsMap             map[string]string // aggregate-uuid -> aggregate-name map
+	currentVal int
+	client     *rest.Client
+	aggrsMap   map[string]string // aggregate-uuid -> aggregate-name map
 }
 
 func New(p *plugin.AbstractPlugin) plugin.Plugin {
@@ -53,16 +49,13 @@ func (my *Volume) Init() error {
 	my.aggrsMap = make(map[string]string)
 
 	// Assigned the value to currentVal so that plugin would be invoked first time to populate cache.
-	if my.currentVal, err = collectors.SetPluginInterval(my.ParentParams, my.Params, my.Logger, DefaultDataPollDuration, DefaultPluginDuration); err != nil {
-		my.Logger.Error().Err(err).Stack().Msg("Failed while setting the plugin interval")
-		return err
-	}
+	my.currentVal = my.SetPluginInterval()
 
 	return nil
 }
 
 func (my *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
-	if my.currentVal >= my.pluginInvocationRate {
+	if my.currentVal >= my.PluginInvocationRate {
 		my.currentVal = 0
 
 		// invoke disk rest and populate info in aggrsMap

--- a/cmd/collectors/zapi/plugins/volume/volume.go
+++ b/cmd/collectors/zapi/plugins/volume/volume.go
@@ -10,18 +10,13 @@ import (
 	"github.com/netapp/harvest/v2/pkg/matrix"
 	"github.com/netapp/harvest/v2/pkg/tree/node"
 	"strconv"
-	"time"
 )
-
-const DefaultPluginDuration = 30 * time.Minute
-const DefaultDataPollDuration = 3 * time.Minute
 
 type Volume struct {
 	*plugin.AbstractPlugin
-	pluginInvocationRate int
-	currentVal           int
-	client               *zapi.Client
-	aggrsMap             map[string]string // aggregate-uuid -> aggregate-name map
+	currentVal int
+	client     *zapi.Client
+	aggrsMap   map[string]string // aggregate-uuid -> aggregate-name map
 }
 
 type aggrData struct {
@@ -53,16 +48,14 @@ func (my *Volume) Init() error {
 	my.aggrsMap = make(map[string]string)
 
 	// Assigned the value to currentVal so that plugin would be invoked first time to populate cache.
-	if my.currentVal, err = collectors.SetPluginInterval(my.ParentParams, my.Params, my.Logger, DefaultDataPollDuration, DefaultPluginDuration); err != nil {
-		my.Logger.Error().Err(err).Stack().Msg("Failed while setting the plugin interval")
-	}
+	my.currentVal = my.SetPluginInterval()
 
 	return nil
 }
 
 func (my *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 
-	if my.currentVal >= my.pluginInvocationRate {
+	if my.currentVal >= my.PluginInvocationRate {
 		my.currentVal = 0
 
 		// invoke disk-encrypt-get-iter zapi and populate disk info

--- a/conf/rest/9.12.0/volume.yaml
+++ b/conf/rest/9.12.0/volume.yaml
@@ -65,7 +65,7 @@ endpoints:
 plugins:
   - Volume:
       schedule:
-        - data: 900s  # should be multiple of data poll duration
+        - data: 15m  # should be multiple of poll duration
   - MetricAgent:
       compute_metric:
         - inode_used_percent PERCENT inode_files_used inode_files_total


### PR DESCRIPTION
Invoking the volume object in Rest.
Before the changes:
```
hardikl@hardikl-mac-2 harvest % ./bin/poller -p cluster-03 --promPort 14010 -c Rest -o Volume
2022-12-13T19:07:57+05:30 INF ./poller.go:202 > Init Poller=cluster-03 configPath=./harvest.yml logLevel=info version="harvest version 22.12.1319-v22.11.1 (commit 6b7e48e2) (build date 2022-12-13T19:00:56+0530) darwin/amd64\n"
2022-12-13T19:07:57+05:30 INF ./poller.go:239 > started in foreground Poller=cluster-03 pid=18697
2022-12-13T19:07:58+05:30 INF collector/helpers.go:139 > best-fit template Poller=cluster-03 collector=Rest:Volume path=conf/rest/9.12.0/volume.yaml v=9.12.1
2022-12-13T19:07:59+05:30 INF ./poller.go:371 > Autosupport scheduled. Poller=cluster-03 asupSchedule=24h
2022-12-13T19:07:59+05:30 INF prometheus/httpd.go:29 > http server listen Poller=cluster-03 addr= exporter=prometheus1 port=14010
2022-12-13T19:07:59+05:30 INF ./poller.go:380 > poller start-up complete Poller=cluster-03
2022-12-13T19:07:59+05:30 INF ./poller.go:528 > updated status, up collectors: 1 (of 1), up exporters: 1 (of 1) Poller=cluster-03
2022-12-13T19:07:59+05:30 INF volume/volume.go:68 > inside plugin Poller=cluster-03 object=Volume plugin=Rest:Volume
2022-12-13T19:07:59+05:30 INF collector/collector.go:483 > Collected Poller=cluster-03 apiMs=249 calcMs=0 collector=Rest:Volume instances=1 metrics=45 parseMs=310 pluginMs=332
2022-12-13T19:09:00+05:30 INF volume/volume.go:68 > inside plugin Poller=cluster-03 object=Volume plugin=Rest:Volume
2022-12-13T19:09:01+05:30 INF collector/collector.go:483 > Collected Poller=cluster-03 apiMs=873 calcMs=0 collector=Rest:Volume instances=1 metrics=45 parseMs=306 pluginMs=961
2022-12-13T19:10:00+05:30 INF volume/volume.go:68 > inside plugin Poller=cluster-03 object=Volume plugin=Rest:Volume
2022-12-13T19:10:01+05:30 INF collector/collector.go:483 > Collected Poller=cluster-03 apiMs=776 calcMs=0 collector=Rest:Volume instances=1 metrics=45 parseMs=306 pluginMs=941
2022-12-13T19:11:00+05:30 INF volume/volume.go:68 > inside plugin Poller=cluster-03 object=Volume plugin=Rest:Volume
2022-12-13T19:11:01+05:30 INF collector/collector.go:483 > Collected Poller=cluster-03 apiMs=868 calcMs=0 collector=Rest:Volume instances=1 metrics=45 parseMs=257 pluginMs=809
```


After the changes:
```
hardikl@hardikl-mac-2 harvest % ./bin/poller -p cluster-03 --promPort 14010 -c Rest -o Volume
2022-12-14T14:47:14+05:30 INF ./poller.go:202 > Init Poller=cluster-03 configPath=./harvest.yml logLevel=info version="harvest version 22.12.1414-v22.11.1 (commit 6b7e48e2) (build date 2022-12-14T14:46:23+0530) darwin/amd64\n"
2022-12-14T14:47:14+05:30 INF ./poller.go:239 > started in foreground Poller=cluster-03 pid=94168
2022-12-14T14:47:15+05:30 INF collector/helpers.go:139 > best-fit template Poller=cluster-03 collector=Rest:Volume path=conf/rest/9.12.0/volume.yaml v=9.12.1
2022-12-14T14:47:17+05:30 INF plugin/plugin.go:159 > PluginInterval=900 PluginInvocationRate=5 PollInterval=180 Poller=cluster-03 object=Volume plugin=Rest:Volume
2022-12-14T14:47:17+05:30 INF ./poller.go:371 > Autosupport scheduled. Poller=cluster-03 asupSchedule=24h
2022-12-14T14:47:17+05:30 INF ./poller.go:380 > poller start-up complete Poller=cluster-03
2022-12-14T14:47:17+05:30 INF prometheus/httpd.go:29 > http server listen Poller=cluster-03 addr= exporter=prometheus1 port=14010
2022-12-14T14:47:17+05:30 INF ./poller.go:528 > updated status, up collectors: 1 (of 1), up exporters: 1 (of 1) Poller=cluster-03
2022-12-14T14:47:19+05:30 INF volume/volume.go:61 > inside plugin Poller=cluster-03 object=Volume plugin=Rest:Volume
2022-12-14T14:47:20+05:30 INF collector/collector.go:483 > Collected Poller=cluster-03 apiMs=1944 calcMs=0 collector=Rest:Volume instances=1 metrics=45 parseMs=512 pluginMs=820
2022-12-14T14:48:19+05:30 INF collector/collector.go:483 > Collected Poller=cluster-03 apiMs=1239 calcMs=0 collector=Rest:Volume instances=1 metrics=45 parseMs=608 pluginMs=0
2022-12-14T14:49:18+05:30 INF collector/collector.go:483 > Collected Poller=cluster-03 apiMs=855 calcMs=0 collector=Rest:Volume instances=1 metrics=45 parseMs=702 pluginMs=0
2022-12-14T14:50:19+05:30 INF volume/volume.go:61 > inside plugin Poller=cluster-03 object=Volume plugin=Rest:Volume
2022-12-14T14:50:20+05:30 INF collector/collector.go:483 > Collected Poller=cluster-03 apiMs=1327 calcMs=0 collector=Rest:Volume instances=1 metrics=45 parseMs=581 pluginMs=1151
2022-12-14T14:51:18+05:30 INF collector/collector.go:483 > Collected Poller=cluster-03 apiMs=857 calcMs=0 collector=Rest:Volume instances=1 metrics=45 parseMs=289 pluginMs=0
2022-12-14T14:52:18+05:30 INF collector/collector.go:483 > Collected Poller=cluster-03 apiMs=948 calcMs=0 collector=Rest:Volume instances=1 metrics=45 parseMs=425 pluginMs=0
2022-12-14T14:53:18+05:30 INF volume/volume.go:61 > inside plugin Poller=cluster-03 object=Volume plugin=Rest:Volume
2022-12-14T14:53:20+05:30 INF collector/collector.go:483 > Collected Poller=cluster-03 apiMs=1054 calcMs=0 collector=Rest:Volume instances=1 metrics=45 parseMs=525 pluginMs=1187
2022-12-14T14:54:18+05:30 INF collector/collector.go:483 > Collected Poller=cluster-03 apiMs=1063 calcMs=0 collector=Rest:Volume instances=1 metrics=45 parseMs=302 pluginMs=0
2022-12-14T14:55:19+05:30 INF collector/collector.go:483 > Collected Poller=cluster-03 apiMs=1275 calcMs=0 collector=Rest:Volume instances=1 metrics=45 parseMs=609 pluginMs=0
```


