### PR TITLE
ci: mediator related ems changes in ci

### DIFF
--- a/integration/test/alert/alert.go
+++ b/integration/test/alert/alert.go
@@ -122,12 +122,9 @@ func GenerateEvents(emsNames []string, nodeScopedEms []string) map[string]bool {
 			arg1 = vserverArwState[vserverArwCount]
 			vserverArwCount++
 		}
-		// bookendkey is ipaddress for below 2 ems
+		// special case as arg order is different in issuing ems than resolving ems
 		if ems == "sm.mediator.misconfigured" {
-			arg2 = "1.1.1.1"
-		}
-		if ems == "sm.mediator.in.quorum" {
-			arg1 = "1.1.1.1"
+			arg2 = "1"
 		}
 
 		// Handle for node-scoped ems, Passing node-name as input


### PR DESCRIPTION
All mediator ems are having bookendkey as `ipaddress`.
Only `sm.mediator.misconfigured` ems has arg order change, rest all have first arg as ipaddress only same as resolving ems `sm.mediator.in.quorum`.