### PR TITLE
fix: change svm panels row name

### DIFF
--- a/grafana/dashboards/cmode/svm.json
+++ b/grafana/dashboards/cmode/svm.json
@@ -3265,7 +3265,7 @@
           "type": "timeseries"
         }
       ],
-      "title": "CIFS Frontend Drilldown",
+      "title": "CIFS Drilldown",
       "type": "row"
     },
     {
@@ -6763,7 +6763,7 @@
           "type": "timeseries"
         }
       ],
-      "title": "NFSv3 Frontend Drilldown",
+      "title": "NFSv3 Drilldown",
       "type": "row"
     },
     {


### PR DESCRIPTION
I encountered some limitations while exploring repeat panels. Here are the issues I encountered:

1. Each timeseries panel requires its own separate variable, such as `TopNfsv3ReadAvgLatency` and `TopNfsv4ReadAvgLatency`. I couldn't find a way to make this dynamic to different scenarios.

2. The NFsv3 row includes histograms, but I chose not to add histograms to other NFS versions in order to avoid exporting excessive data. However, if a user specifically requests it, we can consider adding histograms in the future.

3. In order to maintain consistency with other panels, I simply changed the row name to make it similar to the others.