### PR TITLE
fix: user read|write panels should use power of two bytes

### DIFF
--- a/cmd/tools/grafana/units.yaml
+++ b/cmd/tools/grafana/units.yaml
@@ -3,6 +3,7 @@
 # short  turns 12990 into 13.0 K
 # locale turns 12990 into 12,990
 # string turns 12990 into 12990
+# https://github.com/grafana/grafana/blob/661e44ae6d78dbec91e62161769072f38311ab9f/packages/grafana-data/src/valueFormats/categories.ts#L144
 
 - metric: aggr_space_total
   ontapUnit: bytes

--- a/grafana/dashboards/cmode/disk.json
+++ b/grafana/dashboards/cmode/disk.json
@@ -1189,7 +1189,7 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "kbytes"
         },
         "overrides": []
       },
@@ -1284,7 +1284,7 @@
               }
             ]
           },
-          "unit": "deckbytes"
+          "unit": "kbytes"
         },
         "overrides": []
       },


### PR DESCRIPTION
Thanks to alessandro.nuzzo on [Discord](https://discord.com/channels/855068651522490400/1087393379203166258/1087393379203166258) for raising