### PR TITLE
fix: parseD logger changes

### DIFF
--- a/pkg/api/ontapi/zapi/client.go
+++ b/pkg/api/ontapi/zapi/client.go
@@ -496,6 +496,9 @@ func (c *Client) invoke(withTimers bool) (*node.Node, time.Duration, time.Durati
 		return result, responseT, parseT, errs.New(errs.ErrAPIResponse, response.Status, errs.WithStatus(response.StatusCode))
 	}
 
+	if withTimers {
+		start = time.Now()
+	}
 	// read response body
 	if body, err = io.ReadAll(response.Body); err != nil {
 		return result, responseT, parseT, err
@@ -503,9 +506,6 @@ func (c *Client) invoke(withTimers bool) (*node.Node, time.Duration, time.Durati
 	defer c.printRequestAndResponse(zapiReq, body)
 
 	// parse xml
-	if withTimers {
-		start = time.Now()
-	}
 	if root, err = tree.LoadXML(body); err != nil {
 		return result, responseT, parseT, err
 	}


### PR DESCRIPTION
```
harvest % ./bin/poller -p sarzapi --promPort 13001 -o Qtree -c Zapi
2023-11-15T16:45:44+05:30 INF poller/poller.go:215 > Init Poller=sarzapi asup=false confPath=conf config=harvest.yml configPath=harvest.yml daemon=false debug=false homePath= hostname=hardikl-mac-0 logLevel=info logPath=/var/log/harvest/ profiling=0 promPort=13001 version="harvest version 23.11.1516-v23.11.0 (commit da2b1ff5) (build date 2023-11-15T16:45:40+0530) darwin/amd64"
2023-11-15T16:45:44+05:30 INF poller/poller.go:239 > started in foreground Poller=sarzapi pid=474
2023-11-15T16:45:47+05:30 INF collector/helpers.go:84 > best-fit template Poller=sarzapi collector=Zapi:Qtree path=conf/zapi/cdot/9.8.0/qtree.yaml v=9.13.1
2023-11-15T16:45:48+05:30 INF poller/poller.go:357 > Autosupport scheduled. Poller=sarzapi asupSchedule=24h
2023-11-15T16:45:48+05:30 INF prometheus/httpd.go:40 > server listen Poller=sarzapi exporter=prometheus1 url=http://:13001/metrics
2023-11-15T16:45:48+05:30 INF poller/poller.go:366 > poller start-up complete Poller=sarzapi
2023-11-15T16:45:48+05:30 INF poller/poller.go:514 > updated status, up collectors: 1 (of 1), up exporters: 1 (of 1) Poller=sarzapi
2023-11-15T16:45:50+05:30 INF qtree/qtree.go:225 > Collected Poller=sarzapi apiD=352ms batchSize=500 metrics=392 numQuotas=49 object=Qtree parseD=618ms plugin=Zapi:Qtree
2023-11-15T16:45:50+05:30 INF collector/collector.go:510 > Collected Poller=sarzapi apiMs=278 calcMs=0 collector=Zapi:Qtree instances=243 metrics=1507 parseMs=957 pluginMs=971
2023-11-15T16:48:51+05:30 INF qtree/qtree.go:225 > Collected Poller=sarzapi apiD=898ms batchSize=500 metrics=392 numQuotas=49 object=Qtree parseD=596ms plugin=Zapi:Qtree
2023-11-15T16:48:51+05:30 INF collector/collector.go:510 > Collected Poller=sarzapi apiMs=879 calcMs=0 collector=Zapi:Qtree instances=243 metrics=1507 parseMs=1224 pluginMs=1495
2023-11-15T16:51:51+05:30 INF qtree/qtree.go:225 > Collected Poller=sarzapi apiD=898ms batchSize=500 metrics=392 numQuotas=49 object=Qtree parseD=238ms plugin=Zapi:Qtree
2023-11-15T16:51:51+05:30 INF collector/collector.go:510 > Collected Poller=sarzapi apiMs=907 calcMs=0 collector=Zapi:Qtree instances=243 metrics=1507 parseMs=949 pluginMs=1138
```