### PR TITLE
feat: cifs share templates

### DIFF
--- a/conf/rest/9.6.0/cifs_share.yaml
+++ b/conf/rest/9.6.0/cifs_share.yaml
@@ -1,0 +1,21 @@
+name:               CIFSShare
+query:              api/private/cli/vserver/cifs/share
+object:             cifs_share
+
+counters:
+  - ^^share_name                        => name
+  - ^^vserver                           => svm
+  - ^path
+  - ^share_properties                   => properties
+  - ^symlink_properties
+  - ^volume
+
+export_options:
+  instance_keys:
+    - name
+    - svm
+  instance_labels:
+    - path
+    - properties
+    - symlink_properties
+    - volume

--- a/conf/rest/default.yaml
+++ b/conf/rest/default.yaml
@@ -10,6 +10,7 @@ schedule:
 objects:
   Aggregate:                   aggr.yaml
   CIFSSession:                 cifs_session.yaml
+#  CIFSShare:                    cifs_share.yaml
   CloudTarget:                 cloud_target.yaml
   ClusterPeer:                 clusterpeer.yaml
   Disk:                        disk.yaml

--- a/conf/zapi/cdot/9.8.0/cifs_share.yaml
+++ b/conf/zapi/cdot/9.8.0/cifs_share.yaml
@@ -1,0 +1,26 @@
+name:               CIFSShare
+query:              cifs-share-get-iter
+object:             cifs_share
+
+counters:
+  cifs-share:
+    - ^^share-name                         => name
+    - ^^vserver                            => svm
+    - ^path                                => path
+    - ^volume                              => volume
+    - share-properties:
+        - ^cifs-share-properties           => properties
+    - symlink-properties:
+        - ^cifs-share-symlink-properties   => symlink_properties
+
+collect_only_labels: true
+
+export_options:
+  instance_keys:
+    - name
+    - svm
+  instance_labels:
+    - path
+    - properties
+    - symlink_properties
+    - volume

--- a/conf/zapi/default.yaml
+++ b/conf/zapi/default.yaml
@@ -9,6 +9,7 @@ objects:
   Aggregate:                   aggr.yaml
   AggregateEfficiency:         aggr_efficiency.yaml
   CIFSSession:                 cifs_session.yaml
+#  CIFSShare:                   cifs_share.yaml
   CloudTarget:                 aggr_object_store_config.yaml
   ClusterPeer:                 clusterpeer.yaml
   Disk:                        disk.yaml


### PR DESCRIPTION
Public API [/protocols/cifs/shares](https://library.netapp.com/ecmdocs/ECMLP2885799/html/#docs-NAS-protocols_cifs_shares) does not have the property named `properties`. The private CLI does so we'll use it.