### PR TITLE
fix: `Volume IOPs per Type` legend should use mean, last, max instead…

### DIFF
--- a/grafana/dashboards/cmode/volume.json
+++ b/grafana/dashboards/cmode/volume.json
@@ -2603,7 +2603,9 @@
           "options": {
             "legend": {
               "calcs": [
-                "sum"
+                "mean",
+                "lastNotNull",
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom"


### PR DESCRIPTION
… of sum

Thanks Ed Wilts for reporting!