### PR TITLE
test: remove global `ValidatePortInUse` that caused test to fail

### DIFF
--- a/cmd/harvest/harvest.go
+++ b/cmd/harvest/harvest.go
@@ -504,7 +504,7 @@ func getPollerPrometheusPort(pollerName string, opts *options) int {
 		return opts.promPort
 	}
 
-	if promPort, err = conf.GetPrometheusExporterPorts(pollerName); err != nil {
+	if promPort, err = conf.GetPrometheusExporterPorts(pollerName, false); err != nil {
 		fmt.Println(err)
 		return 0
 	}

--- a/cmd/tools/generate/generate.go
+++ b/cmd/tools/generate/generate.go
@@ -162,10 +162,9 @@ func generateDocker(path string, kind int) {
 	if err != nil {
 		panic(err)
 	}
-	conf.ValidatePortInUse = true
 	var filesd []string
 	for _, v := range conf.Config.PollersOrdered {
-		port, _ := conf.GetPrometheusExporterPorts(v)
+		port, _ := conf.GetPrometheusExporterPorts(v, true)
 		pollerInfo := PollerInfo{
 			ServiceName:   normalizeContainerNames(v),
 			PollerName:    v,

--- a/pkg/conf/conf_test.go
+++ b/pkg/conf/conf_test.go
@@ -12,8 +12,6 @@ var testYml = "../../cmd/tools/doctor/testdata/testConfig.yml"
 
 func TestGetPrometheusExporterPorts(t *testing.T) {
 	TestLoadHarvestConfig(testYml)
-	// Test without checking
-	ValidatePortInUse = true
 	type args struct {
 		pollerNames []string
 	}
@@ -29,7 +27,7 @@ func TestGetPrometheusExporterPorts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for i, v := range tt.args.pollerNames {
-				got, err := GetPrometheusExporterPorts(v)
+				got, err := GetPrometheusExporterPorts(v, true)
 				if (err != nil) != tt.wantErr[i] {
 					t.Errorf("GetPrometheusExporterPorts() error = %v, wantErr %v", err, tt.wantErr)
 					return
@@ -44,8 +42,8 @@ func TestGetPrometheusExporterPorts(t *testing.T) {
 
 func TestGetPrometheusExporterPortsIssue284(t *testing.T) {
 	TestLoadHarvestConfig("../../cmd/tools/doctor/testdata/issue-284.yml")
-	loadPrometheusExporterPortRangeMapping()
-	got, _ := GetPrometheusExporterPorts("issue-284")
+	loadPrometheusExporterPortRangeMapping(false)
+	got, _ := GetPrometheusExporterPorts("issue-284", false)
 	if got != 0 {
 		t.Fatalf("expected port to be 0 but was %d", got)
 	}


### PR DESCRIPTION
Fails without this change
```
go test -test.shuffle 1680613852284376000 ./...
```