### PR TITLE
feat: smb2 restperf counters

### DIFF
--- a/conf/restperf/9.14.1/smb2.yaml
+++ b/conf/restperf/9.14.1/smb2.yaml
@@ -1,0 +1,45 @@
+name:                     SMB2
+query:                    api/cluster/counter/tables/smb2
+object:                   smb2
+
+counters:
+  - ^^id
+  - ^node.name                         => node
+  - ^svm.name                          => svm
+  - close_latency
+  - close_latency_histogram
+  - close_ops
+  - create_latency
+  - create_latency_histogram
+  - create_ops
+  - lock_latency
+  - lock_latency_histogram
+  - lock_ops
+  - negotiate_latency
+  - negotiate_ops
+  - oplock_break_latency
+  - oplock_break_latency_histogram
+  - oplock_break_ops
+  - query_directory_latency
+  - query_directory_latency_histogram
+  - query_directory_ops
+  - query_info_latency
+  - query_info_latency_histogram
+  - query_info_ops
+  - read_latency
+  - read_ops
+  - session_setup_latency
+  - session_setup_latency_histogram
+  - session_setup_ops
+  - set_info_latency
+  - set_info_latency_histogram
+  - set_info_ops
+  - tree_connect_latency
+  - tree_connect_ops
+  - write_latency
+  - write_ops
+
+export_options:
+  instance_keys:
+    - node
+    - svm

--- a/conf/restperf/default.yaml
+++ b/conf/restperf/default.yaml
@@ -46,6 +46,7 @@ objects:
   NFSv4:             nfsv4.yaml
 #  NvmfRdmaPort:      nvmf_rdma_port.yaml
 #  NvmfTcpPort:       nvmf_tcp_port.yaml
+  SMB2:              smb2.yaml
   Volume:            volume.yaml
   VolumeSvm:         volume_svm.yaml
   WAFLCompBin:       wafl_comp_aggr_vol_bin.yaml


### PR DESCRIPTION
The distinction between ZapiPerf and RestPerf is the additional `type` label in ZapiPerf, which is derived from parsing the `instance_uuid`. `instance_uuid` is missing in RestPerf. However, based on the dataset available in our clusters, it appears that the `type` label may not be necessary.


**ZapiPerf:**
`smb2_tree_connect_latency{datacenter="VSIM",cluster="sti62nscluster-1",node="sti62-vsim-ucs140d",svm="vs0",type="kernel"} 0`

**RestPerf:**
`smb2_session_setup_latency{datacenter="VSIM",cluster="sti62nscluster-1",node="sti62-vsim-ucs140d",svm="vs0"} 0`
