### PR TITLE
feat: nvme/tcp and nvme/RoCE counters

### DIFF
--- a/conf/restperf/9.14.1/nvmf_rdma_port.yaml
+++ b/conf/restperf/9.14.1/nvmf_rdma_port.yaml
@@ -1,0 +1,29 @@
+
+name:                     NvmfRdmaPort
+query:                    api/cluster/counter/tables/nvmf_rdma_port
+object:                   nvmf_rdma_port
+
+counters:
+  - ^^id
+  - ^node.name             => node
+  - ^port.id               => lif
+  - ^port_ip_addr
+  - ^svm.name              => svm
+  - average_latency        => avg_latency
+  - average_other_latency  => avg_other_latency
+  - average_read_latency   => avg_read_latency
+  - average_write_latency  => avg_write_latency
+  - other_ops
+  - read_data
+  - read_ops
+  - total_data
+  - total_ops
+  - write_data
+  - write_ops
+
+export_options:
+  instance_keys:
+    - lif
+    - node
+    - port_ip_addr
+    - svm

--- a/conf/restperf/9.14.1/nvmf_tcp_port.yaml
+++ b/conf/restperf/9.14.1/nvmf_tcp_port.yaml
@@ -1,0 +1,29 @@
+
+name:                     NvmfTcpPort
+query:                    api/cluster/counter/tables/nvmf_tcp_port
+object:                   nvmf_tcp_port
+
+counters:
+  - ^^id
+  - ^node.name             => node
+  - ^port.id               => lif
+  - ^port_ip_addr
+  - ^svm.name              => svm
+  - average_latency        => avg_latency
+  - average_other_latency  => avg_other_latency
+  - average_read_latency   => avg_read_latency
+  - average_write_latency  => avg_write_latency
+  - other_ops
+  - read_data
+  - read_ops
+  - total_data
+  - total_ops
+  - write_data
+  - write_ops
+
+export_options:
+  instance_keys:
+    - lif
+    - node
+    - port_ip_addr
+    - svm

--- a/conf/restperf/default.yaml
+++ b/conf/restperf/default.yaml
@@ -44,6 +44,8 @@ objects:
   NFSv41:            nfsv4_1.yaml
   NFSv42:            nfsv4_2.yaml
   NFSv4:             nfsv4.yaml
+#  NvmfRdmaPort:      nvmf_rdma_port.yaml
+#  NvmfTcpPort:       nvmf_tcp_port.yaml
   Volume:            volume.yaml
   VolumeSvm:         volume_svm.yaml
   WAFLCompBin:       wafl_comp_aggr_vol_bin.yaml

--- a/conf/zapiperf/cdot/9.8.0/nvmf_rdma_port.yaml
+++ b/conf/zapiperf/cdot/9.8.0/nvmf_rdma_port.yaml
@@ -1,0 +1,31 @@
+
+name:                     NvmfRdmaPort
+query:                    nvmf_rdma_port
+object:                   nvmf_rdma_port
+
+instance_key:             uuid
+
+counters:
+  - avg_latency
+  - avg_other_latency
+  - avg_read_latency
+  - avg_write_latency
+  - instance_uuid
+  - node_name             => node
+  - other_ops
+  - port_id               => lif
+  - port_ip_addr
+  - read_data
+  - read_ops
+  - total_data
+  - total_ops
+  - vserver_name          => svm
+  - write_data
+  - write_ops
+
+export_options:
+  instance_keys:
+    - lif
+    - node
+    - port_ip_addr
+    - svm

--- a/conf/zapiperf/cdot/9.8.0/nvmf_tcp_port.yaml
+++ b/conf/zapiperf/cdot/9.8.0/nvmf_tcp_port.yaml
@@ -1,0 +1,31 @@
+
+name:                     NvmfTcpPort
+query:                    nvmf_tcp_port
+object:                   nvmf_tcp_port
+
+instance_key:             uuid
+
+counters:
+  - avg_latency
+  - avg_other_latency
+  - avg_read_latency
+  - avg_write_latency
+  - instance_uuid
+  - node_name             => node
+  - other_ops
+  - port_id               => lif
+  - port_ip_addr
+  - read_data
+  - read_ops
+  - total_data
+  - total_ops
+  - vserver_name          => svm
+  - write_data
+  - write_ops
+
+export_options:
+  instance_keys:
+    - lif
+    - node
+    - port_ip_addr
+    - svm

--- a/conf/zapiperf/default.yaml
+++ b/conf/zapiperf/default.yaml
@@ -49,6 +49,8 @@ objects:
   NFSv41:                   nfsv4_1.yaml
   NFSv42:                   nfsv4_2.yaml
   NFSv4:                    nfsv4.yaml
+#  NvmfRdmaPort:             nvmf_rdma_port.yaml
+#  NvmfTcpPort:              nvmf_tcp_port.yaml
   OntapS3SVM:               ontap_s3_svm.yaml
   SMB2:                     smb2.yaml
   Volume:                   volume.yaml


### PR DESCRIPTION
1. RDMA counters are unavailable in all clusters, and their shapes are identical to TCP. I have not yet discovered a method to create these objects.
2. I have mapped `port_id` with `lif` in the template, as name is same as of network interface.

![image](https://github.com/NetApp/harvest/assets/25551691/63a3a445-db92-400a-b0e9-614018188678)


