### PR TITLE
fix: rest collector should include endpoint `api_time`s

### DIFF
--- a/cmd/collectors/rest/rest_test.go
+++ b/cmd/collectors/rest/rest_test.go
@@ -144,10 +144,10 @@ func Test_pollDataVolume(t *testing.T) {
 	}
 }
 
-func volumeEndpoints(e *endPoint) ([]gjson.Result, error) {
+func volumeEndpoints(e *endPoint) ([]gjson.Result, time.Duration, error) {
 	path := "testdata/" + strings.ReplaceAll(e.prop.Query, "/", "-") + ".json.gz"
 	gson := collectors.JSONToGson(path, true)
-	return gson, nil
+	return gson, 0, nil
 }
 
 func newRest(object string, path string) *Rest {


### PR DESCRIPTION
The rest collector's `api_time` only records how long it took for the first query in the rest template to execute, ignoring any endpoint times. Templates with multiple endpoints undercount the `api_time`. This pull request fixes the bug by including all endpoints `api_time`s in the reported `api_time`.