### PR TITLE
chore: update golang to 1.20.3

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,7 @@
 name: Build, Test, Lint License
 
 env:
-  GO_VERSION: "1.20.2"
+  GO_VERSION: "1.20.3"
 
 on:
   push:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.2'
+          go-version: '1.20.3'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/integration/Jenkinsfile
+++ b/integration/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     environment {
         BUILD_ID="dontKillMe"
         JENKINS_NODE_COOKIE="dontKillMe"
-        GO_VERSION = 1.20.3
+        GO_VERSION = "1.20.3"
     }
     
     stages {

--- a/integration/Jenkinsfile
+++ b/integration/Jenkinsfile
@@ -17,7 +17,8 @@ pipeline {
     }
     environment {
         BUILD_ID="dontKillMe"
-        JENKINS_NODE_COOKIE="dontKillMe"    
+        JENKINS_NODE_COOKIE="dontKillMe"
+        GO_VERSION = 1.20.3
     }
     
     stages {
@@ -207,7 +208,7 @@ def void stopAndRemoveDockers() {
 
 def void setupWorkspace() {
  sh '''
-    wget --quiet -O go.tar.gz "https://go.dev/dl/go1.20.1.linux-amd64.tar.gz"
+    wget --quiet -O go.tar.gz "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz"
     rm -rf /usr/local/go && tar -C /usr/local -xzf ./go.tar.gz
     git clone --single-branch --branch $BRANCH https://github.com/NetApp/harvest.git
     cp /u/mpeg/harvest/harvest_cert.yml $WORKSPACE/harvest/integration/test/

--- a/jenkins/artifacts/jenkinsfile
+++ b/jenkins/artifacts/jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
         jfrogImagePrefix = "netappdownloads.jfrog.io/oss-docker-harvest-production/harvest"
         jfrogRepo = "netappdownloads.jfrog.io"
         COMMIT_ID = sh(returnStdout: true, script: 'git rev-parse HEAD')
-        GO_VERSION = 1.20.3
+        GO_VERSION = "1.20.3"
     }
 
     stages {

--- a/jenkins/artifacts/jenkinsfile
+++ b/jenkins/artifacts/jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
         jfrogImagePrefix = "netappdownloads.jfrog.io/oss-docker-harvest-production/harvest"
         jfrogRepo = "netappdownloads.jfrog.io"
         COMMIT_ID = sh(returnStdout: true, script: 'git rev-parse HEAD')
-        GO_VERSION = 1.20
+        GO_VERSION = 1.20.3
     }
 
     stages {


### PR DESCRIPTION
govulncheck is an experimental tool. Share feedback at https://go.dev/s/govulncheck-feedback.

Using go1.20.1 and govulncheck@v0.0.0 with
vulnerability data from https://vuln.go.dev (last modified 2023-04-05 21:13:07 +0000 UTC).

Scanning your code and 195 packages across 30 dependent modules for known vulnerabilities...
Your code is affected by 3 vulnerabilities from the Go standard library.

Vulnerability #1: GO-2023-1705
  Multipart form parsing can consume large amounts of CPU and
  memory when processing form inputs containing very large numbers
  of parts. This stems from several causes: 1.
  mime/multipart.Reader.ReadForm limits the total memory a parsed
  multipart form can consume. ReadForm can undercount the amount
  of memory consumed, leading it to accept larger inputs than
  intended. 2. Limiting total memory does not account for
  increased pressure on the garbage collector from large numbers
  of small allocations in forms with many parts. 3. ReadForm can
  allocate a large number of short-lived buffers, further
  increasing pressure on the garbage collector. The combination of
  these factors can permit an attacker to cause an program that
  parses multipart forms to consume large amounts of CPU and
  memory, potentially resulting in a denial of service. This
  affects programs that use mime/multipart.Reader.ReadForm, as
  well as form parsing in the net/http package with the Request
  methods FormFile, FormValue, ParseMultipartForm, and
  PostFormValue. With fix, ReadForm now does a better job of
  estimating the memory consumption of parsed forms, and performs
  many fewer short-lived allocations. In addition, the fixed
  mime/multipart.Reader imposes the following limits on the size
  of parsed forms: 1. Forms parsed with ReadForm may contain no
  more than 1000 parts. This limit may be adjusted with the
  environment variable GODEBUG=multipartmaxparts=. 2. Form parts
  parsed with NextPart and NextRawPart may contain no more than
  10,000 header fields. In addition, forms parsed with ReadForm
  may contain no more than 10,000 header fields across all parts.
  This limit may be adjusted with the environment variable
  GODEBUG=multipartmaxheaders=.

  More info: https://pkg.go.dev/vuln/GO-2023-1705

  Standard library
    Found in: mime/multipart@go1.20.1
    Fixed in: mime/multipart@go1.20.3

    Call stacks in your code:
      cmd/exporters/prometheus/httpd.go:31:33: github.com/netapp/harvest/v2/cmd/exporters/prometheus.Prometheus.startHTTPD calls net/http.Server.ListenAndServe, which eventually calls mime/multipart.Reader.ReadForm

  Standard library
    Found in: net/textproto@go1.20.1
    Fixed in: net/textproto@go1.20.3

    Call stacks in your code:
      pkg/api/ontapi/zapi/client.go:463:19: github.com/netapp/harvest/v2/pkg/api/ontapi/zapi.Client.InvokeRaw calls io.ReadAll, which eventually calls net/textproto.Reader.ReadMIMEHeader

Vulnerability #2: GO-2023-1704
  HTTP and MIME header parsing can allocate large amounts of
  memory, even when parsing small inputs, potentially leading to a
  denial of service. Certain unusual patterns of input data can
  cause the common function used to parse HTTP and MIME headers to
  allocate substantially more memory than required to hold the
  parsed headers. An attacker can exploit this behavior to cause
  an HTTP server to allocate large amounts of memory from a small
  request, potentially leading to memory exhaustion and a denial
  of service. With fix, header parsing now correctly allocates
  only the memory required to hold parsed headers.

  More info: https://pkg.go.dev/vuln/GO-2023-1704

  Standard library
    Found in: net/textproto@go1.20.1
    Fixed in: net/textproto@go1.20.3

    Call stacks in your code:
      pkg/api/ontapi/zapi/client.go:463:19: github.com/netapp/harvest/v2/pkg/api/ontapi/zapi.Client.InvokeRaw calls io.ReadAll, which eventually calls net/textproto.Reader.ReadMIMEHeader

Vulnerability #3: GO-2023-1621
  The ScalarMult and ScalarBaseMult methods of the P256 Curve may
  return an incorrect result if called with some specific
  unreduced scalars (a scalar larger than the order of the curve).
  This does not impact usages of crypto/ecdsa or crypto/ecdh.

  More info: https://pkg.go.dev/vuln/GO-2023-1621

  Standard library
    Found in: crypto/internal/nistec@go1.20.1
    Fixed in: crypto/internal/nistec@go1.20.2

    Call stacks in your code:
      cmd/admin/auth.go:28:38: github.com/netapp/harvest/v2/cmd/admin.GenerateAdminCerts calls crypto/ecdsa.GenerateKey, which eventually calls crypto/internal/nistec.P256Point.ScalarBaseMult
      cmd/admin/auth.go:69:41: github.com/netapp/harvest/v2/cmd/admin.GenerateAdminCerts calls crypto/x509.CreateCertificate, which eventually calls crypto/internal/nistec.P256OrdInverse
      cmd/admin/auth.go:69:41: github.com/netapp/harvest/v2/cmd/admin.GenerateAdminCerts calls crypto/x509.CreateCertificate, which eventually calls crypto/internal/nistec.P256Point.ScalarMult
