### PR TITLE
feat: collection of other counters for fcvi perf object

### DIFF
--- a/cmd/collectors/restperf/plugins/fcvi/fcvi.go
+++ b/cmd/collectors/restperf/plugins/fcvi/fcvi.go
@@ -1,0 +1,71 @@
+package fcvi
+
+import (
+	"github.com/netapp/harvest/v2/cmd/poller/plugin"
+	"github.com/netapp/harvest/v2/cmd/tools/rest"
+	"github.com/netapp/harvest/v2/pkg/conf"
+	"github.com/netapp/harvest/v2/pkg/matrix"
+	"strings"
+	"time"
+)
+
+type FCVI struct {
+	*plugin.AbstractPlugin
+	client *rest.Client
+}
+
+func New(p *plugin.AbstractPlugin) plugin.Plugin {
+	return &FCVI{AbstractPlugin: p}
+}
+
+func (f *FCVI) Init() error {
+	var err error
+	if err = f.InitAbc(); err != nil {
+		return err
+	}
+
+	timeout, _ := time.ParseDuration(rest.DefaultTimeout)
+	if f.client, err = rest.New(conf.ZapiPoller(f.ParentParams), timeout, f.Auth); err != nil {
+		f.Logger.Error().Stack().Err(err).Msg("connecting")
+		return err
+	}
+
+	if err = f.client.Init(5); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f *FCVI) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, error) {
+	data := dataMap[f.Object]
+	query := "api/private/cli/metrocluster/interconnect/adapter"
+	fields := []string{"node", "adapter", "port_name"}
+	href := rest.BuildHref("", strings.Join(fields, ","), nil, "", "", "", "", query)
+
+	records, err := rest.Fetch(f.client, href)
+	if err != nil {
+		f.Logger.Error().Err(err).Str("href", href).Msg("Failed to fetch data")
+		return nil, err
+	}
+
+	if len(records) == 0 {
+		return nil, nil
+	}
+
+	for _, adapterData := range records {
+		if !adapterData.IsObject() {
+			f.Logger.Warn().Str("type", adapterData.Type.String()).Msg("adapter is not object, skipping")
+			continue
+		}
+		node := adapterData.Get("node").String()
+		adapter := adapterData.Get("adapter").String()
+		port := adapterData.Get("port_name").String()
+
+		// Fetch instance and add port label
+		if instance := data.GetInstance(node + ":" + adapter); instance != nil {
+			instance.SetLabel("port", port)
+		}
+	}
+
+	return nil, nil
+}

--- a/cmd/collectors/restperf/restperf.go
+++ b/cmd/collectors/restperf/restperf.go
@@ -6,6 +6,7 @@ import (
 	"github.com/netapp/harvest/v2/cmd/collectors/restperf/plugins/disk"
 	"github.com/netapp/harvest/v2/cmd/collectors/restperf/plugins/fabricpool"
 	"github.com/netapp/harvest/v2/cmd/collectors/restperf/plugins/fcp"
+	"github.com/netapp/harvest/v2/cmd/collectors/restperf/plugins/fcvi"
 	"github.com/netapp/harvest/v2/cmd/collectors/restperf/plugins/headroom"
 	"github.com/netapp/harvest/v2/cmd/collectors/restperf/plugins/nic"
 	"github.com/netapp/harvest/v2/cmd/collectors/restperf/plugins/volume"
@@ -1231,6 +1232,8 @@ func (r *RestPerf) LoadPlugin(kind string, p *plugin.AbstractPlugin) plugin.Plug
 		return vscan.New(p)
 	case "FabricPool":
 		return fabricpool.New(p)
+	case "FCVI":
+		return fcvi.New(p)
 	default:
 		r.Logger.Info().Str("kind", kind).Msg("no Restperf plugin found")
 	}

--- a/cmd/collectors/zapiperf/plugins/fcvi/fcvi.go
+++ b/cmd/collectors/zapiperf/plugins/fcvi/fcvi.go
@@ -1,0 +1,81 @@
+package fcvi
+
+import (
+	"github.com/netapp/harvest/v2/cmd/poller/plugin"
+	"github.com/netapp/harvest/v2/pkg/api/ontapi/zapi"
+	"github.com/netapp/harvest/v2/pkg/conf"
+	"github.com/netapp/harvest/v2/pkg/errs"
+	"github.com/netapp/harvest/v2/pkg/matrix"
+	"github.com/netapp/harvest/v2/pkg/tree/node"
+)
+
+const batchSize = "500"
+
+type FCVI struct {
+	*plugin.AbstractPlugin
+	client *zapi.Client
+}
+
+func New(p *plugin.AbstractPlugin) plugin.Plugin {
+	return &FCVI{AbstractPlugin: p}
+}
+
+func (f *FCVI) Init() error {
+	var err error
+	if err = f.InitAbc(); err != nil {
+		return err
+	}
+
+	if f.client, err = zapi.New(conf.ZapiPoller(f.ParentParams), f.Auth); err != nil {
+		f.Logger.Error().Stack().Err(err).Msg("connecting")
+		return err
+	}
+	if err = f.client.Init(5); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f *FCVI) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, error) {
+	var (
+		result []*node.Node
+		err    error
+	)
+
+	adapterPortMap := make(map[string]string)
+	data := dataMap[f.Object]
+	query := "metrocluster-interconnect-adapter-get-iter"
+	request := node.NewXMLS(query)
+	request.NewChildS("max-records", batchSize)
+	desired := node.NewXMLS("desired-attributes")
+	metroclusterInterconnectAdapterAttributes := node.NewXMLS("metrocluster-interconnect-adapter")
+	metroclusterInterconnectAdapterAttributes.NewChildS("adapter-name", "")
+	metroclusterInterconnectAdapterAttributes.NewChildS("node-name", "")
+	metroclusterInterconnectAdapterAttributes.NewChildS("port-name", "")
+	desired.AddChild(metroclusterInterconnectAdapterAttributes)
+	request.AddChild(desired)
+
+	if result, err = f.client.InvokeZapiCall(request); err != nil {
+		return nil, err
+	}
+
+	if len(result) == 0 || result == nil {
+		return nil, errs.New(errs.ErrNoInstance, "no records found")
+	}
+	f.Logger.Info().Msgf("%d", len(result))
+
+	for _, adapterData := range result {
+		adapter := adapterData.GetChildContentS("adapter-name")
+		node := adapterData.GetChildContentS("node-name")
+		port := adapterData.GetChildContentS("port-name")
+		adapterPortMap[node+adapter] = port
+	}
+
+	// we would not use getInstance() as key would be `sti8300mcc-215:kernel:fcvi_device_1`
+	for _, instance := range data.GetInstances() {
+		if port, ok := adapterPortMap[instance.GetLabel("node")+instance.GetLabel("fcvi")]; ok {
+			instance.SetLabel("port", port)
+		}
+	}
+	return nil, nil
+}

--- a/cmd/collectors/zapiperf/zapiperf.go
+++ b/cmd/collectors/zapiperf/zapiperf.go
@@ -29,6 +29,7 @@ import (
 	"github.com/netapp/harvest/v2/cmd/collectors/zapiperf/plugins/disk"
 	"github.com/netapp/harvest/v2/cmd/collectors/zapiperf/plugins/externalserviceoperation"
 	"github.com/netapp/harvest/v2/cmd/collectors/zapiperf/plugins/fcp"
+	"github.com/netapp/harvest/v2/cmd/collectors/zapiperf/plugins/fcvi"
 	"github.com/netapp/harvest/v2/cmd/collectors/zapiperf/plugins/headroom"
 	"github.com/netapp/harvest/v2/cmd/collectors/zapiperf/plugins/nic"
 	"github.com/netapp/harvest/v2/cmd/collectors/zapiperf/plugins/volume"
@@ -128,6 +129,8 @@ func (z *ZapiPerf) LoadPlugin(kind string, abc *plugin.AbstractPlugin) plugin.Pl
 		return disk.New(abc)
 	case "ExternalServiceOperation":
 		return externalserviceoperation.New(abc)
+	case "FCVI":
+		return fcvi.New(abc)
 	default:
 		z.Logger.Info().Msgf("no zapiPerf plugin found for %s", kind)
 	}

--- a/conf/restperf/9.12.0/fcvi.yaml
+++ b/conf/restperf/9.12.0/fcvi.yaml
@@ -3,14 +3,28 @@ query:                    api/cluster/counter/tables/fcvi
 object:                   fcvi
 
 counters:
-  - ^^id
-  - ^name                       => fcvi
-  - ^node.name                  => node
-  - rdma.write_average_latency  => rdma_write_avg_latency
-  - rdma.write_ops              => rdma_write_ops
-  - rdma.write_throughput       => rdma_write_throughput
+  - ^^id                                 => fcvi
+  - ^node.name                           => node
+  - firmware.invalid_crc_count           => fw_invalid_crc
+  - firmware.invalid_transmit_word_count => fw_invalid_xmit_words
+  - firmware.link_failure_count          => fw_link_failure
+  - firmware.loss_of_signal_count        => fw_loss_of_signal
+  - firmware.loss_of_sync_count          => fw_loss_of_sync
+  - firmware.systat.discard_frames       => fw_SyStatDiscardFrames
+  - hard_reset_count                     => hard_reset_cnt
+  - rdma.write_average_latency           => rdma_write_avg_latency
+  - rdma.write_ops                       => rdma_write_ops
+  - rdma.write_throughput                => rdma_write_throughput
+  - soft_reset_count                     => soft_reset_cnt
+
+plugins:
+  - LabelAgent:
+    split:
+      - fcvi `:` ,fcvi
+  - FCVI
 
 export_options:
   instance_keys:
     - fcvi
     - node
+    - port

--- a/conf/zapiperf/cdot/9.8.0/fcvi.yaml
+++ b/conf/zapiperf/cdot/9.8.0/fcvi.yaml
@@ -6,14 +6,26 @@ object:                   fcvi
 instance_key:             uuid
 
 counters:
+  - fw_SyStatDiscardFrames
+  - fw_invalid_crc
+  - fw_invalid_xmit_words
+  - fw_link_failure
+  - fw_loss_of_signal
+  - fw_loss_of_sync
+  - hard_reset_cnt
   - instance_name           => fcvi
   - instance_uuid
   - node_name               => node
   - rdma_write_avg_latency
   - rdma_write_ops
   - rdma_write_throughput
+  - soft_reset_cnt
+
+plugins:
+  - FCVI
 
 export_options:
   instance_keys:
     - fcvi
     - node
+    - port


### PR DESCRIPTION
Neither ZapiPerf object `fcvi` nor RestPerf api `api/cluster/counter/tables/fcvi` would be having the detail of port, which customer has asked for.
So, To add those port details, one extra call has been made in plugin. Calling `metrocluster-interconnect-adapter-get-iter` in Zapiperf plugin and calling `api/private/cli/metrocluster/interconnect/adapter` in RestPerf plugin with desired attrs.

Tested against Bigtop MCC cluster.
<img width="1902" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/5d9ce8b3-4e8b-48a4-a50b-eeeb03fb4e94">

<img width="1897" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/fc9db375-0f3a-4c7c-84fc-92556d5e5191">

<img width="1899" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/50fc58de-1743-4f54-ad86-6814cd0078ff">

<img width="1895" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/2bfaac93-55d4-4668-a330-dc383cc68b20">

<img width="1894" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/84f8d409-e59f-4a2f-bbad-109a5d4a75f2">


