### PR TITLE
fix: handle inter-cluster snapmirrors when different datacenter

### DIFF
--- a/grafana/dashboards/cmode/snapmirror.json
+++ b/grafana/dashboards/cmode/snapmirror.json
@@ -4027,8 +4027,8 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(snapmirror_labels{system_type!=\"7mode\"},datacenter)",
-        "description": null,
+        "definition": "label_values(cluster_new_status{system_type!=\"7mode\"},datacenter)",
+        "description": "You need to choose all the datacenters where snapmirror source clusters reside",
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -4037,7 +4037,7 @@
         "name": "Datacenter",
         "options": [],
         "query": {
-          "query": "label_values(snapmirror_labels{system_type!=\"7mode\"},datacenter)",
+          "query": "label_values(cluster_new_status{system_type!=\"7mode\"},datacenter)",
           "refId": "Prometheus-Datacenter-Variable-Query"
         },
         "refresh": 2,


### PR DESCRIPTION
**Snapmirror details**
Source cluster             -->                    Destination cluster
C1_sti22-vsim-ucs583g_1707822354       -->        C1_sti12-vsim-ucs575w_1707989709
volume1                         -->            volume1dst
volume2                         -->            volume2dst

```
C1_sti12-vsim-ucs575w_1707989709::*> snapmirror show                                         
                                                                       Progress
Source            Destination Mirror  Relationship   Total             Last
Path        Type  Path        State   Status         Progress  Healthy Updated
----------- ---- ------------ ------- -------------- --------- ------- --------
vs0:volume1 XDP  svm1:volume1dst 
                              Uninitialized 
                                      Idle           -         false   -
vs0:volume2 XDP  svm1:volume2dst 
                              Uninitialized 
                                      Idle           -         false   -
2 entries were displayed.
```

**Harvest poller config**
```
  C1_sti22-vsim-ucs583g_1707822354:
        datacenter: SS

  C1_sti12-vsim-ucs575w_1707989709:
         datacenter: DD
```

**Prometheus response**
<img width="1772" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/2b919d22-2749-41e6-a6d8-cb5a7b4726ba">


**Grafana 10.3.1 UI** 
**Before the changes**
There is no SS datacenter listed in the dropdown list.
<img width="744" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/1687bf94-9b99-4315-bed8-1e8c31016702">


**After the changes**
We have added the description to understand which datacenter to choose from the list.
Now, SS and DD both are available to choose and If we choose SS then appropriate snapmirrors are listed in dashboard.
<img width="897" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/ed1fb337-338c-43dd-b185-e02b689f45c2">


<img width="1785" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/0d4f5910-a996-4671-9c35-9cc2d5b2a958">
