### PR TITLE
feat: Adding zapi/rest templates for lock-get-iter & protocols/locks

### DIFF
--- a/conf/rest/9.10.0/lock.yaml
+++ b/conf/rest/9.10.0/lock.yaml
@@ -7,7 +7,7 @@ counters:
   - ^interface.name     => lif
   - ^node.name          => node
   - ^path               => path
-  - ^state              => lock_state
+  - ^state              => state
   - ^svm.name           => svm
   - ^volume.name        => volume
 
@@ -15,7 +15,7 @@ plugins:
   - LabelAgent:
       # metric label zapi_value rest_value `default_value`
       value_to_num_regex:
-        - count lock_state .* .* `0`
+        - count state .* .* `0`
   - Aggregator:
       # plugin will create summary/average for each object
       # any names after the object names will be treated as

--- a/conf/rest/9.10.0/lock.yaml
+++ b/conf/rest/9.10.0/lock.yaml
@@ -1,0 +1,30 @@
+name:             Lock
+query:            api/protocols/locks
+object:           lock
+
+counters:
+  - ^^uuid              => uuid
+  - ^interface.name     => lif
+  - ^node.name          => node
+  - ^path               => path
+  - ^state              => lock_state
+  - ^svm.name           => svm
+  - ^volume.name        => volume
+
+plugins:
+  - LabelAgent:
+      # metric label zapi_value rest_value `default_value`
+      value_to_num_regex:
+        - count lock_state .* .* `0`
+  - Aggregator:
+      # plugin will create summary/average for each object
+      # any names after the object names will be treated as
+      # label names that will be added to instances
+      - node
+      - svm
+      - lif
+      - volume
+
+# only export node/aggr aggregations from plugin
+# set this true or comment, to get data for each lock
+export_data: false

--- a/conf/rest/default.yaml
+++ b/conf/rest/default.yaml
@@ -20,6 +20,7 @@ objects:
   FlexCache:                   flexcache.yaml
   FCP:                         fcp.yaml
   LIF:                         lif.yaml
+#  Lock:                        lock.yaml
   Health:                      health.yaml
   Lun:                         lun.yaml
   MetroclusterCheck:           metrocluster_check.yaml

--- a/conf/zapi/cdot/9.8.0/lock.yaml
+++ b/conf/zapi/cdot/9.8.0/lock.yaml
@@ -10,7 +10,7 @@ counters:
     - ^node                 => node
     - ^path                 => path
     - ^volume               => volume
-    - ^vserver              => vserver
+    - ^vserver              => svm
 
 collect_only_labels: true
 
@@ -24,7 +24,7 @@ plugins:
     # any names after the object names will be treated as
     # label names that will be added to instances
     - node
-    - vserver
+    - svm
     - lif
     - volume
 

--- a/conf/zapi/cdot/9.8.0/lock.yaml
+++ b/conf/zapi/cdot/9.8.0/lock.yaml
@@ -6,7 +6,7 @@ counters:
   lock-info:
     - ^^lockid              => lockid
     - ^lif                  => lif
-    - ^lock-state           => lock_state
+    - ^lock-state           => state
     - ^node                 => node
     - ^path                 => path
     - ^volume               => volume
@@ -18,7 +18,7 @@ plugins:
   - LabelAgent:
       # metric label zapi_value rest_value `default_value`
       value_to_num_regex:
-        - count lock_state .* .* `0`
+        - count state .* .* `0`
   - Aggregator:
     # plugin will create summary/average for each object
     # any names after the object names will be treated as

--- a/conf/zapi/cdot/9.8.0/lock.yaml
+++ b/conf/zapi/cdot/9.8.0/lock.yaml
@@ -18,7 +18,7 @@ plugins:
   - LabelAgent:
       # metric label zapi_value rest_value `default_value`
       value_to_num_regex:
-        - new_status lock_state .* .* `0`
+        - count lock_state .* .* `0`
   - Aggregator:
     # plugin will create summary/average for each object
     # any names after the object names will be treated as
@@ -32,12 +32,3 @@ plugins:
 # set this true or comment, to get data for each lock
 export_data: false
 
-export_options:
-  instance_keys:
-    - lockid
-  instance_labels:
-    - lif
-    - node
-    - path
-    - volume
-    - vserver

--- a/conf/zapi/cdot/9.8.0/lock.yaml
+++ b/conf/zapi/cdot/9.8.0/lock.yaml
@@ -6,13 +6,31 @@ counters:
   lock-info:
     - ^^lockid              => lockid
     - ^lif                  => lif
+    - ^lock-state           => lock_state
     - ^node                 => node
     - ^path                 => path
     - ^volume               => volume
     - ^vserver              => vserver
 
-
 collect_only_labels: true
+
+plugins:
+  - LabelAgent:
+      # metric label zapi_value rest_value `default_value`
+      value_to_num_regex:
+        - new_status lock_state .* .* `0`
+  - Aggregator:
+    # plugin will create summary/average for each object
+    # any names after the object names will be treated as
+    # label names that will be added to instances
+    - node
+    - vserver
+    - lif
+    - volume
+
+# only export node/aggr aggregations from plugin
+# set this true or comment, to get data for each lock
+export_data: false
 
 export_options:
   instance_keys:
@@ -23,5 +41,3 @@ export_options:
     - path
     - volume
     - vserver
-
-

--- a/conf/zapi/cdot/9.8.0/lock.yaml
+++ b/conf/zapi/cdot/9.8.0/lock.yaml
@@ -1,0 +1,27 @@
+name:       Lock
+query:      lock-get-iter
+object:     lock
+
+counters:
+  lock-info:
+    - ^^lockid              => lockid
+    - ^lif                  => lif
+    - ^node                 => node
+    - ^path                 => path
+    - ^volume               => volume
+    - ^vserver              => vserver
+
+
+collect_only_labels: true
+
+export_options:
+  instance_keys:
+    - lockid
+  instance_labels:
+    - lif
+    - node
+    - path
+    - volume
+    - vserver
+
+

--- a/conf/zapi/cdot/9.8.0/lock.yaml
+++ b/conf/zapi/cdot/9.8.0/lock.yaml
@@ -4,7 +4,7 @@ object:     lock
 
 counters:
   lock-info:
-    - ^^lockid              => lockid
+    - ^^lockid              => uuid
     - ^lif                  => lif
     - ^lock-state           => state
     - ^node                 => node

--- a/conf/zapi/default.yaml
+++ b/conf/zapi/default.yaml
@@ -17,7 +17,7 @@ objects:
   EmsDestination:              ems_destination.yaml
   FlexCache:                   flexcache.yaml
   LIF:                         lif.yaml
-  Lock:                        lock.yaml
+#  Lock:                        lock.yaml
   Lun:                         lun.yaml
 #  NetPort:                     netport.yaml
   Namespace:                   namespace.yaml

--- a/conf/zapi/default.yaml
+++ b/conf/zapi/default.yaml
@@ -17,6 +17,7 @@ objects:
   EmsDestination:              ems_destination.yaml
   FlexCache:                   flexcache.yaml
   LIF:                         lif.yaml
+  Lock:                        lock.yaml
   Lun:                         lun.yaml
 #  NetPort:                     netport.yaml
   Namespace:                   namespace.yaml


### PR DESCRIPTION
Adding the zapi template for lock-get-iter.

With these below promQL queries, we can get lock count by volume, vserver, lif, node and cluster level and use them for alerting purpose.

<img width="1786" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/351d175d-2a16-4385-b5ee-75062b666a4a">
