### PR TITLE
fix: purging unused metrics from shelf template for 7mode

### DIFF
--- a/cmd/collectors/zapi/plugins/shelf/shelf.go
+++ b/cmd/collectors/zapi/plugins/shelf/shelf.go
@@ -227,8 +227,9 @@ func (my *Shelf) handle7Mode(data *matrix.Matrix, result []*node.Node) ([]*matri
 	my.shelfMetrics.PurgeInstances()
 	my.shelfMetrics.Reset()
 
-	// Purge instances generated from template and updated data metrics from shelfMetrics
+	// Purge instances and metrics generated from template and updated data metrics and instances from shelfMetrics
 	data.PurgeInstances()
+	data.PurgeMetrics()
 	for metricName, m := range my.shelfMetrics.GetMetrics() {
 		_, err := data.NewMetricFloat64(metricName, m.GetName())
 		if err != nil {


### PR DESCRIPTION
**Before the fix with error**
```
harvest % ./bin/poller -p sar -c Zapi -o Shelf --promPort 13001
2024-02-21T07:56:35+05:30 INF poller/poller.go:215 > Init Poller=sar asup=false confPath=conf config=harvest.yml configPath=harvest.yml daemon=false debug=false homePath= hostname=hardikl-mac-0 logLevel=info logPath=/dev/stdout profiling=0 promPort=13001 version="harvest version 24.02.2107-v23.11.0 (commit d6d62688) (build date 2024-02-21T07:56:29+0530) darwin/amd64"
2024-02-21T07:56:35+05:30 INF poller/poller.go:239 > started in foreground Poller=sar pid=97047
2024-02-21T07:56:35+05:30 INF collector/helpers.go:84 > best-fit template Poller=sar collector=Zapi:Shelf path=conf/zapi/7mode/8.6.0/shelf.yaml v=8.2.0
2024-02-21T07:56:35+05:30 INF poller/poller.go:357 > Autosupport scheduled. Poller=sar asupSchedule=24h
2024-02-21T07:56:35+05:30 INF poller/poller.go:366 > poller start-up complete Poller=sar
2024-02-21T07:56:35+05:30 INF prometheus/httpd.go:40 > server listen Poller=sar exporter=prometheus1 url=http://:13001/metrics
2024-02-21T07:56:35+05:30 INF poller/poller.go:523 > updated status, up collectors: 1 (of 1), up exporters: 1 (of 1) Poller=sar
2024-02-21T07:56:35+05:30 INF collector/collector.go:585 > Collected Poller=sar apiMs=0 calcMs=0 collector=Zapi:Shelf exportMs=44 instances=3 instancesExported=5616 metrics=107 metricsExported=15056 parseMs=0 pluginMs=23 pollMs=58 zBegin=1708482395501
2024-02-21T07:57:05+05:30 ERR shelf/shelf.go:238 > add metric error="duplicate metric key => status-reads-failed" Poller=sar object=Shelf plugin=Zapi:Shelf
2024-02-21T07:57:05+05:30 ERR shelf/shelf.go:238 > add metric error="duplicate metric key => status-reads-attempted" Poller=sar object=Shelf plugin=Zapi:Shelf
2024-02-21T07:57:05+05:30 INF collector/collector.go:585 > Collected Poller=sar apiMs=0 calcMs=0 collector=Zapi:Shelf exportMs=40 instances=3 instancesExported=5616 metrics=107 metricsExported=15056 parseMs=0 pluginMs=23 pollMs=55 zBegin=1708482425501
2024-02-21T07:57:35+05:30 ERR shelf/shelf.go:238 > add metric error="duplicate metric key => status-reads-attempted" Poller=sar object=Shelf plugin=Zapi:Shelf
2024-02-21T07:57:35+05:30 ERR shelf/shelf.go:238 > add metric error="duplicate metric key => status-reads-failed" Poller=sar object=Shelf plugin=Zapi:Shelf
2024-02-21T07:57:35+05:30 INF collector/collector.go:585 > Collected Poller=sar apiMs=0 calcMs=0 collector=Zapi:Shelf exportMs=29 instances=3 instancesExported=5616 metrics=107 metricsExported=15056 parseMs=0 pluginMs=16 pollMs=43 zBegin=1708482455501
```

**Metrics count:**
```
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf_ | wc -l   
    1178
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf_fan | wc -l
     220
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf_tem | wc -l
     376
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf_sens | wc -l
     220
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf_vol | wc -l 
     220
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf_psu | wc -l
      84
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf_new | wc -l
      13
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf_la | wc -l 
      13
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf | grep atte | wc -l
      16
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf | grep failed | wc -l
      16
```



**After the fix, without error**
```
harvest % ./bin/poller -p sar -c Zapi -o Shelf --promPort 13001
2024-02-21T08:19:42+05:30 INF poller/poller.go:215 > Init Poller=sar asup=false confPath=conf config=harvest.yml configPath=harvest.yml daemon=false debug=false homePath= hostname=hardikl-mac-0 logLevel=info logPath=/dev/stdout profiling=0 promPort=13001 version="harvest version 24.02.2108-v23.11.0 (commit d6d62688) (build date 2024-02-21T08:19:34+0530) darwin/amd64"
2024-02-21T08:19:42+05:30 INF poller/poller.go:239 > started in foreground Poller=sar pid=1830
2024-02-21T08:19:42+05:30 INF collector/helpers.go:84 > best-fit template Poller=sar collector=Zapi:Shelf path=conf/zapi/7mode/8.6.0/shelf.yaml v=8.2.0
2024-02-21T08:19:42+05:30 INF poller/poller.go:357 > Autosupport scheduled. Poller=sar asupSchedule=24h
2024-02-21T08:19:42+05:30 INF poller/poller.go:366 > poller start-up complete Poller=sar
2024-02-21T08:19:42+05:30 INF prometheus/httpd.go:40 > server listen Poller=sar exporter=prometheus1 url=http://:13001/metrics
2024-02-21T08:19:42+05:30 INF poller/poller.go:523 > updated status, up collectors: 1 (of 1), up exporters: 1 (of 1) Poller=sar
2024-02-21T08:19:42+05:30 INF collector/collector.go:585 > Collected Poller=sar apiMs=0 calcMs=0 collector=Zapi:Shelf exportMs=34 instances=3 instancesExported=5616 metrics=107 metricsExported=15044 parseMs=0 pluginMs=19 pollMs=47 zBegin=1708483782797
2024-02-21T08:20:12+05:30 INF collector/collector.go:585 > Collected Poller=sar apiMs=0 calcMs=0 collector=Zapi:Shelf exportMs=29 instances=3 instancesExported=5616 metrics=81 metricsExported=15044 parseMs=0 pluginMs=16 pollMs=38 zBegin=1708483812892
2024-02-21T08:20:42+05:30 INF collector/collector.go:585 > Collected Poller=sar apiMs=0 calcMs=0 collector=Zapi:Shelf exportMs=29 instances=3 instancesExported=5616 metrics=81 metricsExported=15044 parseMs=0 pluginMs=19 pollMs=50 zBegin=1708483842892
2024-02-21T08:21:12+05:30 INF collector/collector.go:585 > Collected Poller=sar apiMs=0 calcMs=0 collector=Zapi:Shelf exportMs=36 instances=3 instancesExported=5616 metrics=81 metricsExported=15044 parseMs=0 pluginMs=21 pollMs=51 zBegin=1708483872893
```

**Metrics count**
```
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf_ | wc -l             
    1172
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf_fan | wc -l
     220
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf_tem | wc -l
     376
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf_sens | wc -l
     220
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf_vol | wc -l 
     220
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf_psu | wc -l
      84
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf_new | wc -l
      13
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf_la | wc -l 
      13
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf | grep atte | wc -l
      13
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_"  | grep shelf | grep failed | wc -l
      13
```
