### PR TITLE
fix: disk dashboard power on time should use `seconds` unit

### DIFF
--- a/grafana/dashboards/7mode/disk7.json
+++ b/grafana/dashboards/7mode/disk7.json
@@ -1309,11 +1309,11 @@
                   },
                   {
                     "id": "unit",
-                    "value": "clocks"
+                    "value": "s"
                   },
                   {
                     "id": "decimals",
-                    "value": 2
+                    "value": 1
                   }
                 ]
               },

--- a/grafana/dashboards/cmode/disk.json
+++ b/grafana/dashboards/cmode/disk.json
@@ -1485,11 +1485,11 @@
                   },
                   {
                     "id": "unit",
-                    "value": "clocks"
+                    "value": "s"
                   },
                   {
                     "id": "decimals",
-                    "value": 2
+                    "value": 1
                   }
                 ]
               },


### PR DESCRIPTION
Fixes: #2038