### PR TITLE
fix: fixing security account plugin generated metrics

### DIFF
--- a/cmd/collectors/rest/plugins/securityaccount/securityaccount.go
+++ b/cmd/collectors/rest/plugins/securityaccount/securityaccount.go
@@ -11,14 +11,12 @@ import (
 	"github.com/netapp/harvest/v2/pkg/conf"
 	"github.com/netapp/harvest/v2/pkg/errs"
 	"github.com/netapp/harvest/v2/pkg/matrix"
-	"github.com/netapp/harvest/v2/pkg/tree/node"
 	"github.com/tidwall/gjson"
 	"time"
 )
 
 type SecurityAccount struct {
 	*plugin.AbstractPlugin
-	data   *matrix.Matrix
 	client *rest.Client
 	query  string
 }
@@ -52,25 +50,6 @@ func (s *SecurityAccount) Init() error {
 	}
 
 	s.query = "api/security/accounts"
-	s.data = matrix.New(s.Parent+".SecurityAccount", "security_account", "security_account")
-
-	exportOptions := node.NewS("export_options")
-	instanceLabels := exportOptions.NewChildS("instance_labels", "")
-	instanceKeys := exportOptions.NewChildS("instance_keys", "")
-
-	if exportOption := s.ParentParams.GetChildS("export_options"); exportOption != nil {
-		if exportedLabels := exportOption.GetChildS("instance_labels"); exportedLabels != nil {
-			for _, label := range exportedLabels.GetAllChildContentS() {
-				instanceLabels.NewChildS("", label)
-			}
-		}
-		if exportedKeys := exportOption.GetChildS("instance_keys"); exportedKeys != nil {
-			for _, key := range exportedKeys.GetAllChildContentS() {
-				instanceKeys.NewChildS("", key)
-			}
-		}
-	}
-	s.data.SetExportOptions(exportOptions)
 	return nil
 }
 
@@ -82,12 +61,6 @@ func (s *SecurityAccount) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matr
 	)
 
 	data := dataMap[s.Object]
-	// Purge and reset data
-	s.data.PurgeInstances()
-	s.data.Reset()
-
-	// Set all global labels from Rest.go if already not exist
-	s.data.SetGlobalLabels(data.GetGlobalLabels())
 
 	href := rest.BuildHref("", "applications", nil, "", "", "", "", s.query)
 
@@ -126,7 +99,7 @@ func (s *SecurityAccount) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matr
 				for _, method := range methods {
 					var securityAccountNewInstance *matrix.Instance
 					securityAccountNewKey := securityAccountKey + application + method
-					if securityAccountNewInstance, err = s.data.NewInstance(securityAccountNewKey); err != nil {
+					if securityAccountNewInstance, err = data.NewInstance(securityAccountNewKey); err != nil {
 						s.Logger.Error().Err(err).Str("add instance failed for instance key", securityAccountNewKey).Msg("")
 						return nil, err
 					}
@@ -141,5 +114,5 @@ func (s *SecurityAccount) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matr
 		}
 	}
 
-	return []*matrix.Matrix{s.data}, nil
+	return []*matrix.Matrix{data}, nil
 }


### PR DESCRIPTION
Issue:
we are creating new matrix from plugin(with more instances as part of array handling), So this new matrix can't be visible from template and any other plugin which would be used in template, which cause no effect of any `label_agent` or `metric_agent` plugin used in template.
  
Fix:
Instead of creating new matrix from plugin, we should create more instances in actual matrix(data) itself, so all the plugin s available in template can be applied on it and it would work as design.

zapi/rest metric count of labels:
<img width="1769" alt="image" src="https://user-images.githubusercontent.com/83282894/227453607-3482529b-7263-48e8-860d-f72b7f979c41.png">

activediruser:
<img width="1775" alt="image" src="https://user-images.githubusercontent.com/83282894/227454037-93221005-bb92-47b9-ba4e-20528f5d6a31.png">

certificateusers:
<img width="1771" alt="image" src="https://user-images.githubusercontent.com/83282894/227454176-d80ca88b-3db1-4794-aa16-76a4142fd587.png">

Same applies for all.
