### PR TITLE
feat: supporting automated_failover, automated_failover_duplex policy in SM

### DIFF
--- a/cmd/collectors/commonutils.go
+++ b/cmd/collectors/commonutils.go
@@ -180,7 +180,9 @@ func UpdateProtectedFields(instance *matrix.Instance) {
 		} else if policyType == "mirror_vault" {
 			instance.SetLabel("derived_relationship_type", "mirror_vault")
 		} else if policyType == "automated_failover" {
-			instance.SetLabel("derived_relationship_type", "sync_mirror")
+			instance.SetLabel("derived_relationship_type", "automated_failover")
+		} else if policyType == "automated_failover_duplex" {
+			instance.SetLabel("derived_relationship_type", "automated_failover_duplex")
 		} else {
 			instance.SetLabel("derived_relationship_type", relationshipType)
 		}

--- a/cmd/collectors/commonutils_test.go
+++ b/cmd/collectors/commonutils_test.go
@@ -27,6 +27,7 @@ func TestUpdateProtectedFields(t *testing.T) {
 	testSyncMirror(t, instance)
 	testMirrorVault(t, instance)
 	testAutomatedFailover(t, instance)
+	testAutomatedFailoverDuplex(t, instance)
 	testOtherPolicyType(t, instance)
 	testWithNoPolicyType(t, instance)
 	testWithNoPolicyTypeNoRelationshipType(t, instance)
@@ -167,8 +168,18 @@ func testAutomatedFailover(t *testing.T, instance *matrix.Instance) {
 	instance.SetLabel("policy_type", "automated_failover")
 	UpdateProtectedFields(instance)
 
-	if instance.GetLabel("derived_relationship_type") != "sync_mirror" {
-		t.Errorf("Labels derived_relationship_type= %s, expected: sync_mirror", instance.GetLabel("derived_relationship_type"))
+	if instance.GetLabel("derived_relationship_type") != "automated_failover" {
+		t.Errorf("Labels derived_relationship_type= %s, expected: automated_failover", instance.GetLabel("derived_relationship_type"))
+	}
+}
+
+func testAutomatedFailoverDuplex(t *testing.T, instance *matrix.Instance) {
+	instance.SetLabel("relationship_type", "")
+	instance.SetLabel("policy_type", "automated_failover_duplex")
+	UpdateProtectedFields(instance)
+
+	if instance.GetLabel("derived_relationship_type") != "automated_failover_duplex" {
+		t.Errorf("Labels derived_relationship_type= %s, expected: automated_failover_duplex", instance.GetLabel("derived_relationship_type"))
 	}
 }
 

--- a/cmd/collectors/zapi/plugins/snapmirror/snapmirror_test.go
+++ b/cmd/collectors/zapi/plugins/snapmirror/snapmirror_test.go
@@ -25,6 +25,7 @@ func TestProtectedFields(t *testing.T) {
 	testSyncMirror(t, instance)
 	testMirrorVault(t, instance)
 	testAutomatedFailover(t, instance)
+	testAutomatedFailoverDuplex(t, instance)
 	testOtherPolicyType(t, instance)
 	testWithNoPolicyType(t, instance)
 }
@@ -157,8 +158,18 @@ func testAutomatedFailover(t *testing.T, instance *matrix.Instance) {
 	instance.SetLabel("policy_type", "automated_failover")
 	collectors.UpdateProtectedFields(instance)
 
-	if instance.GetLabel("derived_relationship_type") != "sync_mirror" {
-		t.Errorf("Labels derived_relationship_type= %s, expected: sync_mirror", instance.GetLabel("derived_relationship_type"))
+	if instance.GetLabel("derived_relationship_type") != "automated_failover" {
+		t.Errorf("Labels derived_relationship_type= %s, expected: automated_failover", instance.GetLabel("derived_relationship_type"))
+	}
+}
+
+func testAutomatedFailoverDuplex(t *testing.T, instance *matrix.Instance) {
+	instance.SetLabel("relationship_type", "")
+	instance.SetLabel("policy_type", "automated_failover_duplex")
+	collectors.UpdateProtectedFields(instance)
+
+	if instance.GetLabel("derived_relationship_type") != "automated_failover_duplex" {
+		t.Errorf("Labels derived_relationship_type= %s, expected: automated_failover_duplex", instance.GetLabel("derived_relationship_type"))
 	}
 }
 

--- a/grafana/dashboards/cmode/snapmirror.json
+++ b/grafana/dashboards/cmode/snapmirror.json
@@ -3451,14 +3451,15 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 5,
+            "w": 13,
             "x": 0,
-            "y": 30
+            "y": 7
           },
-          "id": 128,
+          "id": 111,
           "options": {
+            "displayLabels": [],
             "legend": {
-              "displayMode": "hidden",
+              "displayMode": "table",
               "placement": "right",
               "values": [
                 "value"
@@ -3481,7 +3482,7 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "count(snapmirror_labels{source_cluster=~\"$SourceCluster\", derived_relationship_type=\"extended_data_protection\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
+              "expr": "count(snapmirror_labels{source_cluster=~\"$SourceCluster\", derived_relationship_type=\"extended_data_protection\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\")) or vector(0)",
               "instant": true,
               "interval": "",
               "legendFormat": "Asynchronous Mirror",
@@ -3489,7 +3490,7 @@
             },
             {
               "exemplar": false,
-              "expr": "count(snapmirror_labels{source_cluster=~\"$SourceCluster\", derived_relationship_type=\"mirror_vault\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
+              "expr": "count(snapmirror_labels{source_cluster=~\"$SourceCluster\", derived_relationship_type=\"mirror_vault\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\")) or vector(0)",
               "hide": false,
               "instant": true,
               "interval": "",
@@ -3498,7 +3499,7 @@
             },
             {
               "exemplar": false,
-              "expr": "count(snapmirror_labels{source_cluster=~\"$SourceCluster\", derived_relationship_type=\"vault\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
+              "expr": "count(snapmirror_labels{source_cluster=~\"$SourceCluster\", derived_relationship_type=\"vault\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\")) or vector(0)",
               "hide": false,
               "instant": true,
               "interval": "",
@@ -3507,7 +3508,7 @@
             },
             {
               "exemplar": false,
-              "expr": "count(snapmirror_labels{source_cluster=~\"$SourceCluster\", derived_relationship_type=\"sync_mirror_strict\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
+              "expr": "count(snapmirror_labels{source_cluster=~\"$SourceCluster\", derived_relationship_type=\"sync_mirror_strict\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\")) or vector(0)",
               "hide": false,
               "instant": true,
               "interval": "",
@@ -3516,206 +3517,35 @@
             },
             {
               "exemplar": false,
-              "expr": "count(snapmirror_labels{source_cluster=~\"$SourceCluster\", derived_relationship_type=\"sync_mirror\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
+              "expr": "count(snapmirror_labels{source_cluster=~\"$SourceCluster\", derived_relationship_type=\"sync_mirror\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\")) or vector(0)",
               "hide": false,
               "instant": true,
               "interval": "",
               "legendFormat": "Sync",
               "refId": "E"
+            },
+            {
+              "exemplar": false,
+              "expr": "count(snapmirror_labels{source_cluster=~\"$SourceCluster\", derived_relationship_type=\"automated_failover\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\")) or vector(0)",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Automated Failover",
+              "refId": "F"
+            },
+            {
+              "exemplar": false,
+              "expr": "count(snapmirror_labels{source_cluster=~\"$SourceCluster\", derived_relationship_type=\"automated_failover_duplex\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\")) or vector(0)",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Automated Failover Duplex",
+              "refId": "G"
             }
           ],
           "title": "Volume relationship count by relationship type",
           "transformations": [],
           "type": "piechart"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "rgb(31, 176, 196)",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 3,
-            "x": 5,
-            "y": 30
-          },
-          "id": 109,
-          "links": [],
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "center",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "8.4.11",
-          "targets": [
-            {
-              "exemplar": false,
-              "expr": "count(snapmirror_labels{source_cluster=~\"$SourceCluster\",derived_relationship_type=\"extended_data_protection\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
-              "format": "table",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "Asynchronous Mirror",
-          "type": "stat"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "rgb(31, 176, 196)",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 3,
-            "x": 8,
-            "y": 30
-          },
-          "id": 110,
-          "links": [],
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "center",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "8.4.11",
-          "targets": [
-            {
-              "exemplar": false,
-              "expr": "count(snapmirror_labels{source_cluster=~\"$SourceCluster\",derived_relationship_type=\"mirror_vault\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
-              "format": "time_series",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "Asynchronous Mirror and Vault",
-          "type": "stat"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "rgb(31, 176, 196)",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 3,
-            "x": 11,
-            "y": 30
-          },
-          "id": 111,
-          "links": [],
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "center",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "8.4.11",
-          "targets": [
-            {
-              "exemplar": false,
-              "expr": "count(snapmirror_labels{source_cluster=~\"$SourceCluster\",derived_relationship_type=\"vault\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
-              "format": "time_series",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "Asynchronous Vault",
-          "type": "stat"
         },
         {
           "datasource": "${DS_PROMETHEUS}",
@@ -3770,14 +3600,14 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 5,
-            "x": 14,
-            "y": 30
+            "w": 11,
+            "x": 13,
+            "y": 7
           },
-          "id": 130,
+          "id": 112,
           "options": {
             "legend": {
-              "displayMode": "hidden",
+              "displayMode": "table",
               "placement": "right",
               "values": [
                 "value"
@@ -3820,257 +3650,6 @@
           ],
           "title": "Volume relationship count by relationship health",
           "type": "piechart"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "semi-dark-green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 5,
-            "x": 19,
-            "y": 30
-          },
-          "id": 114,
-          "links": [],
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "center",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "last"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "8.4.11",
-          "targets": [
-            {
-              "expr": "count((snapmirror_labels{source_cluster=~\"$SourceCluster\",healthy=\"true\",relationship_id!=\"\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\", type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )) or vector (0)",
-              "format": "time_series",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "Healthy",
-              "refId": "A"
-            }
-          ],
-          "title": "Healthy",
-          "type": "stat"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "rgb(31, 176, 196)",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 3,
-            "x": 5,
-            "y": 36
-          },
-          "id": 113,
-          "links": [],
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "center",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "8.4.11",
-          "targets": [
-            {
-              "exemplar": false,
-              "expr": "count(snapmirror_labels{source_cluster=~\"$SourceCluster\",derived_relationship_type=\"sync_mirror_strict\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
-              "format": "time_series",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "StrictSync",
-          "type": "stat"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "rgb(31, 176, 196)",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 3,
-            "x": 8,
-            "y": 36
-          },
-          "id": 112,
-          "links": [],
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "center",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "8.4.11",
-          "targets": [
-            {
-              "exemplar": false,
-              "expr": "count(snapmirror_labels{source_cluster=~\"$SourceCluster\",derived_relationship_type=\"sync_mirror\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\",type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") )",
-              "format": "time_series",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "Sync",
-          "type": "stat"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-yellow",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 5,
-            "x": 19,
-            "y": 36
-          },
-          "id": 115,
-          "links": [],
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "center",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "last"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "8.4.11",
-          "targets": [
-            {
-              "exemplar": false,
-              "expr": "count(group by (source_volume,source_vserver,source_cluster)(snapmirror_labels{source_cluster=~\"$SourceCluster\", healthy=\"false\",relationship_id!=\"\"} * on (source_volume, source_vserver, source_cluster) group_left() label_replace( label_replace( label_replace( volume_labels{datacenter=~\"$Datacenter\", cluster=~\"$SourceCluster\",volume!~\"MDV.*\", type=\"rw\"}, \"source_volume\", \"$1\", \"volume\", \"(.*)\") , \"source_vserver\", \"$1\", \"svm\", \"(.*)\"), \"source_cluster\", \"$1\", \"cluster\", \"(.*)\") ) ) or vector (0)",
-              "format": "table",
-              "hide": false,
-              "instant": true,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "Unhealthy",
-          "type": "stat"
         },
         {
           "datasource": "${DS_PROMETHEUS}",
@@ -4183,7 +3762,7 @@
           },
           "gridPos": {
             "h": 14,
-            "w": 14,
+            "w": 13,
             "x": 0,
             "y": 42
           },
@@ -4332,7 +3911,7 @@
           },
           "gridPos": {
             "h": 14,
-            "w": 10,
+            "w": 11,
             "x": 14,
             "y": 42
           },


### PR DESCRIPTION
Steps followed in cluster 9.15.1 (In 9.14.1 this duplex policy is non-functional):
1. Network interfaces each node
2. Cluster peer
3. SVM, Volumes creation
4. create CG protection

<img width="1771" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/dafb4fb8-b2da-499c-86e3-dde307e39a2b">

Changed the UI slightly for better understanding of the pie chart.
<img width="931" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/37c00f89-0fd3-48e0-b4e5-8762caa5c95a">

<img width="1723" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/a70a7fc1-96bd-48cc-97a3-6e9339af4f77">
