### PR TITLE
feat: support aggr filter chnages in zapiperf

### DIFF
--- a/cmd/collectors/restperf/plugins/volume/volume.go
+++ b/cmd/collectors/restperf/plugins/volume/volume.go
@@ -57,8 +57,8 @@ func (me *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 				fg.SetLabel("style", "flexgroup")
 			}
 
-			flexgroupInstance, err := volumeAggrmetric.NewInstance(key)
-			if err == nil {
+			if volumeAggrmetric.GetInstance(key) == nil {
+				flexgroupInstance, _ := volumeAggrmetric.NewInstance(key)
 				flexgroupInstance.SetLabels(i.GetLabels().Copy())
 				flexgroupInstance.SetLabel("volume", match[1])
 				// Flexgroup don't show any node

--- a/cmd/collectors/zapiperf/plugins/volume/volume.go
+++ b/cmd/collectors/zapiperf/plugins/volume/volume.go
@@ -64,8 +64,8 @@ func (me *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 				fg.SetLabel("style", "flexgroup")
 			}
 
-			flexgroupInstance, err := volumeAggrmetric.NewInstance(key)
-			if err == nil {
+			if volumeAggrmetric.GetInstance(key) == nil {
+				flexgroupInstance, _ := volumeAggrmetric.NewInstance(key)
 				flexgroupInstance.SetLabels(i.GetLabels().Copy())
 				flexgroupInstance.SetLabel("volume", match[1])
 				// Flexgroup don't show any node

--- a/cmd/collectors/zapiperf/plugins/volume/volume.go
+++ b/cmd/collectors/zapiperf/plugins/volume/volume.go
@@ -41,7 +41,7 @@ func (me *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 
 	metric, err := volumeAggrmetric.NewMetricFloat64(metricName)
 	if err != nil {
-		me.Logger.Error().Stack().Err(err).Msg("add metric")
+		me.Logger.Error().Err(err).Msg("add metric")
 		return nil, err
 	}
 	me.Logger.Trace().Msgf("added metric: (%s) %v", metricName, metric)
@@ -72,14 +72,11 @@ func (me *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 				flexgroupInstance.SetLabel("node", "")
 				flexgroupInstance.SetLabel("style", "flexgroup")
 				flexgroupAggrsMap[key] = set.New()
-				flexgroupAggrsMap[key].Add(i.GetLabel("aggr"))
 				if err := metric.SetValueFloat64(flexgroupInstance, 1); err != nil {
-					me.Logger.Error().Stack().Err(err).Str("metric", metricName).Msg("Unable to set value on metric")
+					me.Logger.Error().Err(err).Str("metric", metricName).Msg("Unable to set value on metric")
 				}
-			} else {
-				// update the aggrMap at each flexgroup constituent
-				flexgroupAggrsMap[key].Add(i.GetLabel("aggr"))
 			}
+			flexgroupAggrsMap[key].Add(i.GetLabel("aggr"))
 			i.SetLabel("style", "flexgroup_constituent")
 			i.SetExportable(false)
 		} else {
@@ -90,7 +87,7 @@ func (me *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 				flexvolInstance.SetLabels(i.GetLabels().Copy())
 				flexvolInstance.SetLabel("style", "flexvol")
 				if err := metric.SetValueFloat64(flexvolInstance, 1); err != nil {
-					me.Logger.Error().Stack().Err(err).Str("metric", metricName).Msg("Unable to set value on metric")
+					me.Logger.Error().Err(err).Str("metric", metricName).Msg("Unable to set value on metric")
 				}
 			}
 		}
@@ -118,7 +115,7 @@ func (me *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 
 			fg := cache.GetInstance(key)
 			if fg == nil {
-				me.Logger.Error().Stack().Err(nil).Msgf("instance [%s] not in local cache", key)
+				me.Logger.Error().Err(nil).Msgf("instance [%s] not in local cache", key)
 				continue
 			}
 
@@ -130,7 +127,7 @@ func (me *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 
 				fgm := cache.GetMetric(mkey)
 				if fgm == nil {
-					me.Logger.Error().Stack().Err(nil).Msgf("metric [%s] not in local cache", mkey)
+					me.Logger.Error().Err(nil).Msgf("metric [%s] not in local cache", mkey)
 					continue
 				}
 
@@ -145,7 +142,7 @@ func (me *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 
 						err := fgm.SetValueFloat64(fg, fgv+value)
 						if err != nil {
-							me.Logger.Error().Stack().Err(err).Msg("error")
+							me.Logger.Error().Err(err).Msg("error")
 						}
 						// just for debugging
 						fgv2, _ := fgm.GetValueFloat64(fg)
@@ -183,12 +180,12 @@ func (me *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 							if value != 0 {
 								err = tempOps.SetValueFloat64(fg, tempOpsV+opsValue)
 								if err != nil {
-									me.Logger.Error().Stack().Err(err).Msg("error")
+									me.Logger.Error().Err(err).Msg("error")
 								}
 							}
 							err = fgm.SetValueFloat64(fg, fgv+prod)
 							if err != nil {
-								me.Logger.Error().Stack().Err(err).Msg("error")
+								me.Logger.Error().Err(err).Msg("error")
 							}
 
 							// debugging
@@ -222,7 +219,7 @@ func (me *Volume) Run(data *matrix.Matrix) ([]*matrix.Matrix, error) {
 						if opsValue, ok := ops.GetValueFloat64(i); ok && opsValue != 0 {
 							err := m.SetValueFloat64(i, value/opsValue)
 							if err != nil {
-								me.Logger.Error().Stack().Err(err).Msgf("error")
+								me.Logger.Error().Err(err).Msgf("error")
 							}
 						} else {
 							m.SetValueNAN(i)

--- a/grafana/dashboards/cmode/aggregate.json
+++ b/grafana/dashboards/cmode/aggregate.json
@@ -3882,7 +3882,7 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "topk($TopResources, volume_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\", volume=~\"$TopVolumeSizeUsed\"} * on (cluster, svm, volume) group_left(aggr) volume_aggrs{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\",volume=~\"$TopVolumeSizeUsed\"})",
+              "expr": "topk($TopResources, volume_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\", volume=~\"$TopVolumeSizeUsed\"} * on (cluster, svm, volume) group_left(aggr) volume_aggr_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\",volume=~\"$TopVolumeSizeUsed\"})",
               "hide": false,
               "interval": "",
               "legendFormat": "{{aggr}} - {{volume}} - {{style}}",
@@ -3975,7 +3975,7 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "topk($TopResources, volume_size_used_percent{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",volume=~\"$TopVolumeSizeUsedPercent\"} * on (cluster, svm, volume) group_left(aggr) volume_aggrs{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\",volume=~\"$TopVolumeSizeUsedPercent\"})",
+              "expr": "topk($TopResources, volume_size_used_percent{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",volume=~\"$TopVolumeSizeUsedPercent\"} * on (cluster, svm, volume) group_left(aggr) volume_aggr_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\",volume=~\"$TopVolumeSizeUsedPercent\"})",
               "hide": false,
               "interval": "",
               "legendFormat": "{{aggr}} - {{volume}} - {{style}}",
@@ -4068,7 +4068,7 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "topk($TopResources, volume_snapshots_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",volume=~\"$TopVolumeSnapshotSizeUsed\"} * on (cluster, svm, volume) group_left(aggr) volume_aggrs{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\",volume=~\"$TopVolumeSnapshotSizeUsed\"})",
+              "expr": "topk($TopResources, volume_snapshots_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",volume=~\"$TopVolumeSnapshotSizeUsed\"} * on (cluster, svm, volume) group_left(aggr) volume_aggr_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\",volume=~\"$TopVolumeSnapshotSizeUsed\"})",
               "hide": false,
               "interval": "",
               "legendFormat": "{{aggr}} - {{volume}} - {{style}}",
@@ -4161,7 +4161,7 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "topk($TopResources, volume_snapshot_reserve_used_percent{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",volume=~\"$TopVolumeSnapshotSizeUsedPercent\"} * on (cluster, svm, volume) group_left(aggr) volume_aggrs{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\",volume=~\"$TopVolumeSnapshotSizeUsedPercent\"})",
+              "expr": "topk($TopResources, volume_snapshot_reserve_used_percent{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",volume=~\"$TopVolumeSnapshotSizeUsedPercent\"} * on (cluster, svm, volume) group_left(aggr) volume_aggr_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\",volume=~\"$TopVolumeSnapshotSizeUsedPercent\"})",
               "hide": false,
               "interval": "",
               "legendFormat": "{{aggr}} - {{volume}} - {{style}}",
@@ -4423,7 +4423,7 @@
       },
       {
         "current": {},
-        "definition": "query_result(topk($TopResources, avg_over_time(volume_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\"}[${__range}]) * on (cluster, svm, volume) group_left(aggr) volume_aggrs{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\"}))",
+        "definition": "query_result(topk($TopResources, avg_over_time(volume_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\"}[${__range}]) * on (cluster, svm, volume) group_left(aggr) volume_aggr_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\"}))",
         "hide": 2,
         "includeAll": true,
         "label": "",
@@ -4431,7 +4431,7 @@
         "name": "TopVolumeSizeUsed",
         "options": [],
         "query": {
-          "query": "query_result(topk($TopResources, avg_over_time(volume_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\"}[${__range}]) * on (cluster, svm, volume) group_left(aggr) volume_aggrs{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\"}))",
+          "query": "query_result(topk($TopResources, avg_over_time(volume_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\"}[${__range}]) * on (cluster, svm, volume) group_left(aggr) volume_aggr_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\"}))",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -4442,7 +4442,7 @@
       },
       {
         "current": {},
-        "definition": "query_result(topk($TopResources, avg_over_time(volume_size_used_percent{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\"}[${__range}]) * on (cluster, svm, volume) group_left(aggr) volume_aggrs{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\"}))\n",
+        "definition": "query_result(topk($TopResources, avg_over_time(volume_size_used_percent{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\"}[${__range}]) * on (cluster, svm, volume) group_left(aggr) volume_aggr_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\"}))\n",
         "hide": 2,
         "includeAll": true,
         "label": "",
@@ -4450,7 +4450,7 @@
         "name": "TopVolumeSizeUsedPercent",
         "options": [],
         "query": {
-          "query": "query_result(topk($TopResources, avg_over_time(volume_size_used_percent{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\"}[${__range}]) * on (cluster, svm, volume) group_left(aggr) volume_aggrs{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\"}))\n",
+          "query": "query_result(topk($TopResources, avg_over_time(volume_size_used_percent{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\"}[${__range}]) * on (cluster, svm, volume) group_left(aggr) volume_aggr_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\"}))\n",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -4461,7 +4461,7 @@
       },
       {
         "current": {},
-        "definition": "query_result(topk($TopResources, avg_over_time(volume_snapshots_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\"}[${__range}]) * on (cluster, svm, volume) group_left(aggr) volume_aggrs{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\"}))\n",
+        "definition": "query_result(topk($TopResources, avg_over_time(volume_snapshots_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\"}[${__range}]) * on (cluster, svm, volume) group_left(aggr) volume_aggr_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\"}))\n",
         "hide": 2,
         "includeAll": true,
         "label": "",
@@ -4469,7 +4469,7 @@
         "name": "TopVolumeSnapshotSizeUsed",
         "options": [],
         "query": {
-          "query": "query_result(topk($TopResources, avg_over_time(volume_snapshots_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\"}[${__range}]) * on (cluster, svm, volume) group_left(aggr) volume_aggrs{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\"}))\n",
+          "query": "query_result(topk($TopResources, avg_over_time(volume_snapshots_size_used{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\"}[${__range}]) * on (cluster, svm, volume) group_left(aggr) volume_aggr_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\"}))\n",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -4480,7 +4480,7 @@
       },
       {
         "current": {},
-        "definition": "query_result(topk($TopResources, avg_over_time(volume_snapshot_reserve_used_percent{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\"}[${__range}]) * on (cluster, svm, volume) group_left(aggr) volume_aggrs{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\"}))\n",
+        "definition": "query_result(topk($TopResources, avg_over_time(volume_snapshot_reserve_used_percent{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\"}[${__range}]) * on (cluster, svm, volume) group_left(aggr) volume_aggr_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\"}))\n",
         "hide": 2,
         "includeAll": true,
         "label": "",
@@ -4488,7 +4488,7 @@
         "name": "TopVolumeSnapshotSizeUsedPercent",
         "options": [],
         "query": {
-          "query": "query_result(topk($TopResources, avg_over_time(volume_snapshot_reserve_used_percent{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\"}[${__range}]) * on (cluster, svm, volume) group_left(aggr) volume_aggrs{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\"}))\n",
+          "query": "query_result(topk($TopResources, avg_over_time(volume_snapshot_reserve_used_percent{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\"}[${__range}]) * on (cluster, svm, volume) group_left(aggr) volume_aggr_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",aggr=~\".*$Aggregate.*\"}))\n",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
New `volume_aggr_labels` metric,

for Flexgroup,
<img width="1773" alt="image" src="https://user-images.githubusercontent.com/83282894/217521499-b2c3fc3c-7926-4314-a49e-1e610fb19460.png">

for Flexvol,
<img width="1768" alt="image" src="https://user-images.githubusercontent.com/83282894/217521862-cdb3119d-242d-46f8-9c17-7efea5b8b326.png">


other existing metrics,
for Flexgroup,
<img width="1772" alt="image" src="https://user-images.githubusercontent.com/83282894/217522018-abd4791b-f2b2-4785-a885-3a18cd6e29e3.png">


for Flexvol,
<img width="1764" alt="image" src="https://user-images.githubusercontent.com/83282894/217521944-38c024fa-84b0-436b-8354-4617f671400d.png">



