### PR TITLE
fix: backward compatibility for qtree metrics in rest

### DIFF
--- a/conf/rest/9.12.0/qtree.yaml
+++ b/conf/rest/9.12.0/qtree.yaml
@@ -11,8 +11,6 @@ counters:
   - ^export_policy.name   => export_policy
   - ^security_style       => security_style
   - id                    => id
-  - filter:
-      - name=!""
 
 
 endpoints:
@@ -23,17 +21,18 @@ endpoints:
       - ^^qtree           => qtree
       - ^status           => status
       - ^oplock_mode      => oplocks
-      - filter:
-          - qtree=!""
+
 plugins:
+  - LabelAgent:
+      exclude_equals:
+        - qtree ``
+      replace:
+        - oplocks oplocks `enable` `enabled`
   - Qtree:
       quotaType:
         - tree
 #        - user
 #        - group
-  - LabelAgent:
-      replace:
-        - oplocks oplocks `enable` `enabled`
 
 export_options:
   instance_keys:

--- a/conf/rest/9.12.0/qtree.yaml
+++ b/conf/rest/9.12.0/qtree.yaml
@@ -11,6 +11,8 @@ counters:
   - ^export_policy.name   => export_policy
   - ^security_style       => security_style
   - id                    => id
+  - filter:
+      - name=!""
 
 
 endpoints:
@@ -21,11 +23,10 @@ endpoints:
       - ^^qtree           => qtree
       - ^status           => status
       - ^oplock_mode      => oplocks
-
+      - filter:
+          - qtree=!""
 plugins:
   - LabelAgent:
-      exclude_equals:
-        - qtree ``
       replace:
         - oplocks oplocks `enable` `enabled`
   - Qtree:

--- a/conf/rest/9.12.0/qtree.yaml
+++ b/conf/rest/9.12.0/qtree.yaml
@@ -26,14 +26,14 @@ endpoints:
       - filter:
           - qtree=!""
 plugins:
-  - LabelAgent:
-      replace:
-        - oplocks oplocks `enable` `enabled`
   - Qtree:
       quotaType:
         - tree
 #        - user
 #        - group
+  - LabelAgent:
+      replace:
+        - oplocks oplocks `enable` `enabled`
 
 export_options:
   instance_keys:


### PR DESCRIPTION
Tested with REST collector, 
metrics behaviour in Harvest 22.05 

**qtree_labels:**
<img width="1766" alt="image" src="https://user-images.githubusercontent.com/83282894/222110191-f9b3ebaa-ada7-4af4-9c65-167ebaf5f6e4.png">

**qtree_disk_limit:**
<img width="1775" alt="image" src="https://user-images.githubusercontent.com/83282894/222110481-376ae82b-7b6b-44f5-8a45-190dc70a0043.png">

**quota_disk_limit:**
<img width="1778" alt="image" src="https://user-images.githubusercontent.com/83282894/222110574-478c96b8-c619-43ea-95c4-fa0070f7fe12.png">


metrics behaviour in latest Harvest
Case1: **Same behaviour as Harvest 22.05**
with hidden key-val pair

**qtree_labels:**
<img width="1763" alt="image" src="https://user-images.githubusercontent.com/83282894/222138666-f4e83ff6-558f-4d9f-b2a9-ddae4998aa8a.png">

**qtree_disk_limit:**
<img width="1762" alt="image" src="https://user-images.githubusercontent.com/83282894/222138576-2243c286-d343-41a1-8c4c-d2d26aae6007.png">

**quota_disk_limit:**
<img width="1769" alt="image" src="https://user-images.githubusercontent.com/83282894/222138612-b44a1a21-f110-48cb-af1c-6a5c851539e9.png">



Case2: **Current Harvest behaviour**
without hidden key-val pair:

**qtree_labels:**
<img width="1778" alt="image" src="https://user-images.githubusercontent.com/83282894/222127756-89de5c9c-43e8-4c30-91a5-da4c9432a02d.png">


**qtree_disk_limit:**
<img width="1774" alt="image" src="https://user-images.githubusercontent.com/83282894/222127846-df7ebff9-869f-4c5e-ad81-2396d723b230.png">


**quota_disk_limit:**
<img width="1772" alt="image" src="https://user-images.githubusercontent.com/83282894/222127910-f04045d4-262d-4686-8dec-dcbf7f5d7dc1.png">
