### PR TITLE
fix: handled cloud_target for fabricpool

### DIFF
--- a/cmd/collectors/fabricpool.go
+++ b/cmd/collectors/fabricpool.go
@@ -35,7 +35,7 @@ func GetFlexGroupFabricPoolMetrics(dataMap map[string]*matrix.Matrix, object str
 			continue
 		}
 		if match := re.FindStringSubmatch(i.GetLabel("volume")); len(match) == 3 {
-			key := i.GetLabel("svm") + "." + match[1]
+			key := i.GetLabel("svm") + "." + match[1] + i.GetLabel("cloud_target")
 			if cache.GetInstance(key) == nil {
 				fg, _ := cache.NewInstance(key)
 				fg.SetLabels(maps.Clone(i.GetLabels()))
@@ -50,8 +50,8 @@ func GetFlexGroupFabricPoolMetrics(dataMap map[string]*matrix.Matrix, object str
 	// create summary
 	for _, i := range data.GetInstances() {
 		if match := re.FindStringSubmatch(i.GetLabel("volume")); len(match) == 3 {
-			// instance key is svm.flexgroup-volume
-			key := i.GetLabel("svm") + "." + match[1]
+			// instance key is svm.flexgroup-volume.cloud-target-name
+			key := i.GetLabel("svm") + "." + match[1] + i.GetLabel("cloud_target")
 
 			fg := cache.GetInstance(key)
 			if fg == nil {

--- a/grafana/dashboards/cmode/volume.json
+++ b/grafana/dashboards/cmode/volume.json
@@ -4997,7 +4997,7 @@
               "expr": "topk($TopResources, fabricpool_cloud_bin_op_latency_average{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\",volume=~\"$TopCloudBinOpGetLatency\", metric=\"GET\"})",
               "hide": false,
               "interval": "",
-              "legendFormat": "{{svm}} - {{volume}}",
+              "legendFormat": "{{svm}} - {{volume}} - {{cloud_target}}",
               "refId": "A"
             }
           ],
@@ -5090,7 +5090,7 @@
               "expr": "topk($TopResources, fabricpool_cloud_bin_operation{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\",volume=~\"$TopCloudBinOperationGet\", metric=\"GET\"})",
               "hide": false,
               "interval": "",
-              "legendFormat": "{{svm}} - {{volume}}",
+              "legendFormat": "{{svm}} - {{volume}} - {{cloud_target}}",
               "refId": "A"
             }
           ],
@@ -5183,7 +5183,7 @@
               "expr": "topk($TopResources, fabricpool_cloud_bin_op_latency_average{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\",volume=~\"$TopCloudBinOpPutLatency\", metric=\"PUT\"})",
               "hide": false,
               "interval": "",
-              "legendFormat": "{{svm}} - {{volume}}",
+              "legendFormat": "{{svm}} - {{volume}} - {{cloud_target}}",
               "refId": "A"
             }
           ],
@@ -5276,7 +5276,7 @@
               "expr": "topk($TopResources, fabricpool_cloud_bin_operation{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",svm=~\"$SVM\",volume=~\"$TopCloudBinOperationPut\", metric=\"PUT\"})",
               "hide": false,
               "interval": "",
-              "legendFormat": "{{svm}} - {{volume}} ",
+              "legendFormat": "{{svm}} - {{volume}} - {{cloud_target}}",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
Earlier behaviour:
`cloud_target` label can be non-deterministic as it depends on first constituent.
<img width="1784" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/212c563e-8c69-440b-a87e-5627564e7001">

<img width="1790" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/da08110a-6539-48f6-87ac-b7de708191ed">



Current behaviour:
Now, we are handling fg instance based on the `cloud_target` label.
<img width="1784" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/19674db1-ac94-4ad9-a5cc-2dc78dcbbf83">

<img width="1785" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/b3a55e36-712f-46d8-9548-2c2a3ae56737">

This is same behaviour for flexvols. All flexvols are also showing 2 records, 1 with cloud_target and other without cloud_target. 

Grafana UI panels:
<img width="1736" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/224a5f73-f0ad-4930-af04-0d15f2402478">
