### PR TITLE
chore: bump go

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,7 @@
 name: Build, Test, Lint License
 
 env:
-  GO_VERSION: "1.20.6"
+  GO_VERSION: "1.20.7"
 
 on:
   push:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.6'
+          go-version: '1.20.7'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/integration/Jenkinsfile
+++ b/integration/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     environment {
         BUILD_ID="dontKillMe"
         JENKINS_NODE_COOKIE="dontKillMe"
-        GO_VERSION = "1.20.6"
+        GO_VERSION = "1.20.7"
     }
     
     stages {

--- a/jenkins/artifacts/jenkinsfile
+++ b/jenkins/artifacts/jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
         jfrogImagePrefix = "netappdownloads.jfrog.io/oss-docker-harvest-production/harvest"
         jfrogRepo = "netappdownloads.jfrog.io"
         COMMIT_ID = sh(returnStdout: true, script: 'git rev-parse HEAD')
-        GO_VERSION = "1.20.6"
+        GO_VERSION = "1.20.7"
     }
 
     stages {


### PR DESCRIPTION
govulncheck ./...
govulncheck is an experimental tool. Share feedback at https://go.dev/s/govulncheck-feedback.

Using go1.20.6
 and govulncheck@v0.2.0 with vulnerability data from https://vuln.go.dev (last modified 2023-08-02 20:33:39 +0000 UTC).

Scanning your code and 196 packages across 30 dependent modules for known vulnerabilities...

Vulnerability #1: GO-2023-1987
    Large RSA keys can cause high CPU usage in crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2023-1987
  Standard library
    Found in: crypto/tls@go1.20.6
    Fixed in: crypto/tls@go1.21rc4
    Example traces found:
      #1: cmd/exporters/prometheus/httpd.go:51:34: prometheus.Prometheus.startHTTPD calls http.Server.ListenAndServe, which eventually calls tls.Conn.HandshakeContext
      #2: cmd/collectors/collectorstest.go:48:18: collectors.JSONToGson calls io.Copy, which eventually calls tls.Conn.Read
      #3: cmd/collectors/collectorstest.go:48:18: collectors.JSONToGson calls io.Copy, which eventually calls tls.Conn.Write
      #4: cmd/tools/rest/client.go:260:43: rest.downloadSwagger calls httputil.DumpRequestOut, which eventually calls tls.Dialer.DialContext

Your code is affected by 1 vulnerability from the Go standard library.
make: *** [govulncheck] Error 3
