### PR TITLE
feat: when using a credential script, re-auth on 401s

### DIFF
--- a/pkg/api/ontapi/zapi/client.go
+++ b/pkg/api/ontapi/zapi/client.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"github.com/netapp/harvest/v2/pkg/auth"
 	"github.com/netapp/harvest/v2/pkg/conf"
@@ -304,9 +305,9 @@ func (c *Client) buildRequest(query *node.Node, forceCluster bool) error {
 	return nil
 }
 
-// InvokeZapi will issue API requests with batching
+// invokeZapi will issue API requests with batching
 // The method bails on the first error
-func (c *Client) InvokeZapi(request *node.Node, handle func([]*node.Node) error) error {
+func (c *Client) invokeZapi(request *node.Node, handle func([]*node.Node) error) error {
 	var output []*node.Node
 	tag := "initial"
 
@@ -354,7 +355,7 @@ func (c *Client) InvokeZapi(request *node.Node, handle func([]*node.Node) error)
 // InvokeZapiCall will issue API requests with batching
 func (c *Client) InvokeZapiCall(request *node.Node) ([]*node.Node, error) {
 	var output []*node.Node
-	err := c.InvokeZapi(request, func(response []*node.Node) error {
+	err := c.invokeZapi(request, func(response []*node.Node) error {
 		output = append(output, response...)
 		return nil
 	})
@@ -364,7 +365,7 @@ func (c *Client) InvokeZapiCall(request *node.Node) ([]*node.Node, error) {
 	return output, nil
 }
 
-// Invoke used for 2 purposes
+// Invoke is used for two purposes
 // If testFilePath is non-empty -> Used only from unit test
 // Else -> will issue the API request and return server response
 // this method should only be called after building the request
@@ -380,7 +381,7 @@ func (c *Client) Invoke(testFilePath string) (*node.Node, error) {
 	return result, err
 }
 
-// InvokeBatchRequest used for 2 purposes
+// InvokeBatchRequest is used for two purposes
 // If testFilePath is non-empty -> Used only from unit test
 // Else -> will issue API requests in series, once there
 // are no more instances returned by the server, returned results will be nil
@@ -421,7 +422,7 @@ func (c *Client) InvokeBatchWithTimers(request *node.Node, tag string) (*node.No
 		return nil, "", rd, pd, err
 	}
 
-	if results, rd, pd, err = c.invoke(true); err != nil {
+	if results, rd, pd, err = c.invokeWithAuthRetry(true); err != nil {
 		return nil, "", rd, pd, err
 	}
 
@@ -453,7 +454,7 @@ func (c *Client) InvokeRequest(request *node.Node) (*node.Node, error) {
 	return nil, err
 }
 
-// InvokeWithTimers used for 2 purposes
+// InvokeWithTimers is used for two purposes
 // If testFilePath is non-empty -> Used only from unit test
 // Else -> invokes the request and returns parsed XML response and timers:
 // API wait time and XML parse time.
@@ -466,28 +467,42 @@ func (c *Client) InvokeWithTimers(testFilePath string) (*node.Node, time.Duratio
 			return nil, 0, 0, err
 		}
 	}
-	return c.invoke(true)
+	return c.invokeWithAuthRetry(true)
 }
 
-// InvokeRaw invokes the request and returns the raw server response
-// This method should only be called after building the request
-func (c *Client) InvokeRaw() ([]byte, error) {
-	var (
-		response *http.Response
-		body     []byte
-		err      error
-	)
-
-	if response, err = c.client.Do(c.request); err != nil {
-		return body, errs.New(errs.ErrConnection, err.Error())
-	}
-	//goland:noinspection GoUnhandledErrorResult
-	defer response.Body.Close()
-	if response.StatusCode != 200 {
-		return body, errs.New(errs.ErrAPIResponse, response.Status)
+func (c *Client) invokeWithAuthRetry(withTimers bool) (*node.Node, time.Duration, time.Duration, error) {
+	var buffer bytes.Buffer
+	if c.auth.HasCredentialScript() {
+		// Save the buffer in case it needs to be replayed after an auth failure
+		// This is required because Go clears the buffer when making a POST request
+		buffer = *c.buffer
 	}
 
-	return io.ReadAll(response.Body)
+	resp, t1, t2, err := c.invoke(withTimers)
+
+	if err != nil {
+		var he errs.HarvestError
+		if errors.As(err, &he) {
+			// If this is an auth failure and the client is using a credential script,
+			// expire the current credentials, call the script again, update the client's password,
+			// and try again
+			if errors.Is(he, errs.ErrAuthFailed) && c.auth.HasCredentialScript() {
+				c.auth.Expire()
+				pollerAuth, err2 := c.auth.GetPollerAuth()
+				if err2 != nil {
+					return nil, t1, t2, err2
+				}
+				c.request.SetBasicAuth(pollerAuth.Username, pollerAuth.Password)
+				c.request.Body = io.NopCloser(&buffer)
+				c.request.ContentLength = int64(buffer.Len())
+				result2, s1, s2, err3 := c.invoke(withTimers)
+				u1 := t1.Nanoseconds() + s1.Nanoseconds()
+				u2 := t2.Nanoseconds() + s2.Nanoseconds()
+				return result2, time.Duration(u1) * time.Nanosecond, time.Duration(u2) * time.Nanosecond, err3
+			}
+		}
+	}
+	return resp, t1, t2, err
 }
 
 // invokes the request that has been built with one of the BuildRequest* methods
@@ -504,7 +519,8 @@ func (c *Client) invoke(withTimers bool) (*node.Node, time.Duration, time.Durati
 		err               error
 	)
 
-	defer func(Body io.ReadCloser) { _ = Body.Close() }(c.request.Body)
+	//goland:noinspection GoUnhandledErrorResult
+	defer c.request.Body.Close()
 	defer c.buffer.Reset()
 
 	// issue request to server
@@ -528,6 +544,9 @@ func (c *Client) invoke(withTimers bool) (*node.Node, time.Duration, time.Durati
 	}
 
 	if response.StatusCode != 200 {
+		if response.StatusCode == 401 {
+			return result, responseT, parseT, errs.New(errs.ErrAuthFailed, response.Status)
+		}
 		return result, responseT, parseT, errs.New(errs.ErrAPIResponse, response.Status)
 	}
 
@@ -548,7 +567,7 @@ func (c *Client) invoke(withTimers bool) (*node.Node, time.Duration, time.Durati
 		parseT = time.Since(start)
 	}
 
-	// check if request was successful
+	// check if the request was successful
 	if result = root.GetChildS("results"); result == nil {
 		return result, responseT, parseT, errs.New(errs.ErrAPIResponse, "missing \"results\"")
 	}


### PR DESCRIPTION
This handles the Zapi and ZapiPerf case.
Will add Rest and StorageGRID after this approach is reviewed