### PR TITLE
fix: hide idle metric and max to auto for cpu_domain_busy

### DIFF
--- a/cmd/tools/grafana/dashboard_test.go
+++ b/cmd/tools/grafana/dashboard_test.go
@@ -1055,6 +1055,8 @@ func TestPercentHasMinMax(t *testing.T) {
 }
 
 func checkPercentHasMinMax(t *testing.T, path string, data []byte) {
+	// These panels can show percent value more than 100.
+	exceptions := []string{"CPU Busy Domains"}
 	dashPath := ShortPath(path)
 
 	VisitAllPanels(data, func(path string, key, value gjson.Result) {
@@ -1072,7 +1074,7 @@ func checkPercentHasMinMax(t *testing.T, path string, data []byte) {
 			t.Errorf(`dashboard=%s path=%s panel="%s" has unit=%s, min should be 0 got=%s`,
 				dashPath, path, value.Get("title").String(), defaultUnit, theMin)
 		}
-		if defaultUnit == "percent" && theMax != "100" {
+		if defaultUnit == "percent" && !slices.Contains(exceptions, value.Get("title").String()) && theMax != "100" {
 			t.Errorf(`dashboard=%s path=%s panel="%s" has unit=%s, max should be 100 got=%s`,
 				dashPath, path, value.Get("title").String(), defaultUnit, theMax)
 		}

--- a/grafana/dashboards/cmode/node.json
+++ b/grafana/dashboards/cmode/node.json
@@ -1236,7 +1236,6 @@
                 }
               },
               "mappings": [],
-              "max": 100,
               "min": 0,
               "thresholds": {
                 "mode": "absolute",
@@ -1253,7 +1252,32 @@
               },
               "unit": "percent"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "__systemRef": "hideSeriesFrom",
+                "matcher": {
+                  "id": "byNames",
+                  "options": {
+                    "mode": "include",
+                    "names": [
+                      "idle"
+                    ],
+                    "prefix": "All except:",
+                    "readOnly": true
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 9,
@@ -1289,7 +1313,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "CPU Busy Domains ",
+          "title": "CPU Busy Domains",
           "transformations": [],
           "type": "timeseries"
         }


### PR DESCRIPTION
Fixing in this panel:
1. Changes max from 100 to auto as this panel can go beyond 100%.
2. metric `idle` show as hidden(grayed) as default.