### PR TITLE
revert: "perf: Zapi allocs improvements (#2380)"

### DIFF
--- a/cmd/collectors/sensor_test.go
+++ b/cmd/collectors/sensor_test.go
@@ -27,7 +27,7 @@ func loadTestdata() {
 	// setup matrix data
 	var err error
 	var fetch func(*matrix.Instance, *node.Node, []string)
-	dat, err := os.Open(testxml)
+	dat, err := os.ReadFile(testxml)
 	if err != nil {
 		abs, _ := filepath.Abs(testxml)
 		fmt.Printf("failed to load %s\n", abs)

--- a/pkg/api/ontapi/zapi/client.go
+++ b/pkg/api/ontapi/zapi/client.go
@@ -16,7 +16,6 @@ import (
 	"github.com/netapp/harvest/v2/pkg/requests"
 	"github.com/netapp/harvest/v2/pkg/tree"
 	"github.com/netapp/harvest/v2/pkg/tree/node"
-	"github.com/netapp/harvest/v2/pkg/tree/xml"
 	"io"
 	"net/http"
 	"strconv"
@@ -497,20 +496,21 @@ func (c *Client) invoke(withTimers bool) (*node.Node, time.Duration, time.Durati
 		return result, responseT, parseT, errs.New(errs.ErrAPIResponse, response.Status, errs.WithStatus(response.StatusCode))
 	}
 
+	// read response body
+	if body, err = io.ReadAll(response.Body); err != nil {
+		return result, responseT, parseT, err
+	}
+	defer c.printRequestAndResponse(zapiReq, body)
+
 	// parse xml
 	if withTimers {
 		start = time.Now()
 	}
-	if root, body, err = xml.Load(response.Body, c.logZapi); err != nil {
+	if root, err = tree.LoadXML(body); err != nil {
 		return result, responseT, parseT, err
 	}
 	if withTimers {
 		parseT = time.Since(start)
-	}
-
-	// read response body
-	if c.logZapi {
-		defer c.printRequestAndResponse(zapiReq, body)
 	}
 
 	// check if the request was successful
@@ -551,11 +551,11 @@ func (c *Client) TraceLogSet(collectorName string, config *node.Node) {
 }
 
 func (c *Client) printRequestAndResponse(req string, response []byte) {
+	res := "<nil>"
+	if response != nil {
+		res = string(response)
+	}
 	if req != "" {
-		res := "<nil>"
-		if response != nil {
-			res = string(response)
-		}
 		c.Logger.Info().
 			Str("Request", req).
 			Str("Response", res).

--- a/pkg/tree/tree.go
+++ b/pkg/tree/tree.go
@@ -9,7 +9,6 @@ import (
 	"github.com/netapp/harvest/v2/pkg/tree/node"
 	"github.com/netapp/harvest/v2/pkg/tree/xml"
 	y3 "gopkg.in/yaml.v3"
-	"io"
 	"os"
 )
 
@@ -68,9 +67,8 @@ func consume(r *node.Node, key string, y *y3.Node, makeNewChild bool) {
 	}
 }
 
-func LoadXML(r io.Reader) (*node.Node, error) {
-	root, _, err := xml.Load(r, false)
-	return root, err
+func LoadXML(data []byte) (*node.Node, error) {
+	return xml.Load(data)
 }
 
 func DumpXML(n *node.Node) ([]byte, error) {
@@ -78,11 +76,9 @@ func DumpXML(n *node.Node) ([]byte, error) {
 }
 
 func ImportXML(filepath string) (*node.Node, error) {
-	file, err := os.Open(filepath)
+	data, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, err
 	}
-	//goland:noinspection GoUnhandledErrorResult
-	defer file.Close()
-	return LoadXML(file)
+	return LoadXML(data)
 }

--- a/pkg/tree/xml/xml.go
+++ b/pkg/tree/xml/xml.go
@@ -8,24 +8,16 @@ import (
 	"bytes"
 	"encoding/xml"
 	"github.com/netapp/harvest/v2/pkg/tree/node"
-	"io"
 )
 
-func Load(data io.Reader, log bool) (*node.Node, []byte, error) {
-	var buf bytes.Buffer
-	reader := data
-
-	if log {
-		reader = io.TeeReader(data, &buf)
-	}
-
+func Load(data []byte) (*node.Node, error) {
 	root := new(node.Node)
-	dec := xml.NewDecoder(reader)
+	buf := bytes.NewBuffer(data)
+	dec := xml.NewDecoder(buf)
 	if err := dec.Decode(&root); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-
-	return root, buf.Bytes(), nil
+	return root, nil
 }
 
 func Dump(n *node.Node) ([]byte, error) {


### PR DESCRIPTION
This reverts commit 1489cfc7da74dafd23c36030afce2846e7fa2e60.

Change done in #2380, reduces allocs but also increases parse time for xml payload due to streaming. Reverting the changes.

```
2023-09-29T01:59:40+05:30 INF collector/collector.go:485 > Collected Poller=dc-1 apiMs=15772 calcMs=0 collector=ZapiPerf:WorkloadDetailVolume instances=3360 metrics=20160 parseMs=37599 pluginMs=0 skips=0
```