### PR TITLE
doc: bump the minimum Prometheus version to 2.33

### DIFF
--- a/docs/system-requirements.md
+++ b/docs/system-requirements.md
@@ -10,7 +10,7 @@ With the default configuration, when monitoring 10 clusters, we recommend:
 
 Harvest is compatible with:
 
-- Prometheus: `2.26` or higher
+- Prometheus: `2.33` or higher
 - InfluxDB: `v2`
 - Grafana: `8.1.X` or higher
 - Docker: `20.10.0` or higher and compatible Docker Compose


### PR DESCRIPTION
Prometheus 2.33+ is required to use the PromQL modifier `@`.

See:
- https://discord.com/channels/855068651522490400/1184394042268717087
- https://prometheus.io/blog/2021/02/18/introducing-the-@-modifier/