### PR TITLE
fix: workload missing label value

### DIFF
--- a/cmd/collectors/restperf/restperf.go
+++ b/cmd/collectors/restperf/restperf.go
@@ -756,7 +756,7 @@ func (r *RestPerf) pollData(startTime time.Time, perfRecords []rest.PerfRecord) 
 						if r.Prop.Query == "api/cluster/counter/tables/disk:constituent" && label == "physical_disk_id" {
 							r.Logger.Debug().Str("instanceKey", instanceKey).Str("label", label).Msg("Missing label value")
 						} else {
-							r.Logger.Warn().Str("instanceKey", instanceKey).Str("label", label).Msg("Missing label value")
+							r.Logger.Error().Str("instanceKey", instanceKey).Str("label", label).Msg("Missing label value")
 						}
 					}
 				}

--- a/conf/restperf/9.12.0/workload_detail.yaml
+++ b/conf/restperf/9.12.0/workload_detail.yaml
@@ -15,7 +15,6 @@ schedule:
 counters:
   - ^^id
   - ^node.name      => node
-  - ^resource_name  => resource
   - service_time
   - visits
   - wait_time

--- a/conf/restperf/9.12.0/workload_detail_volume.yaml
+++ b/conf/restperf/9.12.0/workload_detail_volume.yaml
@@ -13,7 +13,6 @@ schedule:
 
 counters:
   - ^^id
-  - ^resource_name  => resource
   - service_time
   - visits
   - wait_time

--- a/jenkins/artifacts/jenkinsfile
+++ b/jenkins/artifacts/jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                apt-get install -y net-tools
                apt install -y git-all
                apt-get install -y build-essential
-               apt install python3-pip
+               apt install -y python3-pip
                pip install mkdocs
                pip install mike
                pip install mkdocs-material-extensions


### PR DESCRIPTION

Although the value of `resource_name` should be `resource.name`, we are not currently utilizing it. Instead, we set the resource at the metric level, rather than at the instance level. The resource is retrieved from the instance key. It is worth noting that this warning in the log does not have any functional impact.

I have also changed this warning to error just like in Rest Collector.