### PR TITLE
fix: handled when metric not found in plugin

### DIFF
--- a/cmd/poller/plugin/metricagent/metric_agent.go
+++ b/cmd/poller/plugin/metricagent/metric_agent.go
@@ -59,6 +59,7 @@ func (a *MetricAgent) computeMetrics(m *matrix.Matrix) error {
 		metric                    *matrix.Metric
 		metricVal, firstMetricVal *matrix.Metric
 		err                       error
+		metricNotFound            []error
 	)
 
 	// map values for compute_metric mapping rules
@@ -96,8 +97,8 @@ func (a *MetricAgent) computeMetrics(m *matrix.Matrix) error {
 					if metricVal != nil {
 						v, _ = metricVal.GetValueFloat64(instance)
 					} else {
-						a.Logger.Warn().Err(err).Str("metricName", r.metricNames[i]).Msg("computeMetrics: metric not found")
-						return nil
+						metricNotFound = append(metricNotFound, err)
+						break
 					}
 				}
 
@@ -130,6 +131,9 @@ func (a *MetricAgent) computeMetrics(m *matrix.Matrix) error {
 			_ = metric.SetValueFloat64(instance, result)
 			a.Logger.Trace().Str("metricName", r.metric).Float64("metricValue", result).Msg("computeMetrics: new metric created")
 		}
+	}
+	if len(metricNotFound) > 0 {
+		a.Logger.Warn().Errs("computeMetrics: errors for metric not found", metricNotFound).Send()
 	}
 	return nil
 }


### PR DESCRIPTION
```
% ./bin/poller -p aff-250 --promPort 18001 -c Rest -o Aggregate
2023-08-11T16:53:56+05:30 INF poller/poller.go:194 > Init Poller=aff-250 configPath=./harvest.yml logLevel=info version="harvest version 23.08.1116-v23.05.0 (commit 0ff1e6d6) (build date 2023-08-11T16:53:50+0530) darwin/amd64\n"
2023-08-11T16:53:56+05:30 INF poller/poller.go:231 > started in foreground Poller=aff-250 pid=64704
2023-08-11T16:53:58+05:30 INF collector/helpers.go:139 > best-fit template Poller=aff-250 collector=Rest:Aggregate path=conf/rest/9.10.0/aggr.yaml v=9.11.0
2023-08-11T16:53:58+05:30 INF poller/poller.go:349 > Autosupport scheduled. Poller=aff-250 asupSchedule=24h
2023-08-11T16:53:58+05:30 INF poller/poller.go:358 > poller start-up complete Poller=aff-250
2023-08-11T16:53:58+05:30 INF prometheus/httpd.go:40 > server listen Poller=aff-250 exporter=prometheus1 url=http://:18001/metrics
2023-08-11T16:53:58+05:30 INF poller/poller.go:506 > updated status, up collectors: 1 (of 1), up exporters: 1 (of 1) Poller=aff-250
2023-08-11T16:54:01+05:30 WRN metricagent/metric_agent.go:136 > Poller=aff-250 computeMetrics: errors for metric not found=["strconv.Atoi: parsing \"block_storage.hybrid_cache.disk_count\": invalid syntax","strconv.Atoi: parsing \"block_storage.hybrid_cache.disk_count\": invalid syntax","strconv.Atoi: parsing \"block_storage.hybrid_cache.disk_count\": invalid syntax"] object=Aggregate plugin=Rest:MetricAgent
2023-08-11T16:54:01+05:30 INF collector/collector.go:483 > Collected Poller=aff-250 apiMs=3168 calcMs=0 collector=Rest:Aggregate instances=3 metrics=115 parseMs=1 pluginMs=0
```


With these changes, 
All metrics from compute_metric plugins from template are generated as expected.