### PR TITLE
chore: bump go

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,7 @@
 name: Build, Test, Lint License
 
 env:
-  GO_VERSION: "1.20.5"
+  GO_VERSION: "1.20.6"
 
 on:
   push:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.3'
+          go-version: '1.20.6'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/integration/Jenkinsfile
+++ b/integration/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     environment {
         BUILD_ID="dontKillMe"
         JENKINS_NODE_COOKIE="dontKillMe"
-        GO_VERSION = "1.20.5"
+        GO_VERSION = "1.20.6"
     }
     
     stages {

--- a/jenkins/artifacts/jenkinsfile
+++ b/jenkins/artifacts/jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
         jfrogImagePrefix = "netappdownloads.jfrog.io/oss-docker-harvest-production/harvest"
         jfrogRepo = "netappdownloads.jfrog.io"
         COMMIT_ID = sh(returnStdout: true, script: 'git rev-parse HEAD')
-        GO_VERSION = "1.20.5"
+        GO_VERSION = "1.20.6"
     }
 
     stages {


### PR DESCRIPTION
updated due to govulcheck issue

Using go1.20.5
 and govulncheck@v0.2.0 with vulnerability data from https://vuln.go.dev (last modified 2023-07-[11](https://github.com/NetApp/harvest/actions/runs/5529819307/jobs/10088396504?pr=2204#step:5:12) 19:19:08 +0000 UTC).

Scanning your code and 195 packages across 30 dependent modules for known vulnerabilities...

Vulnerability #1: GO-2023-1878
    Insufficient sanitization of Host header in net/http
  More info: https://pkg.go.dev/vuln/GO-2023-1878
  Standard library
    Found in: net/http@go1.20.5
    Fixed in: net/http@go1.20.6
    Example traces found:
Error:       #1: cmd/poller/poller.go:1064:31: poller.Poller.publishDetails calls http.Client.CloseIdleConnections
Error:       #2: cmd/exporters/influxdb/influxdb.go:2[13](https://github.com/NetApp/harvest/actions/runs/5529819307/jobs/10088396504?pr=2204#step:5:14):32: influxdb.InfluxDB.Emit calls http.Client.Do
Error:       #3: cmd/harvest/version/version.go:106:25: version.latestRelease calls http.Client.Get
Error:       #4: cmd/tools/doctor/restZapiDiff.go:747:23: doctor.getResponse calls http.Get
Error:       #5: cmd/tools/rest/client.go:3[16](https://github.com/NetApp/harvest/actions/runs/5529819307/jobs/10088396504?pr=2204#step:5:17):43: rest.downloadSwagger calls httputil.DumpRequestOut, which calls http.Transport.CloseIdleConnections
Error:       #6: cmd/tools/rest/client.go:316:43: rest.downloadSwagger calls httputil.DumpRequestOut, which calls http.Transport.RoundTrip