### PR TITLE
fix: exclude node/svm vols and include data svms

### DIFF
--- a/conf/zapi/cdot/9.8.0/svm.yaml
+++ b/conf/zapi/cdot/9.8.0/svm.yaml
@@ -8,6 +8,7 @@ counters:
     - ^^uuid                                  => svm_uuid
     - ^vserver-name                           => svm
     - ^state                                  => state
+    - ^vserver-type                           => type
     - ^anti-ransomware-default-volume-state   => anti_ransomware_state
     - name-server-switch:
         - ^nsswitch                           => nameservice_switch
@@ -19,6 +20,8 @@ plugins:
       schedule:
         - data: 900s  # should be multiple of data poll duration
   - LabelAgent:
+      include_equals:
+        - type `data`
       value_to_num:
         - new_status state online online `0`
         - ldap_signed ldap_session_security sign sign `0`
@@ -47,3 +50,4 @@ export_options:
     - nfs_kerberos_protocol_enabled
     - smb_encryption_required
     - smb_signing_required
+    - type

--- a/conf/zapi/cdot/9.8.0/volume.yaml
+++ b/conf/zapi/cdot/9.8.0/volume.yaml
@@ -59,6 +59,8 @@ counters:
     - volume-state-attributes:
       - ^state
       - ^status
+      - ^is-node-root                       => node_root
+      - ^is-vserver-root                    => svm_root
 
     - volume-snapshot-attributes:
       - ^auto-snapshots-enabled             => auto_snapshots_enabled
@@ -79,6 +81,8 @@ plugins:
       - new_status state online online `0`
     exclude_equals:
       - style `flexgroup_constituent`
+      - node_root `true`
+      - svm_root `true`
     # To prevent visibility of transient volumes, uncomment the following lines
 #    exclude_regex:
 #      # Exclude SnapProtect/CommVault Intellisnap, Clone volumes have a “_CVclone” suffix
@@ -112,4 +116,6 @@ export_options:
     - type
     - isEncrypted
     - isHardwareEncrypted
+    - svm_root
+    - node_root
 


### PR DESCRIPTION
Naming conventions
volume
- svm_root volume name: xxx_root
- node_root volume name: vol0

SVM
- system_svm: cluster
- node_svm: node name
- admin_svm: cluster name

**Before applying on template level filter**


Volume:
svm_root: 16
![image](https://user-images.githubusercontent.com/83282894/212044855-b7aa79a5-3f97-48fd-98ab-126adfcc0805.png)

node_root:2
![image](https://user-images.githubusercontent.com/83282894/212044905-b312df6b-66db-49d1-b020-b02ea2000e42.png)

total volume:527
![image](https://user-images.githubusercontent.com/83282894/212044974-1151c3cb-304a-4cba-ad12-fc31609fb52a.png)

SVM:
data svm:17
![image](https://user-images.githubusercontent.com/83282894/212045797-0826b538-c558-417f-a2d4-a02e1739f3a8.png)

node,system,admin svm: 4
![image](https://user-images.githubusercontent.com/83282894/212046005-1e3bf4de-18e7-462b-98df-14daf86e3bbc.png)

total svm: 21
![image](https://user-images.githubusercontent.com/83282894/212045898-ba686db6-fb5f-4b5a-9a9c-9051a5f84e51.png)


**After applying the template level filter**
Volume:
total volume: 509
![image](https://user-images.githubusercontent.com/83282894/212083100-b7474047-2140-4115-a94b-3c1b35760d95.png)


SVM:
total svm: 17
![image](https://user-images.githubusercontent.com/83282894/212081655-da9a3498-7162-4b08-9ec4-e926abd998fa.png)
