### PR TITLE
fix: bin dir prints error when there are no files in it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,7 @@ endif
 
 clean: header ## Cleanup the project binary (bin) folders
 	@echo "Cleaning harvest files"
-	@if [ -d bin ]; then \
-		ls -d ./bin/* | grep -v "asup" | xargs rm -f; \
-	fi
+	@find ./bin -type f ! -name "*asup*" -exec rm -f {} \;
 
 test: ## run tests
 	@echo "Running tests"

--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,11 @@ ifeq ("${CORRECT_GO_VERSION}", "0")
 	@exit 1
 endif
 
-clean: header ## Cleanup the project binary (bin) folders
+clean: ## Cleanup the project binary (bin) folders
 	@echo "Cleaning harvest files"
-	@find ./bin -type f ! -name "*asup*" -exec rm -f {} \;
+	@if [ -d bin ]; then \
+		find ./bin -type f -not -name "*asup*" -exec rm -f {} +; \
+	fi
 
 test: ## run tests
 	@echo "Running tests"


### PR DESCRIPTION
#2289 didn't fix the issue. If bin dir is empty then , We still get below printed. Changing to `find`

`ls: ./bin/*: No such file or directory`
