### PR TITLE
fix: removing status metric in security_cert as nowhere used

### DIFF
--- a/cmd/collectors/zapi/plugins/certificate/certificate.go
+++ b/cmd/collectors/zapi/plugins/certificate/certificate.go
@@ -93,14 +93,14 @@ func (my *Certificate) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 		}
 
 		// update certificate instance based on admin vaserver serial
-		for _, certificateInstance := range data.GetInstances() {
+		for certificateInstanceKey, certificateInstance := range data.GetInstances() {
 			if certificateInstance.IsExportable() {
 				certificateInstance.SetExportable(false)
 				serialNumber := certificateInstance.GetLabel("serial_number")
 
 				if serialNumber == adminVserverSerial {
 					certificateInstance.SetExportable(true)
-					my.setCertificateIssuerType(certificateInstance)
+					my.setCertificateIssuerType(certificateInstance, certificateInstanceKey)
 					my.setCertificateValidity(data, certificateInstance)
 				}
 			}
@@ -112,17 +112,16 @@ func (my *Certificate) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 	return nil, nil
 }
 
-func (my *Certificate) setCertificateIssuerType(instance *matrix.Instance) {
+func (my *Certificate) setCertificateIssuerType(instance *matrix.Instance, certificateInstanceKey string) {
 	var (
 		cert *x509.Certificate
 		err  error
 	)
 
 	certificatePEM := instance.GetLabel("certificatePEM")
-	certUUID := instance.GetLabel("uuid")
 
 	if certificatePEM == "" {
-		my.Logger.Debug().Str("uuid", certUUID).Msg("Certificate is not found")
+		my.Logger.Debug().Str("certificateInstanceKey", certificateInstanceKey).Msg("Certificate is not found")
 		instance.SetLabel("certificateIssuerType", "unknown")
 	} else {
 		instance.SetLabel("certificateIssuerType", "self_signed")

--- a/conf/rest/9.12.0/security_certificate.yaml
+++ b/conf/rest/9.12.0/security_certificate.yaml
@@ -17,9 +17,6 @@ counters:
       - type="server"
 
 plugins:
-  - LabelAgent:
-      value_to_num:
-        - status name - - `0`
   - Certificate:
       schedule:
         - data: 180s  # should be multiple of data poll duration

--- a/conf/zapi/cdot/9.8.0/security_certificate.yaml
+++ b/conf/zapi/cdot/9.8.0/security_certificate.yaml
@@ -16,8 +16,6 @@ plugins:
   - LabelAgent:
       include_equals:
         - type `server`
-      value_to_num:
-        - status name - - `0`
   - Certificate:
       schedule:
         - data: 180s  # should be multiple of data poll duration


### PR DESCRIPTION
Compared ZAPI and REST, 

Security_certificate would have 2 metrics, 
1. security_certitifcate_labels which contains all labels
2. security_certificate_expiry_time timestamp of expiry


<img width="1772" alt="image" src="https://user-images.githubusercontent.com/83282894/210987312-23700bf5-eb7c-4da1-9309-e6ad0eb2fc40.png">



<img width="1758" alt="image" src="https://user-images.githubusercontent.com/83282894/210987201-8fb9a7bc-1064-420b-8030-770c49daba3f.png">
