### PR TITLE
fix: changed warn to error in ems for key/labels

### DIFF
--- a/cmd/collectors/ems/ems.go
+++ b/cmd/collectors/ems/ems.go
@@ -605,7 +605,7 @@ func (e *Ems) HandleResults(result []gjson.Result, prop map[string][]*emsProp) (
 							}
 							instanceLabelCount++
 						} else {
-							e.Logger.Warn().Str("Instance key", instanceKey).Str("label", label).Msg("Missing label value")
+							e.Logger.Error().Str("Instance key", instanceKey).Str("label", label).Msg("Missing label value")
 						}
 					}
 
@@ -684,9 +684,9 @@ func (e *Ems) getInstanceKeys(p *emsProp, instanceData gjson.Result) string {
 	for _, k := range p.InstanceKeys {
 		value := parseProperties(instanceData, k)
 		if value.Exists() {
-			instanceKey += Hyphen + value.String()
+			instanceKey += value.String() + Hyphen
 		} else {
-			e.Logger.Warn().Str("key", k).Msg("skip instance, missing key")
+			e.Logger.Error().Str("key", k).Msg("skip instance, missing key")
 			break
 		}
 	}


### PR DESCRIPTION
Changes:
- Warn to Error for instanceKey missing
- Warn to Error for instanceLabel missing
- Changed to position of Hyphen in instanceKeys
Before:
<img width="1536" alt="image" src="https://user-images.githubusercontent.com/83282894/233953564-2f104615-4e78-4222-9824-2f9e90149d13.png">

After changing hyphen to later
Now,
<img width="1527" alt="image" src="https://user-images.githubusercontent.com/83282894/233955242-a52cf54b-8730-4745-a7cb-ffcca9f130df.png">
