### PR TITLE
ci: fix nightly build

### DIFF
--- a/jenkins/artifacts/jenkinsfile
+++ b/jenkins/artifacts/jenkinsfile
@@ -70,10 +70,10 @@ pipeline {
                apt install -y git-all
                apt-get install -y build-essential
                apt install -y python3-pip
-               pip install mkdocs==1.4.3
+               pip install mkdocs==1.5.3
                pip install mike==1.1.2
-               pip install mkdocs-material-extensions==1.1.1
-               pip install mkdocs-material==9.1.11
+               pip install mkdocs-material-extensions==1.3
+               pip install mkdocs-material==9.5.6
                pip install mkdocs-macros-plugin==0.7.0
                 '''
             }


### PR DESCRIPTION
+ mike deploy -r https://****@github.com/NetApp/harvest.git --push --update-aliases nightly
error: MkDocs encountered an error parsing the configuration file: while constructing a Python object
cannot find module 'material.extensions.emoji' (No module named 'material.extensions')
  in "mkdocs.yml", line 100, column 20