### PR TITLE
build: enable golangci-lint permission checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,8 @@ linters:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+  include:
+    - EXC0009
 
 output:
   format: github-actions


### PR DESCRIPTION
- ensure directory permissions are 0750 or less
- ensure file permissions are 0600 or less