### PR TITLE
feat: disabled the templates whose all metrics are not consumed in dashboards

### DIFF
--- a/conf/restperf/default.yaml
+++ b/conf/restperf/default.yaml
@@ -27,7 +27,7 @@ objects:
   Path:              path.yaml
   Qtree:             qtree.yaml
   SystemNode:        system_node.yaml
-  TokenManager:      token_manager.yaml
+#  TokenManager:      token_manager.yaml
   VolumeNode:        volume_node.yaml
   WAFL:              wafl.yaml
   WAFLAggr:          wafl_hya_per_aggr.yaml
@@ -47,12 +47,12 @@ objects:
   NFSv4:             nfsv4.yaml
 #  NvmfRdmaPort:      nvmf_rdma_port.yaml
 #  NvmfTcpPort:       nvmf_tcp_port.yaml
-  OntapS3SVM:        ontap_s3_svm.yaml
+#  OntapS3SVM:        ontap_s3_svm.yaml
   SMB2:              smb2.yaml
   Volume:            volume.yaml
   VolumeSvm:         volume_svm.yaml
   WAFLCompBin:       wafl_comp_aggr_vol_bin.yaml
-  Vscan:             vscan.yaml
+#  Vscan:             vscan.yaml
   VscanSVM:          vscan_svm.yaml
 
 #  Uncomment to collect workload/QOS counters.

--- a/conf/zapiperf/default.yaml
+++ b/conf/zapiperf/default.yaml
@@ -26,12 +26,12 @@ objects:
   NVMfLif:                  nvmf_lif.yaml
   Namespace:                namespace.yaml
   NicCommon:                nic_common.yaml
-  ObjectStoreClient:        object_store_client_op.yaml
+#  ObjectStoreClient:        object_store_client_op.yaml
   Path:                     path.yaml
   Qtree:                    qtree.yaml
   Rwctx:                    rwctx.yaml
   SystemNode:               system_node.yaml
-  TokenManager:             token_manager.yaml
+#  TokenManager:             token_manager.yaml
   VolumeNode:               volume_node.yaml
   WAFL:                     wafl.yaml
   WAFLAggr:                 wafl_hya_per_aggr.yaml
@@ -52,12 +52,12 @@ objects:
   NFSv4:                    nfsv4.yaml
 #  NvmfRdmaPort:             nvmf_rdma_port.yaml
 #  NvmfTcpPort:              nvmf_tcp_port.yaml
-  OntapS3SVM:               ontap_s3_svm.yaml
+#  OntapS3SVM:               ontap_s3_svm.yaml
   SMB2:                     smb2.yaml
   Volume:                   volume.yaml
   VolumeSvm:                volume_svm.yaml
   WAFLCompBin:              wafl_comp_aggr_vol_bin.yaml
-  Vscan:                    vscan.yaml
+#  Vscan:                    vscan.yaml
   VscanSVM:                 vscan_svm.yaml
 
 #  Uncomment to collect workload/QOS counters.


### PR DESCRIPTION
Disable **4** templates from ZapiPerf and **3** templates from RestPerf.

As discussed, we will disable the few templates where no counters are used in any dashboards and leave remaining template as-is. So, closing this PR https://github.com/NetApp/harvest/pull/2507.