### PR TITLE
feat: go test should detect races and order dependent tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
 
@@ -38,7 +38,7 @@ jobs:
       run: go build -v ./...
 
     - name: Test
-      run: go test -v ./...
+      run: go test -v -race -shuffle=on ./...
 
     - name: Check code formatting using gofmt
       uses: Jerome1337/gofmt-action@v1.0.5
@@ -50,7 +50,7 @@ jobs:
       steps:
       - uses: actions/checkout@v3
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: '1.20.2'
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ clean: header ## Cleanup the project binary (bin) folders
 
 test: ## run tests
 	@echo "Running tests"
-	go test ./...
+	go test -race -shuffle=on ./...
 
 fmt: ## format the go source files
 	@echo "Running gofmt"

--- a/cmd/poller/plugin/aggregator/aggregator_test.go
+++ b/cmd/poller/plugin/aggregator/aggregator_test.go
@@ -11,19 +11,17 @@ import (
 	"testing"
 )
 
-var p *Aggregator
-
-func TestMain(m *testing.M) {
+func newAggregator() *Aggregator {
 	params := node.NewS("Aggregator")
 	params.NewChildS("", "node")
 
 	abc := plugin.New("Test", nil, params, nil, "", nil)
-	p = &Aggregator{AbstractPlugin: abc}
+	p := &Aggregator{AbstractPlugin: abc}
 
 	if err := p.Init(); err != nil {
 		panic(err)
 	}
-	m.Run()
+	return p
 }
 
 func TestRuleSimpleAggregation(t *testing.T) {
@@ -33,6 +31,7 @@ func TestRuleSimpleAggregation(t *testing.T) {
 		metricA, metricB *matrix.Metric
 	)
 	m := newArtificialData()
+	p := newAggregator()
 
 	// run the plugin
 	dataMap := map[string]*matrix.Matrix{
@@ -86,6 +85,8 @@ func TestRuleSimpleAggregation(t *testing.T) {
 
 func TestRuleIncludeAllLabels(t *testing.T) {
 	m := newArtificialData()
+	p := newAggregator()
+
 	var n *matrix.Matrix
 
 	params := node.NewS("Aggregator")
@@ -150,6 +151,7 @@ func TestComplexRuleRegex(t *testing.T) {
 
 	params := node.NewS("Aggregator")
 	params.NewChildS("", "volume<`_\\d{4}$`>flexgroup aggr,svm")
+	p := newAggregator()
 
 	p.Params = params
 	m := newArtificialData()
@@ -307,6 +309,7 @@ func TestRuleSimpleLatencyAggregation(t *testing.T) {
 
 	params := node.NewS("Aggregator")
 	params.NewChildS("", "node")
+	p := newAggregator()
 
 	p.Params = params
 
@@ -414,6 +417,7 @@ func TestRuleSimpleLatencyZeroAggregation(t *testing.T) {
 
 	params := node.NewS("Aggregator")
 	params.NewChildS("", "node")
+	p := newAggregator()
 
 	p.Params = params
 

--- a/cmd/poller/plugin/labelagent/label_agent_test.go
+++ b/cmd/poller/plugin/labelagent/label_agent_test.go
@@ -12,13 +12,7 @@ import (
 	//"github.com/netapp/harvest/v2/share/logger"
 )
 
-var p *LabelAgent
-
-func TestInitPlugin(t *testing.T) {
-
-	// uncomment for debugging
-	//logger.SetLevel(0)
-
+func newLabelAgent() *LabelAgent {
 	// define plugin rules
 	params := node.NewS("LabelAgent")
 	// split value of "X" into 4 and take last 2 as new labels
@@ -71,15 +65,17 @@ func TestInitPlugin(t *testing.T) {
 	params.NewChildS("exclude_contains", "").NewChildS("", "volstatus `stop`")
 
 	abc := plugin.New("Test", nil, params, nil, "", nil)
-	p = &LabelAgent{AbstractPlugin: abc}
+	p := &LabelAgent{AbstractPlugin: abc}
 
 	if err := p.Init(); err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
+	return p
 }
 
 func TestSplitSimpleRule(t *testing.T) {
 	m := matrix.New("TestLabelAgent", "test", "test")
+	p := newLabelAgent()
 	instance, _ := m.NewInstance("0")
 	instance.SetLabel("X", "a/b/c/d")
 
@@ -96,6 +92,8 @@ func TestSplitSimpleRule(t *testing.T) {
 
 func TestSplitRegexRule(t *testing.T) {
 	m := matrix.New("TestLabelAgent", "test", "test")
+	p := newLabelAgent()
+
 	instance, _ := m.NewInstance("0")
 	instance.SetLabel("X", "xxxA22_B333")
 
@@ -112,6 +110,8 @@ func TestSplitRegexRule(t *testing.T) {
 
 func TestSplitPairsRule(t *testing.T) {
 	m := matrix.New("TestLabelAgent", "test", "test")
+	p := newLabelAgent()
+
 	instance, _ := m.NewInstance("0")
 	instance.SetLabel("X", "owner:jack contact:some@email")
 
@@ -128,6 +128,8 @@ func TestSplitPairsRule(t *testing.T) {
 
 func TestJoinSimpleRule(t *testing.T) {
 	m := matrix.New("TestLabelAgent", "test", "test")
+	p := newLabelAgent()
+
 	instance, _ := m.NewInstance("0")
 	instance.SetLabel("A", "aaa")
 	instance.SetLabel("B", "bbb")
@@ -145,6 +147,8 @@ func TestJoinSimpleRule(t *testing.T) {
 
 func TestReplaceSimpleRule(t *testing.T) {
 	m := matrix.New("TestLabelAgent", "test", "test")
+	p := newLabelAgent()
+
 	instance, _ := m.NewInstance("0")
 	instance.SetLabel("A", "aaa_X")
 
@@ -161,6 +165,8 @@ func TestReplaceSimpleRule(t *testing.T) {
 
 func TestReplaceRegexRule(t *testing.T) {
 	m := matrix.New("TestLabelAgent", "test", "test")
+	p := newLabelAgent()
+
 	instance, _ := m.NewInstance("0")
 	instance.SetLabel("A", "aaa_12345_abcDEF")
 
@@ -177,6 +183,8 @@ func TestReplaceRegexRule(t *testing.T) {
 
 func TestExcludeEqualsRule(t *testing.T) {
 	m := matrix.New("TestLabelAgent", "test", "test")
+	p := newLabelAgent()
+
 	// should match
 	instanceYes, _ := m.NewInstance("0")
 	instanceYes.SetLabel("A", "aaa bbb ccc")
@@ -199,6 +207,8 @@ func TestExcludeEqualsRule(t *testing.T) {
 
 func TestExcludeContainsRule(t *testing.T) {
 	m := matrix.New("TestLabelAgent", "test", "test")
+	p := newLabelAgent()
+
 	// should match
 	instanceYes, _ := m.NewInstance("0")
 	instanceYes.SetLabel("A", "xxx_aaa_xxx")
@@ -220,6 +230,8 @@ func TestExcludeContainsRule(t *testing.T) {
 
 func TestExcludeRegexRule(t *testing.T) {
 	m := matrix.New("TestLabelAgent", "test", "test")
+	p := newLabelAgent()
+
 	// should match
 	instanceYes, _ := m.NewInstance("0")
 	instanceYes.SetLabel("A", "aaa_123")
@@ -241,6 +253,8 @@ func TestExcludeRegexRule(t *testing.T) {
 
 func TestIncludeEqualsRule(t *testing.T) {
 	m := matrix.New("TestLabelAgent", "test", "test")
+	p := newLabelAgent()
+
 	// should match
 	instanceYes, _ := m.NewInstance("0")
 	instanceYes.SetLabel("A", "aaa bbb ccc")
@@ -263,6 +277,8 @@ func TestIncludeEqualsRule(t *testing.T) {
 
 func TestIncludeContainsRule(t *testing.T) {
 	m := matrix.New("TestLabelAgent", "test", "test")
+	p := newLabelAgent()
+
 	// should match
 	instanceYes, _ := m.NewInstance("0")
 	instanceYes.SetLabel("A", "xxx_aaa_xxx")
@@ -284,6 +300,8 @@ func TestIncludeContainsRule(t *testing.T) {
 
 func TestIncludeRegexRule(t *testing.T) {
 	m := matrix.New("TestLabelAgent", "test", "test")
+	p := newLabelAgent()
+
 	// should match
 	instanceYes, _ := m.NewInstance("0")
 	instanceYes.SetLabel("A", "aaa_123")
@@ -314,6 +332,7 @@ func TestValueToNumRule(t *testing.T) {
 	)
 	// should match
 	m := matrix.New("TestLabelAgent", "test", "test")
+	p := newLabelAgent()
 
 	if instanceA, err = m.NewInstance("A"); err != nil {
 		t.Fatal(err)
@@ -414,6 +433,7 @@ func TestValueToNumRegexRule(t *testing.T) {
 	)
 
 	m := matrix.New("TestLabelAgent", "test", "test")
+	p := newLabelAgent()
 
 	if instanceA, err = m.NewInstance("A"); err != nil {
 		t.Fatal(err)
@@ -508,6 +528,7 @@ func TestValueToNumRegexRule(t *testing.T) {
 
 func TestExcludeEqualIncludeEqualRuleOrder(t *testing.T) {
 	m := matrix.New("TestLabelAgent", "test", "test")
+	p := newLabelAgent()
 
 	instanceOne, _ := m.NewInstance("1")
 	instanceOne.SetLabel("volstate", "offline")
@@ -540,6 +561,7 @@ func TestExcludeEqualIncludeEqualRuleOrder(t *testing.T) {
 
 func TestIncludeContainExcludeContainRuleOrder(t *testing.T) {
 	m := matrix.New("TestLabelAgent", "test", "test")
+	p := newLabelAgent()
 
 	instanceFour, _ := m.NewInstance("4")
 	instanceFour.SetLabel("volstyle", "flexvol")

--- a/cmd/poller/plugin/metricagent/metric_agent_test.go
+++ b/cmd/poller/plugin/metricagent/metric_agent_test.go
@@ -12,9 +12,7 @@ import (
 	//"github.com/netapp/harvest/v2/share/logger"
 )
 
-var p *MetricAgent
-
-func TestInitPlugin(t *testing.T) {
+func newAgent() *MetricAgent {
 
 	// uncomment for debugging
 	//logger.SetLevel(0)
@@ -33,11 +31,12 @@ func TestInitPlugin(t *testing.T) {
 	params.NewChildS("compute_metric", "").NewChildS("", "transmission_rate DIVIDE transfer.bytes_transferred transfer.total_duration")
 
 	abc := plugin.New("Test", nil, params, nil, "", nil)
-	p = &MetricAgent{AbstractPlugin: abc}
+	p := &MetricAgent{AbstractPlugin: abc}
 
 	if err := p.Init(); err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
+	return p
 }
 
 func TestComputeMetricsRule(t *testing.T) {
@@ -53,6 +52,7 @@ func TestComputeMetricsRule(t *testing.T) {
 		err                                                                 error
 	)
 
+	p := newAgent()
 	m := matrix.New("TestLabelAgent", "test", "test")
 
 	if instanceA, err = m.NewInstance("A"); err != nil {


### PR DESCRIPTION
fix: tests should pass regardless of execution order

ci: upgrade actions/setup-go to use cached installs