### PR TITLE
fix: handle custom file of status_7mode object

### DIFF
--- a/cmd/poller/collector/helpers.go
+++ b/cmd/poller/collector/helpers.go
@@ -126,7 +126,7 @@ func (c *AbstractCollector) ImportSubTemplate(model, filename string, ver [3]int
 
 		if selectedVersion == "" {
 			// workaround for 7mode template that will always be missing in cdot
-			if filename == "status_7.yaml" && model == "cdot" {
+			if c.Object == "Status_7mode" && model == "cdot" {
 				return nil, "", errs.New(errs.ErrWrongTemplate, "unable to load status_7.yaml on cdot")
 			}
 			return nil, "", errors.New("no best-fit template found")


### PR DESCRIPTION
Tested locally with `custom.yaml` file with this content

```
objects:
  Status_7mode:    status_7_custom.yaml
```

```
./bin/poller -p sarzapi --promPort 13006 -o Status_7mode -c Zapi --config harvestopenlab.yml
2023-04-12T14:12:32+05:30 INF ./poller.go:205 > Init Poller=sarzapi configPath=harvestopenlab.yml logLevel=info version="harvest version 23.04.1214-v23.02.0 (commit d830c6c7) (build date 2023-04-12T14:12:12+0530) darwin/amd64\n"
2023-04-12T14:12:32+05:30 INF ./poller.go:242 > started in foreground Poller=sarzapi pid=88976
2023-04-12T14:12:33+05:30 INF ./poller.go:1215 > Use ZAPIs HARVEST_NO_COLLECTOR_UPGRADE= Poller=sarzapi collector=Zapi preferZAPI=true v=9.12.1
2023-04-12T14:12:34+05:30 WRN ./poller.go:331 > no collectors initialized, stopping Poller=sarzapi
2023-04-12T14:12:34+05:30 INF ./poller.go:556 > cleaning up and stopping [pid=88976] Poller=sarzapi
```