### PR TITLE
perf: use parse instead of getMany for gjson

### DIFF
--- a/cmd/collectors/collectorstest.go
+++ b/cmd/collectors/collectorstest.go
@@ -50,13 +50,11 @@ func JSONToGson(path string, flatten bool) []gjson.Result {
 		return nil
 	}
 	bb := b.Bytes()
-	output := gjson.GetManyBytes(bb, "records", "num_records", "_links.next.href")
+	output := gjson.ParseBytes(bb)
+	data := output.Get("records")
+	numRecords := output.Get("num_records")
 
-	data := output[0]
-	numRecords := output[1]
-	isNonIterRestCall := !data.Exists()
-
-	if isNonIterRestCall {
+	if !data.Exists() {
 		contentJSON := `{"records":[]}`
 		response, err := sjson.SetRawBytes([]byte(contentJSON), "records.-1", bb)
 		if err != nil {

--- a/cmd/collectors/restperf/restperf.go
+++ b/cmd/collectors/restperf/restperf.go
@@ -476,18 +476,12 @@ func parseMetricResponse(instanceData gjson.Result, metric string) *metricRespon
 	for _, name := range t.Array() {
 		if name.String() == metric {
 			metricPath := "counters.#(name=" + metric + ")"
-			many := gjson.GetMany(instanceDataS,
-				metricPath+".value",
-				metricPath+".values",
-				metricPath+".labels",
-				metricPath+".counters.#.label",
-				metricPath+".counters.#.values",
-			)
-			value := many[0]
-			values := many[1]
-			labels := many[2]
-			subLabels := many[3]
-			subValues := many[4]
+			many := gjson.Parse(instanceDataS)
+			value := many.Get(metricPath + ".value")
+			values := many.Get(metricPath + ".values")
+			labels := many.Get(metricPath + ".labels")
+			subLabels := many.Get(metricPath + ".counters.#.label")
+			subValues := many.Get(metricPath + ".counters.#.values")
 			if value.String() != "" {
 				return &metricResponse{value: strings.Clone(value.String()), label: ""}
 			}

--- a/cmd/collectors/storagegrid/plugins/joinrest/joinrest.go
+++ b/cmd/collectors/storagegrid/plugins/joinrest/joinrest.go
@@ -131,9 +131,9 @@ func (t *JoinRest) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, err
 }
 
 func (t *JoinRest) updateCache(model join, bytes *[]byte) {
-	results := gjson.GetManyBytes(*bytes, "data.#."+model.JoinRest, "data.#."+model.LabelRest)
-	keys := results[0].Array()
-	vals := results[1].Array()
+	results := gjson.ParseBytes(*bytes)
+	keys := results.Get("data.#." + model.JoinRest).Array()
+	vals := results.Get("data.#." + model.LabelRest).Array()
 	if len(keys) != len(vals) {
 		t.Logger.Error().
 			Str("restKey", model.JoinRest).

--- a/cmd/tools/rest/client.go
+++ b/cmd/tools/rest/client.go
@@ -301,13 +301,13 @@ func (c *Client) Init(retries int) error {
 			continue
 		}
 
-		results := gjson.GetManyBytes(content, "name", "uuid", "version.full", "version.generation", "version.major", "version.minor")
-		c.cluster.Name = results[0].String()
-		c.cluster.UUID = results[1].String()
-		c.cluster.Info = results[2].String()
-		c.cluster.Version[0] = int(results[3].Int())
-		c.cluster.Version[1] = int(results[4].Int())
-		c.cluster.Version[2] = int(results[5].Int())
+		results := gjson.ParseBytes(content)
+		c.cluster.Name = results.Get("name").String()
+		c.cluster.UUID = results.Get("uuid").String()
+		c.cluster.Info = results.Get("version.full").String()
+		c.cluster.Version[0] = int(results.Get("version.generation").Int())
+		c.cluster.Version[1] = int(results.Get("version.major").Int())
+		c.cluster.Version[2] = int(results.Get("version.minor").Int())
 		return nil
 	}
 	return err

--- a/cmd/tools/rest/rest.go
+++ b/cmd/tools/rest/rest.go
@@ -450,16 +450,12 @@ func fetch(client *Client, href string, records *[]gjson.Result, downloadAll boo
 		return fmt.Errorf("error making request %w", err)
 	}
 
-	isNonIterRestCall := false
-	output := gjson.GetManyBytes(getRest, "records", "num_records", "_links.next.href")
-	data := output[0]
-	numRecords := output[1]
-	next := output[2]
-	if !data.Exists() {
-		isNonIterRestCall = true
-	}
+	output := gjson.ParseBytes(getRest)
+	data := output.Get("records")
+	numRecords := output.Get("num_records")
+	next := output.Get("_links.next.href")
 
-	if isNonIterRestCall {
+	if !data.Exists() {
 		contentJSON := `{"records":[]}`
 		response, err := sjson.SetRawBytes([]byte(contentJSON), "records.-1", getRest)
 		if err != nil {
@@ -503,11 +499,11 @@ func fetchAnalytics(client *Client, href string, records *[]gjson.Result, analyt
 		return fmt.Errorf("error making request %w", err)
 	}
 
-	output := gjson.GetManyBytes(getRest, "records", "num_records", "_links.next.href", "analytics")
-	data := output[0]
-	numRecords := output[1]
-	next := output[2]
-	*analytics = output[3]
+	output := gjson.ParseBytes(getRest)
+	data := output.Get("records")
+	numRecords := output.Get("num_records")
+	next := output.Get("_links.next.href")
+	*analytics = output.Get("analytics")
 
 	// extract returned records since paginated records need to be merged into a single lists
 	if numRecords.Exists() && numRecords.Int() > 0 {
@@ -546,11 +542,10 @@ func FetchRestPerfData(client *Client, href string, perfRecords *[]PerfRecord) e
 	}
 
 	// extract returned records since paginated records need to be merged into a single list
-	output := gjson.GetManyBytes(getRest, "records", "num_records", "_links.next.href")
-
-	data := output[0]
-	numRecords := output[1]
-	next := output[2]
+	output := gjson.ParseBytes(getRest)
+	data := output.Get("records")
+	numRecords := output.Get("num_records")
+	next := output.Get("_links.next.href")
 
 	if numRecords.Exists() && numRecords.Int() > 0 {
 		p := PerfRecord{Records: data, Timestamp: time.Now().UnixNano()}


### PR DESCRIPTION
**BenchStat**

```
benchstat old.txt new.txt                                                                                              
goos: darwin
goarch: amd64
pkg: github.com/netapp/harvest/v2/cmd/tools/rest
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
      │   old.txt   │              new.txt               │
      │   sec/op    │   sec/op     vs base               │
Run-8   175.5m ± 3%   167.8m ± 1%  -4.39% (p=0.000 n=20)

      │    old.txt    │               new.txt                │
      │     B/op      │     B/op      vs base                │
Run-8   29.432Mi ± 0%   4.494Mi ± 0%  -84.73% (p=0.000 n=20)

      │  old.txt   │              new.txt               │
      │ allocs/op  │ allocs/op   vs base                │
Run-8   23.00 ± 0%   20.00 ± 0%  -13.04% (p=0.000 n=20)
```

**GetManyBytes**

```
goos: darwin
goarch: amd64
pkg: github.com/netapp/harvest/v2/cmd/tools/rest
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkRun-8   	       6	 176583157 ns/op	30864000 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 171905008 ns/op	30863104 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 173131458 ns/op	30861786 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 172861186 ns/op	30861738 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 191586987 ns/op	30863104 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 208865388 ns/op	30861738 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 182311277 ns/op	30861738 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 184147214 ns/op	30861744 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 174858837 ns/op	30861738 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 172048299 ns/op	30861738 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 175390261 ns/op	30861738 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 174621808 ns/op	30861738 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 175406557 ns/op	30861738 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 182451984 ns/op	30861770 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 171076953 ns/op	30861738 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 175685866 ns/op	30861738 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 176748725 ns/op	30861738 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 177837733 ns/op	30861754 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 173864807 ns/op	30861738 B/op	      23 allocs/op
BenchmarkRun-8   	       6	 181394717 ns/op	30861738 B/op	      23 allocs/op
PASS
ok  	github.com/netapp/harvest/v2/cmd/tools/rest	66.796s
```

**ParseBytes**

```
goos: darwin
goarch: amd64
pkg: github.com/netapp/harvest/v2/cmd/tools/rest
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkRun-8   	       7	 166125964 ns/op	 4714582 B/op	      20 allocs/op
BenchmarkRun-8   	       6	 168723358 ns/op	 4712624 B/op	      20 allocs/op
BenchmarkRun-8   	       7	 166443073 ns/op	 4712624 B/op	      20 allocs/op
BenchmarkRun-8   	       7	 168285388 ns/op	 4712624 B/op	      20 allocs/op
BenchmarkRun-8   	       7	 168824665 ns/op	 4713794 B/op	      20 allocs/op
BenchmarkRun-8   	       6	 167641136 ns/op	 4712624 B/op	      20 allocs/op
BenchmarkRun-8   	       6	 168703432 ns/op	 4712624 B/op	      20 allocs/op
BenchmarkRun-8   	       6	 166981145 ns/op	 4717426 B/op	      20 allocs/op
BenchmarkRun-8   	       7	 168052484 ns/op	 4712624 B/op	      20 allocs/op
BenchmarkRun-8   	       6	 177139801 ns/op	 4712624 B/op	      20 allocs/op
BenchmarkRun-8   	       7	 171096416 ns/op	 4712624 B/op	      20 allocs/op
BenchmarkRun-8   	       7	 168462390 ns/op	 4712624 B/op	      20 allocs/op
BenchmarkRun-8   	       7	 167633231 ns/op	 4712624 B/op	      20 allocs/op
BenchmarkRun-8   	       7	 166960088 ns/op	 4712624 B/op	      20 allocs/op
BenchmarkRun-8   	       6	 167239540 ns/op	 4712629 B/op	      20 allocs/op
BenchmarkRun-8   	       7	 167137994 ns/op	 4712624 B/op	      20 allocs/op
BenchmarkRun-8   	       6	 170434566 ns/op	 4712624 B/op	      20 allocs/op
BenchmarkRun-8   	       7	 164541698 ns/op	 4712624 B/op	      20 allocs/op
BenchmarkRun-8   	       6	 177470561 ns/op	 4712624 B/op	      20 allocs/op
BenchmarkRun-8   	       7	 167038610 ns/op	 4712624 B/op	      20 allocs/op
PASS
ok  	github.com/netapp/harvest/v2/cmd/tools/rest	70.290s
```


**Benchmark Code**

```go
package rest

import (
	"github.com/tidwall/gjson"
	"github.com/tidwall/sjson"
	"io/ioutil"
	"net/http"
	"testing"
)

var path = "https://raw.githubusercontent.com/json-iterator/test-data/master/large-file.json"

func BenchmarkParse(b *testing.B) {
	_, newJson := initFile()

	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		o := gjson.Parse(newJson)
		records := o.Get("records").Array()
		numRecords := o.Get("num_records").Int()
		href := o.Get("_links.self.href").String()

		_ = records
		_ = numRecords
		_ = href
	}
}

func BenchmarkGet(b *testing.B) {

	bytes, _ := initFile()
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		o := gjson.GetManyBytes(bytes, "records", "num_records", "_links.next.href")
		records := o[0].Array()
		numRecords := o[1].Int()
		links := o[2].String()
		_ = records
		_ = numRecords
		_ = links
	}

}

func initFile() ([]byte, string) {
	resp, err := http.Get(path)
	if err != nil {
		panic(err)
	}
	defer resp.Body.Close()

	bytes, err := ioutil.ReadAll(resp.Body)
	if err != nil {
		panic(err)
	}

	json := string(bytes)

	newJson, err := sjson.SetRaw(`{}`, "records", json)
	if err != nil {
		panic(err)
	}

	newJson, err = sjson.Set(newJson, "num_records", 197)
	if err != nil {
		panic(err)
	}

	newJson, err = sjson.Set(newJson, "_links.self.href", "/api/storage/volumes?fields=*")
	if err != nil {
		panic(err)
	}

	bytes = []byte(newJson)

	return bytes, newJson
}
```


