### PR TITLE
feat: support node aggregation for flexgroup also

### DIFF
--- a/conf/restperf/9.12.0/volume.yaml
+++ b/conf/restperf/9.12.0/volume.yaml
@@ -21,11 +21,11 @@ counters:
   - average_latency        => avg_latency
 
 plugins:
-  - Volume
   - Aggregator:
       # plugin will create summary/average for each object
       # any names after the object names will be treated as label names that will be added to instances
       - node
+  - Volume
 #  - LabelAgent:
 #      # To prevent visibility of transient volumes, uncomment the following lines
 #      exclude_regex:

--- a/conf/zapiperf/cdot/9.8.0/volume.yaml
+++ b/conf/zapiperf/cdot/9.8.0/volume.yaml
@@ -23,11 +23,11 @@ counters:
   - avg_latency
 
 plugins:
-  - Volume
   - Aggregator:
     # plugin will create summary/average for each object
     # any names after the object names will be treated as label names that will be added to instances
     - node
+  - Volume
 #  - LabelAgent:
 #      # To prevent visibility of transient volumes, uncomment the following lines
 #      exclude_regex:

--- a/grafana/dashboards/cmode/cdot.json
+++ b/grafana/dashboards/cmode/cdot.json
@@ -514,7 +514,7 @@
                   }
                 ]
               },
-              "unit": "ms"
+              "unit": "µs"
             },
             "overrides": []
           },
@@ -544,7 +544,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "topk($TopResources, avg(node_volume_avg_latency{datacenter=~\"$Datacenter\",cluster=~\"$TopAvgLatency\"}) by (cluster)) / 1000",
+              "expr": "topk($TopResources, avg(node_volume_avg_latency{datacenter=~\"$Datacenter\",cluster=~\"$TopAvgLatency\"}) by (cluster))",
               "interval": "",
               "legendFormat": "{{cluster}}",
               "refId": "A"

--- a/grafana/dashboards/cmode/cluster.json
+++ b/grafana/dashboards/cmode/cluster.json
@@ -334,7 +334,7 @@
               }
             ]
           },
-          "unit": "MBs"
+          "unit": "Bps"
         },
         "overrides": [
           {
@@ -374,7 +374,7 @@
         {
           "datasource": "${DS_PROMETHEUS}",
           "exemplar": false,
-          "expr": "topk($TopResources, sum(node_volume_read_data{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$TopVolumeTotalData\"}) by (node) + sum(node_volume_write_data{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$TopVolumeTotalData\"}) by(node)) / 1000000",
+          "expr": "topk($TopResources, sum(node_volume_read_data{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$TopVolumeTotalData\"}) by (node) + sum(node_volume_write_data{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$TopVolumeTotalData\"}) by(node))",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -754,7 +754,7 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "µs"
         },
         "overrides": []
       },
@@ -785,7 +785,7 @@
         {
           "datasource": "${DS_PROMETHEUS}",
           "exemplar": true,
-          "expr": "topk($TopResources, sum(node_volume_avg_latency{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\", node=~\"$TopVolumeAvgLatency\"}) by (node)) / 1000",
+          "expr": "topk($TopResources, sum(node_volume_avg_latency{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\", node=~\"$TopVolumeAvgLatency\"}) by (node))",
           "interval": "",
           "legendFormat": "{{node}}",
           "refId": "A"
@@ -845,7 +845,7 @@
               }
             ]
           },
-          "unit": "MBs"
+          "unit": "Bps"
         },
         "overrides": []
       },
@@ -876,7 +876,7 @@
         {
           "datasource": "${DS_PROMETHEUS}",
           "exemplar": true,
-          "expr": "topk($TopResources, sum(node_volume_read_data{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\", node=~\"$TopVolumeTotalData\"}) by (node) + sum(node_volume_write_data{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\", node=~\"$TopVolumeTotalData\"}) by(node)) / 1000000",
+          "expr": "topk($TopResources, sum(node_volume_read_data{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\", node=~\"$TopVolumeTotalData\"}) by (node) + sum(node_volume_write_data{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\", node=~\"$TopVolumeTotalData\"}) by(node))",
           "interval": "",
           "legendFormat": "{{node}}",
           "refId": "A"

--- a/grafana/dashboards/cmode/node.json
+++ b/grafana/dashboards/cmode/node.json
@@ -2031,7 +2031,7 @@
             {
               "exemplar": false,
               "expr": "abs(avg(wafl_cp_phase_times{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\",metric=\"P2_FLUSH\"}) - 100)",
-              "hide": true,
+              "hide": false,
               "interval": "",
               "legendFormat": "WAFL Write Cleaning",
               "refId": "D"

--- a/grafana/dashboards/cmode/node.json
+++ b/grafana/dashboards/cmode/node.json
@@ -295,7 +295,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "avg(volume_avg_latency{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})/1000",
+          "expr": "avg(node_volume_avg_latency{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})/1000",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -351,7 +351,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "sum(volume_write_data+volume_read_data{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
+          "expr": "sum(node_volume_write_data+node_volume_read_data{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -407,7 +407,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "sum(volume_total_ops{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
+          "expr": "sum(node_volume_total_ops{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -553,7 +553,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "avg by(node) (volume_avg_latency{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
+          "expr": "avg by(node) (node_volume_avg_latency{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
           "interval": "",
           "legendFormat": "{{node}}",
           "refId": "A"
@@ -644,7 +644,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "sum by (node) (volume_write_data+volume_read_data{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
+          "expr": "sum by (node) (node_volume_write_data+node_volume_read_data{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
           "interval": "",
           "legendFormat": "{{node}}",
           "refId": "A"
@@ -735,7 +735,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "sum by(node) (volume_total_ops{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
+          "expr": "sum by(node) (node_volume_total_ops{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
           "interval": "",
           "legendFormat": "{{node}}",
           "refId": "A"
@@ -1796,7 +1796,7 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "sum(volume_read_data{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
+              "expr": "sum(node_volume_read_data{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "Read",
@@ -1804,7 +1804,7 @@
             },
             {
               "exemplar": false,
-              "expr": "sum(volume_write_data{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
+              "expr": "sum(node_volume_write_data{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "Write",
@@ -1896,21 +1896,21 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "sum(volume_read_ops{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
+              "expr": "sum(node_volume_read_ops{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
               "interval": "",
               "legendFormat": "Read",
               "refId": "A"
             },
             {
               "exemplar": false,
-              "expr": "sum(volume_write_ops{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
+              "expr": "sum(node_volume_write_ops{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
               "interval": "",
               "legendFormat": "Write",
               "refId": "B"
             },
             {
               "exemplar": false,
-              "expr": "sum(volume_other_ops{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
+              "expr": "sum(node_volume_other_ops{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"})",
               "interval": "",
               "legendFormat": "Other",
               "refId": "C"


### PR DESCRIPTION
Node aggregation for volume perf metrics are used in these panels:
1. Node dashbord: 
Backend Drilldown panels: -> Values are matching with 1.6

2. Cdot dashboard:
Used avg of node_volume_avg_latency.  

3. Cluster dashboard:
Highlight panels: --> values are matching with 1.6

Side changes:
- one query `WAFL Write Cleaning` was hidden in 2.0, whereas 1.6 showing the same.
- changed few units such that same metric would have same units for all dashboard.