### PR TITLE
fix: change color scheme for heatmaps

### DIFF
--- a/grafana/dashboards/cmode/smb2.json
+++ b/grafana/dashboards/cmode/smb2.json
@@ -622,9 +622,9 @@
           "color": {
             "cardColor": "#b4ff00",
             "colorScale": "sqrt",
-            "colorScheme": "interpolateOranges",
+            "colorScheme": "interpolateRdYlGn",
             "exponent": 0.5,
-            "mode": "opacity"
+            "mode": "spectrum"
           },
           "dataFormat": "tsbuckets",
           "datasource": "${DS_PROMETHEUS}",
@@ -691,9 +691,9 @@
           "color": {
             "cardColor": "#b4ff00",
             "colorScale": "sqrt",
-            "colorScheme": "interpolateOranges",
+            "colorScheme": "interpolateRdYlGn",
             "exponent": 0.5,
-            "mode": "opacity"
+            "mode": "spectrum"
           },
           "dataFormat": "tsbuckets",
           "datasource": "${DS_PROMETHEUS}",
@@ -760,9 +760,9 @@
           "color": {
             "cardColor": "#b4ff00",
             "colorScale": "sqrt",
-            "colorScheme": "interpolateOranges",
+            "colorScheme": "interpolateRdYlGn",
             "exponent": 0.5,
-            "mode": "opacity"
+            "mode": "spectrum"
           },
           "dataFormat": "tsbuckets",
           "datasource": "${DS_PROMETHEUS}",
@@ -829,9 +829,9 @@
           "color": {
             "cardColor": "#b4ff00",
             "colorScale": "sqrt",
-            "colorScheme": "interpolateOranges",
+            "colorScheme": "interpolateRdYlGn",
             "exponent": 0.5,
-            "mode": "opacity"
+            "mode": "spectrum"
           },
           "dataFormat": "tsbuckets",
           "datasource": "${DS_PROMETHEUS}",
@@ -898,9 +898,9 @@
           "color": {
             "cardColor": "#b4ff00",
             "colorScale": "sqrt",
-            "colorScheme": "interpolateOranges",
+            "colorScheme": "interpolateRdYlGn",
             "exponent": 0.5,
-            "mode": "opacity"
+            "mode": "spectrum"
           },
           "dataFormat": "tsbuckets",
           "datasource": "${DS_PROMETHEUS}",
@@ -967,9 +967,9 @@
           "color": {
             "cardColor": "#b4ff00",
             "colorScale": "sqrt",
-            "colorScheme": "interpolateOranges",
+            "colorScheme": "interpolateRdYlGn",
             "exponent": 0.5,
-            "mode": "opacity"
+            "mode": "spectrum"
           },
           "dataFormat": "tsbuckets",
           "datasource": "${DS_PROMETHEUS}",
@@ -1036,9 +1036,9 @@
           "color": {
             "cardColor": "#b4ff00",
             "colorScale": "sqrt",
-            "colorScheme": "interpolateOranges",
+            "colorScheme": "interpolateRdYlGn",
             "exponent": 0.5,
-            "mode": "opacity"
+            "mode": "spectrum"
           },
           "dataFormat": "tsbuckets",
           "datasource": "${DS_PROMETHEUS}",
@@ -1105,9 +1105,9 @@
           "color": {
             "cardColor": "#b4ff00",
             "colorScale": "sqrt",
-            "colorScheme": "interpolateOranges",
+            "colorScheme": "interpolateRdYlGn",
             "exponent": 0.5,
-            "mode": "opacity"
+            "mode": "spectrum"
           },
           "dataFormat": "tsbuckets",
           "datasource": "${DS_PROMETHEUS}",
@@ -1301,5 +1301,5 @@
   "timezone": "",
   "title": "ONTAP: SMB2",
   "uid": "",
-  "version": 2
+  "version": 3
 }

--- a/grafana/dashboards/cmode/svm.json
+++ b/grafana/dashboards/cmode/svm.json
@@ -5930,9 +5930,9 @@
           "color": {
             "cardColor": "#b4ff00",
             "colorScale": "sqrt",
-            "colorScheme": "interpolateOranges",
+            "colorScheme": "interpolateRdYlGn",
             "exponent": 0.5,
-            "mode": "opacity"
+            "mode": "spectrum"
           },
           "dataFormat": "tsbuckets",
           "datasource": null,
@@ -5999,9 +5999,9 @@
           "color": {
             "cardColor": "#b4ff00",
             "colorScale": "sqrt",
-            "colorScheme": "interpolateOranges",
+            "colorScheme": "interpolateRdYlGn",
             "exponent": 0.5,
-            "mode": "opacity"
+            "mode": "spectrum"
           },
           "dataFormat": "tsbuckets",
           "datasource": null,
@@ -6068,9 +6068,9 @@
           "color": {
             "cardColor": "#b4ff00",
             "colorScale": "sqrt",
-            "colorScheme": "interpolateOranges",
+            "colorScheme": "interpolateRdYlGn",
             "exponent": 0.5,
-            "mode": "opacity"
+            "mode": "spectrum"
           },
           "dataFormat": "tsbuckets",
           "datasource": null,
@@ -14518,5 +14518,5 @@
   "timezone": "",
   "title": "ONTAP: SVM",
   "uid": "",
-  "version": 20
+  "version": 21
 }


### PR DESCRIPTION
Light Theme Before:

![image](https://user-images.githubusercontent.com/25551691/229043396-393e2b40-494e-4e2b-8ea0-3c3512287659.png)


Light Theme After:

![image](https://user-images.githubusercontent.com/25551691/229042931-6d1653ba-f654-4db0-ab15-aaf6935c2f8c.png)


Dark Theme Before:

![image](https://user-images.githubusercontent.com/25551691/229043231-0dac4aab-8dc4-4ca2-b4c2-e8224021abaf.png)

Dark Theme After:

![image](https://user-images.githubusercontent.com/25551691/229043638-840ece16-0933-4c77-ad07-55ffd7937960.png)

