### PR TITLE
feat: include start time, exported metrics, and poll duration in coll…

### DIFF
--- a/cmd/collectors/restperf/restperf_test.go
+++ b/cmd/collectors/restperf/restperf_test.go
@@ -78,12 +78,12 @@ func TestMain(m *testing.M) {
 
 	benchPerf = newRestPerf("Volume", "volume.yaml")
 	counters := jsonToPerfRecords("testdata/volume-counters.json")
-	_, _ = benchPerf.pollCounter(counters[0].Records.Array())
+	_, _ = benchPerf.pollCounter(counters[0].Records.Array(), 0)
 	now := time.Now().Truncate(time.Second)
 	propertiesData = jsonToPerfRecords("testdata/volume-poll-properties.json.gz")
 	fullPollData = jsonToPerfRecords("testdata/volume-poll-full.json.gz")
 	fullPollData[0].Timestamp = now.UnixNano()
-	_, _ = benchPerf.pollInstance(propertiesData[0].Records.Array())
+	_, _ = benchPerf.pollInstance(propertiesData[0].Records.Array(), 0)
 	_, _ = benchPerf.pollData(now, fullPollData)
 
 	os.Exit(m.Run())
@@ -97,7 +97,7 @@ func BenchmarkRestPerf_PollData(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		now = now.Add(time.Minute * 15)
 		fullPollData[0].Timestamp = now.UnixNano()
-		mi, _ := benchPerf.pollInstance(propertiesData[0].Records.Array())
+		mi, _ := benchPerf.pollInstance(propertiesData[0].Records.Array(), 0)
 		for _, mm := range mi {
 			ms = append(ms, mm)
 		}
@@ -142,13 +142,13 @@ func TestRestPerf_pollData(t *testing.T) {
 			r := newRestPerf("Volume", "volume.yaml")
 
 			counters := jsonToPerfRecords(tt.pollCounters)
-			_, err := r.pollCounter(counters[0].Records.Array())
+			_, err := r.pollCounter(counters[0].Records.Array(), 0)
 			if err != nil {
 				t.Fatal(err)
 			}
 			pollInstance := jsonToPerfRecords(tt.pollInstance)
 			pollData := jsonToPerfRecords(tt.pollDataPath1)
-			_, err = r.pollInstance(pollInstance[0].Records.Array())
+			_, err = r.pollInstance(pollInstance[0].Records.Array(), 0)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -277,13 +277,13 @@ func TestQosVolume(t *testing.T) {
 			r := newRestPerf("WorkloadVolume", "workload_volume.yaml")
 
 			counters := jsonToPerfRecords(tt.pollCounters)
-			_, err := r.pollCounter(counters[0].Records.Array())
+			_, err := r.pollCounter(counters[0].Records.Array(), 0)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			pollInst := jsonToPerfRecords(tt.pollInstance)
-			_, err = r.pollInstance(pollInst[0].Records.Array())
+			_, err = r.pollInstance(pollInst[0].Records.Array(), 0)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/collectors/zapi/collector/zapi.go
+++ b/cmd/collectors/zapi/collector/zapi.go
@@ -255,16 +255,11 @@ func (z *Zapi) PollData() (map[string]*matrix.Matrix, error) {
 		count, skipped    uint64
 		tag               string
 		err               error
+		apiD, parseD      time.Duration // Request/API time, Parse time, Fetch time
 		ad, pd            time.Duration // Request/API time, Parse time, Fetch time
 		fetch             func(*matrix.Instance, *node.Node, []string, bool)
 		instances         []*node.Node
 	)
-
-	count = 0
-	skipped = 0
-
-	apiT := 0 * time.Second
-	parseT := 0 * time.Second
 
 	oldInstances := set.New()
 	mat := z.Matrix[z.Object]
@@ -352,8 +347,8 @@ func (z *Zapi) PollData() (map[string]*matrix.Matrix, error) {
 			break
 		}
 
-		apiT += ad
-		parseT += pd
+		apiD += ad
+		parseD += pd
 
 		instances = response.SearchChildren(z.shortestPathPrefix)
 
@@ -409,8 +404,8 @@ func (z *Zapi) PollData() (map[string]*matrix.Matrix, error) {
 
 	numInstances := len(mat.GetInstances())
 	// update metadata
-	_ = z.Metadata.LazySetValueInt64("api_time", "data", apiT.Microseconds())
-	_ = z.Metadata.LazySetValueInt64("parse_time", "data", parseT.Microseconds())
+	_ = z.Metadata.LazySetValueInt64("api_time", "data", apiD.Microseconds())
+	_ = z.Metadata.LazySetValueInt64("parse_time", "data", parseD.Microseconds())
 	_ = z.Metadata.LazySetValueUint64("metrics", "data", count)
 	_ = z.Metadata.LazySetValueUint64("instances", "data", uint64(numInstances))
 	z.AddCollectCount(count)

--- a/cmd/exporters/influxdb/influxdb_test.go
+++ b/cmd/exporters/influxdb/influxdb_test.go
@@ -117,7 +117,7 @@ func TestExportDebug(t *testing.T) {
 	}
 
 	// render data
-	if err := influx.Export(data); err != nil {
+	if _, err := influx.Export(data); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cmd/exporters/prometheus/httpd.go
+++ b/cmd/exporters/prometheus/httpd.go
@@ -129,7 +129,7 @@ func (p *Prometheus) ServeMetrics(w http.ResponseWriter, r *http.Request) {
 
 	// serve our own metadata
 	// notice that some values are always taken from previous session
-	md := p.render(p.Metadata)
+	md, _ := p.render(p.Metadata)
 	data = append(data, md...)
 	count += len(md)
 	/*

--- a/cmd/poller/poller.go
+++ b/cmd/poller/poller.go
@@ -501,10 +501,10 @@ func (p *Poller) Run() {
 
 			// @TODO if there are no "master" exporters, don't collect metadata
 			for _, ee := range p.exporters {
-				if err := ee.Export(p.metadata); err != nil {
+				if _, err := ee.Export(p.metadata); err != nil {
 					logger.Error().Stack().Err(err).Msg("export component metadata:")
 				}
-				if err := ee.Export(p.status); err != nil {
+				if _, err := ee.Export(p.status); err != nil {
 					logger.Error().Stack().Err(err).Msg("export target metadata:")
 				}
 			}


### PR DESCRIPTION
…ector logs

feat: PollInstance and PollCounter should be logged with start time, api, and poll duration

Examples:

`2023-11-16T13:26:57-05:00 INF collector/collector.go:567 > Collected Poller=sar apiMs=1574 begin=1700159216 collector=RestPerf:WAFLAggr metrics=23 pollMs=1580 task=counter`

`2023-11-16T13:26:58-05:00 INF collector/collector.go:567 > Collected Poller=sar apiMs=354 begin=1700159218 collector=RestPerf:NFSv42 instances=9 pollMs=354 task=instance`

`2023-11-16T13:29:03-05:00 INF collector/collector.go:567 > Collected Poller=sar apiMs=4152 begin=1700159336414 calcMs=0 collector=Rest:SecurityAccount exportMs=2 instances=39 instancesExported=266 metrics=193 metricsExported=1620 parseMs=0 pluginMs=3185 pollMs=7337`

Fixes: #1519