### PR TITLE
feat: Change stat panel for uptime,power status,fan status to table in node dashboard

### DIFF
--- a/grafana/dashboards/cmode/node.json
+++ b/grafana/dashboards/cmode/node.json
@@ -77,7 +77,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1706780561075,
+  "iteration": 1707902598340,
   "links": [
     {
       "asDropdown": true,
@@ -876,11 +876,16 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "The total time, in seconds, that the node has been up.",
+      "description": "`Uptime:` This represents the total uptime of the node, formatted as duration (d hh:mm:ss)\n\n`Fan Status:` If there are chasis fans failure then it shows `Check Fans` else `OK`\n\n`Power Status:` If there are Power supply unit failures then it shows `Check Power` else `OK`\n\n`Healthy:` If Node is not healthy then it shows `No` else `Yes`.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": true
           },
           "mappings": [],
           "thresholds": {
@@ -892,210 +897,260 @@
               }
             ]
           },
-          "unit": "dtdhms"
+          "unit": "locale"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Uptime"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dtdhms"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Fan Status"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "string"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "OK"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "from": 0.1,
+                      "result": {
+                        "color": "red",
+                        "index": 1,
+                        "text": "Check Fans"
+                      },
+                      "to": 4294967295
+                    },
+                    "type": "range"
+                  }
+                ]
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-text"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Power Status"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "string"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "OK"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "from": 0.1,
+                      "result": {
+                        "index": 1,
+                        "text": "Check Power"
+                      },
+                      "to": 4294967295
+                    },
+                    "type": "range"
+                  }
+                ]
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-text"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Healthy"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "false": {
+                        "color": "red",
+                        "index": 1,
+                        "text": "No"
+                      },
+                      "true": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "Yes"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-text"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 4,
-        "w": 8,
+        "h": 14,
+        "w": 24,
         "x": 0,
         "y": 17
       },
-      "id": 105,
+      "id": 138,
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "vertical",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Uptime"
+          }
+        ]
       },
       "pluginVersion": "8.1.8",
       "targets": [
         {
           "exemplar": false,
-          "expr": "node_uptime{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"}",
-          "format": "time_series",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "{{cluster}} - {{node}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Node Uptime",
-      "type": "stat"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "description": "Specifies a count of the number of chassis fans that are not operating within the recommended RPM range.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "color": "green",
-                  "index": 0,
-                  "text": "OK"
-                }
-              },
-              "type": "value"
-            },
-            {
-              "options": {
-                "from": 0.1,
-                "result": {
-                  "color": "red",
-                  "index": 1,
-                  "text": "Check Fans"
-                },
-                "to": 1
-              },
-              "type": "range"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "string"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 8,
-        "y": 17
-      },
-      "id": 115,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "vertical",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.1.8",
-      "targets": [
-        {
-          "exemplar": false,
-          "expr": "node_failed_fan{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"}",
-          "format": "time_series",
+          "expr": "label_join(node_uptime{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"}, \"unique_id\", \"-\", \"datacenter\", \"cluster\", \"node\")",
+          "format": "table",
           "instant": true,
           "interval": "",
-          "legendFormat": "{{cluster}} - {{node}}",
+          "legendFormat": "",
           "refId": "A"
-        }
-      ],
-      "title": "Node Fan Status",
-      "type": "stat"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "description": "Number of failed power supply units.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "color": "green",
-                  "index": 0,
-                  "text": "OK"
-                }
-              },
-              "type": "value"
-            },
-            {
-              "options": {
-                "from": 0.1,
-                "result": {
-                  "color": "red",
-                  "index": 1,
-                  "text": "Check Power"
-                },
-                "to": 1
-              },
-              "type": "range"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "string"
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 16,
-        "y": 17
-      },
-      "id": 116,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "vertical",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.1.8",
-      "targets": [
         {
           "exemplar": false,
-          "expr": "node_failed_power{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"}",
-          "format": "time_series",
+          "expr": "label_join(node_failed_fan{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"}, \"unique_id\", \"-\", \"datacenter\", \"cluster\", \"node\")",
+          "format": "table",
+          "hide": false,
           "instant": true,
           "interval": "",
-          "legendFormat": "{{cluster}} - {{node}}",
-          "refId": "A"
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "exemplar": false,
+          "expr": "label_join(node_failed_power{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"}, \"unique_id\", \"-\", \"datacenter\", \"cluster\", \"node\")",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
+        },
+        {
+          "exemplar": false,
+          "expr": "label_join(node_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\",node=~\"$Node\"}, \"unique_id\", \"-\", \"datacenter\", \"cluster\", \"node\")",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "D"
         }
       ],
-      "title": "Node Power Status",
-      "type": "stat"
+      "title": "Node Details",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "unique_id"
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "cluster 1",
+                "datacenter 1",
+                "Value #A",
+                "Value #B",
+                "Value #C",
+                "cpu_firmware_release",
+                "healthy",
+                "location",
+                "model",
+                "vendor",
+                "version"
+              ]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Value #A": 2,
+              "Value #B": 3,
+              "Value #C": 4,
+              "cluster 1": 1,
+              "cpu_firmware_release": 9,
+              "datacenter 1": 0,
+              "healthy": 5,
+              "location": 7,
+              "model": 6,
+              "vendor": 10,
+              "version": 8
+            },
+            "renameByName": {
+              "Value #A": "Uptime",
+              "Value #B": "Fan Status",
+              "Value #C": "Power Status",
+              "cluster 1": "Cluster",
+              "cpu_firmware_release": "CPU Firmware Version",
+              "datacenter 1": "Datacenter",
+              "healthy": "Healthy",
+              "location": "Location",
+              "model": "Model",
+              "vendor": "Vendor",
+              "version": "Version"
+            }
+          }
+        }
+      ],
+      "type": "table"
     },
     {
       "collapsed": true,
@@ -1104,7 +1159,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 31
       },
       "id": 131,
       "panels": [
@@ -1392,7 +1447,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 32
       },
       "id": 57,
       "panels": [
@@ -1625,7 +1680,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 33
       },
       "id": 107,
       "panels": [
@@ -2006,7 +2061,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 34
       },
       "id": 28,
       "panels": [
@@ -2064,7 +2119,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 24
+            "y": 47
           },
           "id": 30,
           "options": {
@@ -2169,7 +2224,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 24
+            "y": 47
           },
           "id": 31,
           "options": {
@@ -2269,7 +2324,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 24
+            "y": 47
           },
           "id": 32,
           "options": {
@@ -2381,7 +2436,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 33
+            "y": 56
           },
           "id": 41,
           "options": {
@@ -2500,7 +2555,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 33
+            "y": 56
           },
           "id": 43,
           "options": {
@@ -2618,7 +2673,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 33
+            "y": 56
           },
           "id": 42,
           "options": {
@@ -2701,7 +2756,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 35
       },
       "id": 88,
       "panels": [
@@ -3449,7 +3504,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 36
       },
       "id": 59,
       "panels": [
@@ -3793,7 +3848,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 37
       },
       "id": 67,
       "panels": [
@@ -4207,7 +4262,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 38
       },
       "id": 118,
       "panels": [
@@ -4623,7 +4678,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 39
       },
       "id": 76,
       "panels": [
@@ -5037,7 +5092,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 40
       },
       "id": 38,
       "panels": [
@@ -5902,5 +5957,5 @@
   "timezone": "",
   "title": "ONTAP: Node",
   "uid": "",
-  "version": 9
+  "version": 10
 }


### PR DESCRIPTION
Before:


<img width="1847" alt="image" src="https://github.com/NetApp/harvest/assets/25551691/396e651a-aa9b-4b79-b726-c644c5b20eef">



After:

<img width="1846" alt="image" src="https://github.com/NetApp/harvest/assets/25551691/44f83072-4cd8-4cb1-bc66-9792b166eafb">
