### PR TITLE
feat: dashboards would work with grafana 10.x.x

### DIFF
--- a/cmd/tools/grafana/grafana.go
+++ b/cmd/tools/grafana/grafana.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -33,7 +32,7 @@ import (
 
 const (
 	clientTimeout                 = 5
-	grafanaDataSource             = "prometheus"
+	DefaultDataSource             = "prometheus"
 	GPerm             os.FileMode = 0644
 )
 
@@ -459,7 +458,7 @@ func importDashboards(opts *options) {
 
 func importFiles(dir string, folder *Folder) {
 	var (
-		request, dashboard map[string]interface{}
+		request, dashboard map[string]any
 		files              []os.DirEntry
 		importedFiles      int
 		data               []byte
@@ -546,7 +545,7 @@ func importFiles(dir string, folder *Folder) {
 			continue
 		}
 
-		request = make(map[string]interface{})
+		request = make(map[string]any)
 		request["overwrite"] = opts.overwrite
 		request["folderId"] = folder.id
 		request["dashboard"] = dashboard
@@ -585,7 +584,7 @@ func importFiles(dir string, folder *Folder) {
 	}
 }
 
-func writeCustomDashboard(dashboard map[string]interface{}, dir string, file os.DirEntry) error {
+func writeCustomDashboard(dashboard map[string]any, dir string, file os.DirEntry) error {
 	data, err := json.Marshal(dashboard)
 	if err != nil {
 		return err
@@ -609,11 +608,11 @@ func writeCustomDashboard(dashboard map[string]interface{}, dir string, file os.
 // add a constant prefix to all metrics, before they are pushed
 // to GitHub, then replace them with a user-defined prefix
 // (or empty string) when the import tool is used.
-func addGlobalPrefix(db map[string]interface{}, prefix string) {
+func addGlobalPrefix(db map[string]any, prefix string) {
 
 	var (
 		panels, templates, subPanels       []interface{}
-		panel, templating, template, query map[string]interface{}
+		panel, templating, template, query map[string]any
 		queryString, definition            string
 		ok, has                            bool
 	)
@@ -632,7 +631,7 @@ func addGlobalPrefix(db map[string]interface{}, prefix string) {
 		handlingPanels(p, prefix)
 
 		// handling for sub-panels
-		if panel, ok = p.(map[string]interface{}); !ok {
+		if panel, ok = p.(map[string]any); !ok {
 			continue
 		}
 
@@ -647,7 +646,7 @@ func addGlobalPrefix(db map[string]interface{}, prefix string) {
 	}
 
 	// apply to variables
-	if templating, ok = db["templating"].(map[string]interface{}); !ok {
+	if templating, ok = db["templating"].(map[string]any); !ok {
 		return
 	}
 
@@ -656,11 +655,11 @@ func addGlobalPrefix(db map[string]interface{}, prefix string) {
 	}
 
 	for _, t := range templates {
-		if template, ok = t.(map[string]interface{}); ok {
+		if template, ok = t.(map[string]any); ok {
 			if definition, ok = template["definition"].(string); ok {
 				template["definition"] = addPrefixToMetricNames(definition, prefix)
 			}
-			if query, ok = template["query"].(map[string]interface{}); ok {
+			if query, ok = template["query"].(map[string]any); ok {
 				if queryString, ok = query["query"].(string); ok {
 					query["query"] = addPrefixToMetricNames(queryString, prefix)
 				}
@@ -672,11 +671,11 @@ func addGlobalPrefix(db map[string]interface{}, prefix string) {
 func handlingPanels(p interface{}, prefix string) {
 	var (
 		targets       []interface{}
-		panel, target map[string]interface{}
+		panel, target map[string]any
 		ok, has       bool
 		expr          string
 	)
-	if panel, ok = p.(map[string]interface{}); !ok {
+	if panel, ok = p.(map[string]any); !ok {
 		return
 	}
 
@@ -689,7 +688,7 @@ func handlingPanels(p interface{}, prefix string) {
 	}
 
 	for _, t := range targets {
-		if target, ok = t.(map[string]interface{}); !ok {
+		if target, ok = t.(map[string]any); !ok {
 			continue
 		}
 		if _, has = target["expr"]; has {
@@ -763,6 +762,7 @@ func checkToken(opts *options, ignoreConfig bool, tries int) error {
 	var (
 		token, configPath, answer string
 		err                       error
+		isValidDS                 bool
 	)
 
 	if tries == 0 {
@@ -830,25 +830,22 @@ func checkToken(opts *options, ignoreConfig bool, tries int) error {
 		}
 	}
 
-	// get grafana version, we are more or less guaranteed this succeeds
+	// get grafana version
 	if result, _, _, err = sendRequest(opts, "GET", "/api/frontend/settings", nil); err != nil {
 		return err
 	}
 
-	isValidDS := isValidDatasource(result)
 	if opts.forceImport {
-		fmt.Printf("warning: Prometheus type datasource hasn't been validated against grafana \n")
-		fmt.Printf("continue anyway? [y/N]: ")
-		_, _ = fmt.Scanf("%s\n", &answer)
-		if answer != "y" && answer != "yes" {
-			os.Exit(0)
-		}
-	} else if !isValidDS {
-		fmt.Printf("Prometheus type datasource is either not exist in Grafana or not matching with given datasource name.")
+		isValidDS = true
+	} else {
+		isValidDS = isValidDatasource(result)
+	}
+	if !isValidDS {
+		fmt.Printf("A Prometheus-typed datasource named \"%s\" does not exist in Grafana.\n", opts.datasource)
 		os.Exit(0)
 	}
 
-	buildInfo := result["buildInfo"].(map[string]interface{})
+	buildInfo := result["buildInfo"].(map[string]any)
 	if buildInfo == nil {
 		fmt.Printf("warning: unable to get grafana version. Ignoring grafana version check")
 		return nil
@@ -872,41 +869,36 @@ func checkToken(opts *options, ignoreConfig bool, tries int) error {
 	return nil
 }
 
-func isValidDatasource(result map[string]interface{}) bool {
-	isValidDs := false
-	promDSSlice := make([]string, 0)
-
+func isValidDatasource(result map[string]any) bool {
 	if result == nil {
-		fmt.Printf("warning: unable to get datasources detail")
-		return isValidDs
+		fmt.Printf("warning: result is null.")
+		return false
 	}
 	datasourcesInfo := result["datasources"]
 	if datasourcesInfo == nil {
-		fmt.Printf("warning: unable to get datasources detail")
-		return isValidDs
-	}
-	for dsName, dsInfo := range datasourcesInfo.(map[string]interface{}) {
-		if dsInfo == nil {
-			fmt.Printf("warning: unable to get datasources detail")
-			return isValidDs
-		}
-		dsDetail := dsInfo.(map[string]interface{})
-		dsType := dsDetail["type"]
-		if dsType == nil {
-			fmt.Printf("warning: unable to get datasource type")
-			continue
-		}
-		if dsType.(string) == "prometheus" {
-			promDSSlice = append(promDSSlice, dsName)
-			isValidDs = true
-		}
-	}
-
-	if isValidDs && !slices.Contains(promDSSlice, opts.datasource) {
+		fmt.Printf("warning: datasources are missing")
 		return false
 	}
 
-	return isValidDs
+	for dsName, dsInfo := range datasourcesInfo.(map[string]any) {
+		if dsInfo == nil {
+			fmt.Printf("warning: dsInfo is missing for %s\n", dsName)
+			continue
+		}
+		dsDetail := dsInfo.(map[string]any)
+		dsType := dsDetail["type"]
+		if dsType == nil {
+			fmt.Printf("warning: dsType is missing for %s\n", dsName)
+			continue
+		}
+		if dsType.(string) == DefaultDataSource && strings.EqualFold(dsName, opts.datasource) {
+			// overwrite datasource name with the one from Grafana when the names differ by case
+			opts.datasource = dsName
+			return true
+		}
+	}
+
+	return false
 }
 
 func checkVersion(inputVersion string) bool {
@@ -982,9 +974,9 @@ func createServerFolder(folder *Folder) error {
 	return nil
 }
 
-func sendRequest(opts *options, method, url string, query map[string]interface{}) (map[string]interface{}, string, int, error) {
+func sendRequest(opts *options, method, url string, query map[string]any) (map[string]any, string, int, error) {
 
-	var result map[string]interface{}
+	var result map[string]any
 
 	data, status, code, err := doRequestWithRetry(opts, method, url, query, 3)
 	if err != nil {
@@ -998,9 +990,9 @@ func sendRequest(opts *options, method, url string, query map[string]interface{}
 	return result, status, code, err
 }
 
-func sendRequestArray(opts *options, method, url string, query map[string]interface{}) ([]map[string]interface{}, string, int, error) {
+func sendRequestArray(opts *options, method, url string, query map[string]any) ([]map[string]any, string, int, error) {
 
-	var result []map[string]interface{}
+	var result []map[string]any
 
 	data, status, code, err := doRequestWithRetry(opts, method, url, query, 3)
 	if err != nil {
@@ -1036,7 +1028,7 @@ func doRequestWithRetry(opts *options, method, url string, query map[string]any,
 	return data, status, code, err
 }
 
-func doRequest(opts *options, method, url string, query map[string]interface{}) ([]byte, string, int, error) {
+func doRequest(opts *options, method, url string, query map[string]any) ([]byte, string, int, error) {
 
 	var (
 		request  *http.Request
@@ -1136,10 +1128,10 @@ func init() {
 		"For each label, create a variable and add as chained query to other variables")
 	importCmd.PersistentFlags().BoolVar(&opts.addMultiSelect, "multi", true,
 		"Modify the dashboards to add multi-select dropdowns for each variable")
-	importCmd.PersistentFlags().BoolVar(&opts.forceImport, "forceImport", false,
-		"Use force dashboard import without datasource being added to grafana")
+	importCmd.PersistentFlags().BoolVar(&opts.forceImport, "force", false,
+		"Import even if the datasource name is not defined in Grafana")
 	_ = importCmd.PersistentFlags().MarkHidden("multi")
-	_ = importCmd.PersistentFlags().MarkHidden("forceImport")
+	_ = importCmd.PersistentFlags().MarkHidden("force")
 
 	metricsCmd.PersistentFlags().StringVarP(&opts.dir, "directory", "d",
 		"", "local directory that contains dashboards (searched recursively).")
@@ -1155,7 +1147,7 @@ func addCommonFlags(commands ...*cobra.Command) {
 		cmd.PersistentFlags().StringVar(&opts.config, "config", "./harvest.yml", "harvest config file path")
 		cmd.PersistentFlags().StringVar(&opts.svmRegex, "svm-variable-regex", "", "SVM variable regex to filter SVM query results")
 		cmd.PersistentFlags().StringVarP(&opts.prefix, "prefix", "p", "", "Use global metric prefix in queries")
-		cmd.PersistentFlags().StringVarP(&opts.datasource, "datasource", "s", grafanaDataSource, "Name of your Prometheus datasource used by the imported dashboards")
+		cmd.PersistentFlags().StringVarP(&opts.datasource, "datasource", "s", DefaultDataSource, "Name of your Prometheus datasource used by the imported dashboards")
 		cmd.PersistentFlags().BoolVarP(&opts.variable, "variable", "v", false, "Use datasource as variable, overrides: --datasource")
 		cmd.PersistentFlags().StringVarP(&opts.dir, "directory", "d", "", "When importing, import dashboards from this local directory.\nWhen exporting, local directory to write dashboards to")
 

--- a/cmd/tools/grafana/grafana_test.go
+++ b/cmd/tools/grafana/grafana_test.go
@@ -191,3 +191,81 @@ func TestChainedParsing(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidDatasource(t *testing.T) {
+	type test struct {
+		name   string
+		result map[string]interface{}
+		dsArg  string
+		want   bool
+	}
+
+	noDS := map[string]interface{}{
+		"datasources": nil,
+	}
+	nonPrometheusDS := map[string]interface{}{
+		"datasources": map[string]interface{}{
+			"Grafana": map[string]interface{}{
+				"type": "dashboard",
+			},
+			"Influx": map[string]interface{}{
+				"type": "influxdb",
+			},
+		},
+	}
+	defaultPrometheusDS := map[string]interface{}{
+		"datasources": map[string]interface{}{
+			"Influx": map[string]interface{}{
+				"type": "influxdb",
+			},
+			"prometheus": map[string]interface{}{
+				"type": "prometheus",
+			},
+		},
+	}
+	multiPrometheusDSWithSameDS := map[string]interface{}{
+		"datasources": map[string]interface{}{
+			"Influx": map[string]interface{}{
+				"type": "influxdb",
+			},
+			"prometheus": map[string]interface{}{
+				"type": "prometheus",
+			},
+			"NetProm": map[string]interface{}{
+				"type": "prometheus",
+			},
+		},
+	}
+	multiPrometheusDSWithOtherDS := map[string]interface{}{
+		"datasources": map[string]interface{}{
+			"Influx": map[string]interface{}{
+				"type": "influxdb",
+			},
+			"prometheus": map[string]interface{}{
+				"type": "prometheus",
+			},
+			"NetProm": map[string]interface{}{
+				"type": "prometheus",
+			},
+		},
+	}
+
+	tests := []test{
+		{name: "empty", result: nil, dsArg: "prometheus", want: false},
+		{name: "nil datasource", result: noDS, dsArg: "prometheus", want: false},
+		{name: "non prometheus datasource", result: nonPrometheusDS, dsArg: "prometheus", want: false},
+		{name: "valid prometheus datasource", result: defaultPrometheusDS, dsArg: "prometheus", want: true},
+		{name: "multiple prometheus datasource with same datasource given", result: multiPrometheusDSWithSameDS, dsArg: "NetProm", want: true},
+		{name: "multiple prometheus datasource with different datasource given", result: multiPrometheusDSWithOtherDS, dsArg: "UpdateProm", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts.datasource = tt.dsArg
+			got := isValidDatasource(tt.result)
+			if got != tt.want {
+				t.Errorf("TestIsValidDatasource\n got=[%v]\nwant=[%v]", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/tools/grafana/grafana_test.go
+++ b/cmd/tools/grafana/grafana_test.go
@@ -66,7 +66,7 @@ func TestHttpsAddr(t *testing.T) {
 func TestAddPrefixToMetricNames(t *testing.T) {
 
 	var (
-		dashboard                      map[string]interface{}
+		dashboard                      map[string]any
 		oldExpressions, newExpressions []string
 		updatedData                    []byte
 		err                            error
@@ -195,66 +195,77 @@ func TestChainedParsing(t *testing.T) {
 func TestIsValidDatasource(t *testing.T) {
 	type test struct {
 		name   string
-		result map[string]interface{}
+		result map[string]any
 		dsArg  string
 		want   bool
 	}
 
-	noDS := map[string]interface{}{
+	noDS := map[string]any{
 		"datasources": nil,
 	}
-	nonPrometheusDS := map[string]interface{}{
-		"datasources": map[string]interface{}{
-			"Grafana": map[string]interface{}{
+	nonPrometheusDS := map[string]any{
+		"datasources": map[string]any{
+			"Grafana": map[string]any{
 				"type": "dashboard",
 			},
-			"Influx": map[string]interface{}{
+			"Influx": map[string]any{
 				"type": "influxdb",
 			},
 		},
 	}
-	defaultPrometheusDS := map[string]interface{}{
-		"datasources": map[string]interface{}{
-			"Influx": map[string]interface{}{
+	defaultPrometheusDS := map[string]any{
+		"datasources": map[string]any{
+			"Influx": map[string]any{
 				"type": "influxdb",
 			},
-			"prometheus": map[string]interface{}{
-				"type": "prometheus",
+			DefaultDataSource: map[string]any{
+				"type": DefaultDataSource,
 			},
 		},
 	}
-	multiPrometheusDSWithSameDS := map[string]interface{}{
-		"datasources": map[string]interface{}{
-			"Influx": map[string]interface{}{
+	legacyPrometheusDS := map[string]any{
+		"datasources": map[string]any{
+			"Influx": map[string]any{
 				"type": "influxdb",
 			},
-			"prometheus": map[string]interface{}{
-				"type": "prometheus",
-			},
-			"NetProm": map[string]interface{}{
-				"type": "prometheus",
+			"Prometheus": map[string]any{
+				"type": DefaultDataSource,
 			},
 		},
 	}
-	multiPrometheusDSWithOtherDS := map[string]interface{}{
-		"datasources": map[string]interface{}{
-			"Influx": map[string]interface{}{
+	multiPrometheusDSWithSameDS := map[string]any{
+		"datasources": map[string]any{
+			"Influx": map[string]any{
 				"type": "influxdb",
 			},
-			"prometheus": map[string]interface{}{
-				"type": "prometheus",
+			DefaultDataSource: map[string]any{
+				"type": DefaultDataSource,
 			},
-			"NetProm": map[string]interface{}{
-				"type": "prometheus",
+			"NetProm": map[string]any{
+				"type": DefaultDataSource,
+			},
+		},
+	}
+	multiPrometheusDSWithOtherDS := map[string]any{
+		"datasources": map[string]any{
+			"Influx": map[string]any{
+				"type": "influxdb",
+			},
+			DefaultDataSource: map[string]any{
+				"type": DefaultDataSource,
+			},
+			"NetProm": map[string]any{
+				"type": DefaultDataSource,
 			},
 		},
 	}
 
 	tests := []test{
-		{name: "empty", result: nil, dsArg: "prometheus", want: false},
-		{name: "nil datasource", result: noDS, dsArg: "prometheus", want: false},
-		{name: "non prometheus datasource", result: nonPrometheusDS, dsArg: "prometheus", want: false},
-		{name: "valid prometheus datasource", result: defaultPrometheusDS, dsArg: "prometheus", want: true},
+		{name: "empty", result: nil, dsArg: DefaultDataSource, want: false},
+		{name: "nil datasource", result: noDS, dsArg: DefaultDataSource, want: false},
+		{name: "non prometheus datasource", result: nonPrometheusDS, dsArg: DefaultDataSource, want: false},
+		{name: "valid prometheus datasource", result: defaultPrometheusDS, dsArg: DefaultDataSource, want: true},
+		{name: "legacy valid prometheus datasource", result: legacyPrometheusDS, dsArg: DefaultDataSource, want: true},
 		{name: "multiple prometheus datasource with same datasource given", result: multiPrometheusDSWithSameDS, dsArg: "NetProm", want: true},
 		{name: "multiple prometheus datasource with different datasource given", result: multiPrometheusDSWithOtherDS, dsArg: "UpdateProm", want: false},
 	}

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -27,7 +27,10 @@ Similarly, to export:
 $ bin/harvest grafana export --addr my.grafana.server:3000 --directory /path/to/export/directory --serverfolder grafanaFolderName
 ```
 
-By default, the dashboards are connected to a datasource named `Prometheus`. This is a datasource of the Prometheus type, defined in Grafana. However, despite the type, the datasource can have any name. If you have a Prometheus type datasource with a name different from `Prometheus`, you can specify this name using the `--datasource` flag during import/export.
+By default, the dashboards are connected to a datasource named `prometheus`. This is a datasource of the Prometheus type, defined in Grafana. However, despite the type, the datasource can have any name. If you have a Prometheus type datasource with a name different from `prometheus`, you can specify this name using the `--datasource` flag during import/export.
+```
+$ bin/harvest grafana import --datasource custom_datasource_name --addr my.grafana.server:3000
+```
 ### CLI
 
 The `bin/harvest grafana` tool includes CLI help when passing the `--help` command line argument flag like so:

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -17,20 +17,26 @@ or add the token to the `Tools` section of your configuration file. (see below)
 For example, let's say your Grafana server is on `http://my.grafana.server:3000` and you want to import the
 Prometheus-based dashboards from the `grafana` directory. You would run this:
 
-```
-$ bin/harvest grafana import --addr my.grafana.server:3000
+```bash
+bin/harvest grafana import --addr my.grafana.server:3000
 ```
 
 Similarly, to export:
 
-```
-$ bin/harvest grafana export --addr my.grafana.server:3000 --directory /path/to/export/directory --serverfolder grafanaFolderName
+```bash
+bin/harvest grafana export --addr my.grafana.server:3000 --directory /path/to/export/directory --serverfolder grafanaFolderName
 ```
 
-By default, the dashboards are connected to a datasource named `prometheus`. This is a datasource of the Prometheus type, defined in Grafana. However, despite the type, the datasource can have any name. If you have a Prometheus type datasource with a name different from `prometheus`, you can specify this name using the `--datasource` flag during import/export.
+By default, the dashboards are connected to a datasource named `prometheus` (case-sensitive).
+This is a datasource of the Prometheus type, defined in Grafana.
+However, despite the type, the datasource can have any name.
+If you have a Prometheus type datasource with a name different from `prometheus`,
+you can specify this name using the `--datasource` flag during import/export like this:
+
+```bash
+bin/harvest grafana import --addr my.grafana.server:3000 --datasource custom_datasource_name
 ```
-$ bin/harvest grafana import --datasource custom_datasource_name --addr my.grafana.server:3000
-```
+
 ### CLI
 
 The `bin/harvest grafana` tool includes CLI help when passing the `--help` command line argument flag like so:
@@ -56,7 +62,7 @@ This will cause Harvest to do the following for each dashboard:
 
 Here's an example:
 
-```
+```bash
 bin/harvest grafana import --labels "org,dept"
 ```
 

--- a/grafana/datasources/datasource.yml
+++ b/grafana/datasources/datasource.yml
@@ -1,7 +1,7 @@
 apiVersion: 1
 
 datasources:
-  - name: Prometheus
+  - name: prometheus
     type: prometheus
     access: proxy
     orgId: 1

--- a/integration/test/utils/utils.go
+++ b/integration/test/utils/utils.go
@@ -190,7 +190,7 @@ func AddPrometheusToGrafana() {
 	log.Info().Msg("Add Prometheus into Grafana")
 	url := GetGrafanaHTTPURL() + "/api/datasources"
 	method := "POST"
-	jsonValue := []byte(fmt.Sprintf(`{"name": "Prometheus", "type": "prometheus", "access": "direct",
+	jsonValue := []byte(fmt.Sprintf(`{"name": "prometheus", "type": "prometheus", "access": "direct",
 		"url": "%s", "isDefault": true, "basicAuth": false}`, "http://"+GetOutboundIP()+":"+PrometheusPort))
 	data := SendReqAndGetRes(url, method, jsonValue)
 	key := fmt.Sprintf("%v", data["message"])

--- a/integration/test/utils/utils.go
+++ b/integration/test/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/netapp/harvest/v2/cmd/tools/grafana"
 	"github.com/netapp/harvest/v2/pkg/conf"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -190,8 +191,11 @@ func AddPrometheusToGrafana() {
 	log.Info().Msg("Add Prometheus into Grafana")
 	url := GetGrafanaHTTPURL() + "/api/datasources"
 	method := "POST"
-	jsonValue := []byte(fmt.Sprintf(`{"name": "prometheus", "type": "prometheus", "access": "direct",
-		"url": "%s", "isDefault": true, "basicAuth": false}`, "http://"+GetOutboundIP()+":"+PrometheusPort))
+	//goland:noinspection HttpUrlsUsage
+	jsonValue := []byte(fmt.Sprintf(`{"name": "%s", "type": "prometheus", "access": "direct",
+		"url": "%s", "isDefault": true, "basicAuth": false}`,
+		grafana.DefaultDataSource,
+		"http://"+GetOutboundIP()+":"+PrometheusPort))
 	data := SendReqAndGetRes(url, method, jsonValue)
 	key := fmt.Sprintf("%v", data["message"])
 	if key == "Datasource added" {
@@ -273,6 +277,7 @@ func WriteToken(token string) {
 }
 
 func GetGrafanaHTTPURL() string {
+	//goland:noinspection HttpUrlsUsage
 	return "http://admin:admin@" + GetGrafanaURL()
 }
 


### PR DESCRIPTION
Task to be completed with this PR
- [ ] Changed default prometheus datasource name to `prometheus`
    - [x] Docker
    - [ ] NABox
    - [ ] Ansible
- [x] Update documentation
- [x] Test the existence of datasource in Grafana
- [x] `forceImport` CLI option implementation to force import

--------------------------------------

**Grafana test cases covered.**
**1. No datasource in grafana**
**a. normal cli -> fail**
```
harvest % ./bin/harvest grafana import
using API token from config
A Prometheus-typed datasource named "prometheus" does not exist in Grafana.                                                                        
```
**b. normal cli with force -> pass dashboards empty and not populating data as absense of datasource**
```
harvest % ./bin/harvest grafana import --force
using API token from config
connected to Grafana server (version: 10.3.1)
created Grafana folder [Harvest-24.02.2615-cDOT] - OK
created Grafana folder [Harvest-24.02.2615-7mode] - OK
created Grafana folder [Harvest-24.02.2615-StorageGrid] - OK
preparing to import dashboards...
OK - imported Harvest-24.02.2615-cDOT / [aggregate.json]
OK - imported Harvest-24.02.2615-cDOT / [cdot.json]
OK - imported Harvest-24.02.2615-cDOT / [changelogMonitor.json]
OK - imported Harvest-24.02.2615-cDOT / [cluster.json]
OK - imported Harvest-24.02.2615-cDOT / [compliance.json]
OK - imported Harvest-24.02.2615-cDOT / [data_protection_snapshot.json]
OK - imported Harvest-24.02.2615-cDOT / [datacenter.json]
OK - imported Harvest-24.02.2615-cDOT / [disk.json]
OK - imported Harvest-24.02.2615-cDOT / [external_service_op.json]
OK - imported Harvest-24.02.2615-cDOT / [flexcache.json]
OK - imported Harvest-24.02.2615-cDOT / [flexgroup.json]
OK - imported Harvest-24.02.2615-cDOT / [fsa.json]
OK - imported Harvest-24.02.2615-cDOT / [headroom.json]
OK - imported Harvest-24.02.2615-cDOT / [health.json]
OK - imported Harvest-24.02.2615-cDOT / [lun.json]
OK - imported Harvest-24.02.2615-cDOT / [mcc_cluster.json]
OK - imported Harvest-24.02.2615-cDOT / [metadata.json]
OK - imported Harvest-24.02.2615-cDOT / [namespace.json]
OK - imported Harvest-24.02.2615-cDOT / [network.json]
OK - imported Harvest-24.02.2615-cDOT / [nfs4storePool.json]
OK - imported Harvest-24.02.2615-cDOT / [nfs_clients.json]
OK - imported Harvest-24.02.2615-cDOT / [node.json]
OK - imported Harvest-24.02.2615-cDOT / [power.json]
OK - imported Harvest-24.02.2615-cDOT / [qtree.json]
OK - imported Harvest-24.02.2615-cDOT / [quotaReport.json]
OK - imported Harvest-24.02.2615-cDOT / [s3ObjectStorage.json]
OK - imported Harvest-24.02.2615-cDOT / [security.json]
OK - imported Harvest-24.02.2615-cDOT / [shelf.json]
OK - imported Harvest-24.02.2615-cDOT / [smb.json]
OK - imported Harvest-24.02.2615-cDOT / [snapmirror.json]
OK - imported Harvest-24.02.2615-cDOT / [svm.json]
OK - imported Harvest-24.02.2615-cDOT / [volume.json]
OK - imported Harvest-24.02.2615-cDOT / [workload.json]
Imported 33 dashboards to [Harvest-24.02.2615-cDOT] from [grafana/dashboards/cmode]
OK - imported Harvest-24.02.2615-7mode / [aggregate7.json]
OK - imported Harvest-24.02.2615-7mode / [cluster7.json]
OK - imported Harvest-24.02.2615-7mode / [disk7.json]
OK - imported Harvest-24.02.2615-7mode / [lun7.json]
OK - imported Harvest-24.02.2615-7mode / [network7.json]
OK - imported Harvest-24.02.2615-7mode / [node7.json]
OK - imported Harvest-24.02.2615-7mode / [shelf7.json]
OK - imported Harvest-24.02.2615-7mode / [volume7.json]
Imported 8 dashboards to [Harvest-24.02.2615-7mode] from [grafana/dashboards/7mode]
OK - imported Harvest-24.02.2615-StorageGrid / [fabricpool.json]
OK - imported Harvest-24.02.2615-StorageGrid / [overview.json]
OK - imported Harvest-24.02.2615-StorageGrid / [tenant.json]
Imported 3 dashboards to [Harvest-24.02.2615-StorageGrid] from [grafana/dashboards/storagegrid]
```

**c. normal cli with datasource -> fail**
```
harvest % ./bin/harvest grafana import --datasource prometheus
using API token from config
A Prometheus-typed datasource named "prometheus" does not exist in Grafana.                                                                        harvest % ./bin/harvest grafana import --datasource Prometheus
using API token from config
A Prometheus-typed datasource named "prometheus" does not exist in Grafana.                                                                          harvest % ./bin/harvest grafana import --datasource updatedName
using API token from config
A Prometheus-typed datasource named "prometheus" does not exist in Grafana.                                                                         
```

**2. default datasource in grafana(prometheus)**

<img width="1150" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/fe3f368f-c606-4a27-9113-7e6418c3ff46">

**a. normal cli -> pass, working in grafana**
```
harvest % ./bin/harvest grafana import                         
using API token from config
connected to Grafana server (version: 10.3.1)
created Grafana folder [Harvest-24.02.2615-cDOT] - OK
created Grafana folder [Harvest-24.02.2615-7mode] - OK
created Grafana folder [Harvest-24.02.2615-StorageGrid] - OK
preparing to import dashboards...
OK - imported Harvest-24.02.2615-cDOT / [aggregate.json]
OK - imported Harvest-24.02.2615-cDOT / [cdot.json]
OK - imported Harvest-24.02.2615-cDOT / [changelogMonitor.json]
OK - imported Harvest-24.02.2615-cDOT / [cluster.json]
OK - imported Harvest-24.02.2615-cDOT / [compliance.json]
OK - imported Harvest-24.02.2615-cDOT / [data_protection_snapshot.json]
OK - imported Harvest-24.02.2615-cDOT / [datacenter.json]
OK - imported Harvest-24.02.2615-cDOT / [disk.json]
OK - imported Harvest-24.02.2615-cDOT / [external_service_op.json]
OK - imported Harvest-24.02.2615-cDOT / [flexcache.json]
OK - imported Harvest-24.02.2615-cDOT / [flexgroup.json]
OK - imported Harvest-24.02.2615-cDOT / [fsa.json]
OK - imported Harvest-24.02.2615-cDOT / [headroom.json]
OK - imported Harvest-24.02.2615-cDOT / [health.json]
OK - imported Harvest-24.02.2615-cDOT / [lun.json]
OK - imported Harvest-24.02.2615-cDOT / [mcc_cluster.json]
OK - imported Harvest-24.02.2615-cDOT / [metadata.json]
OK - imported Harvest-24.02.2615-cDOT / [namespace.json]
OK - imported Harvest-24.02.2615-cDOT / [network.json]
OK - imported Harvest-24.02.2615-cDOT / [nfs4storePool.json]
OK - imported Harvest-24.02.2615-cDOT / [nfs_clients.json]
OK - imported Harvest-24.02.2615-cDOT / [node.json]
OK - imported Harvest-24.02.2615-cDOT / [power.json]
OK - imported Harvest-24.02.2615-cDOT / [qtree.json]
OK - imported Harvest-24.02.2615-cDOT / [quotaReport.json]
OK - imported Harvest-24.02.2615-cDOT / [s3ObjectStorage.json]
OK - imported Harvest-24.02.2615-cDOT / [security.json]
OK - imported Harvest-24.02.2615-cDOT / [shelf.json]
OK - imported Harvest-24.02.2615-cDOT / [smb.json]
OK - imported Harvest-24.02.2615-cDOT / [snapmirror.json]
OK - imported Harvest-24.02.2615-cDOT / [svm.json]
OK - imported Harvest-24.02.2615-cDOT / [volume.json]
OK - imported Harvest-24.02.2615-cDOT / [workload.json]
Imported 33 dashboards to [Harvest-24.02.2615-cDOT] from [grafana/dashboards/cmode]
OK - imported Harvest-24.02.2615-7mode / [aggregate7.json]
OK - imported Harvest-24.02.2615-7mode / [cluster7.json]
OK - imported Harvest-24.02.2615-7mode / [disk7.json]
OK - imported Harvest-24.02.2615-7mode / [lun7.json]
OK - imported Harvest-24.02.2615-7mode / [network7.json]
OK - imported Harvest-24.02.2615-7mode / [node7.json]
OK - imported Harvest-24.02.2615-7mode / [shelf7.json]
OK - imported Harvest-24.02.2615-7mode / [volume7.json]
Imported 8 dashboards to [Harvest-24.02.2615-7mode] from [grafana/dashboards/7mode]
OK - imported Harvest-24.02.2615-StorageGrid / [fabricpool.json]
OK - imported Harvest-24.02.2615-StorageGrid / [overview.json]
OK - imported Harvest-24.02.2615-StorageGrid / [tenant.json]
Imported 3 dashboards to [Harvest-24.02.2615-StorageGrid] from [grafana/dashboards/storagegrid]
```

**b. normal cli with other datasource -> fail**
```
harvest % ./bin/harvest grafana import --datasource updatedName
using API token from config
A Prometheus-typed datasource named "updatedName" does not exist in Grafana.                                                             ```
```


**c. normal cli with other datasource Prometheus (caps)-> pass, working in grafana**
```
harvest % ./bin/harvest grafana import --datasource Prometheus
using API token from config
connected to Grafana server (version: 10.3.1)
created Grafana folder [Harvest-24.02.2815-cDOT] - OK
created Grafana folder [Harvest-24.02.2815-7mode] - OK
created Grafana folder [Harvest-24.02.2815-StorageGrid] - OK
preparing to import dashboards...
OK - imported Harvest-24.02.2815-7mode / [aggregate7.json]
OK - imported Harvest-24.02.2815-7mode / [cluster7.json]
OK - imported Harvest-24.02.2815-7mode / [disk7.json]
OK - imported Harvest-24.02.2815-7mode / [lun7.json]
OK - imported Harvest-24.02.2815-7mode / [network7.json]
OK - imported Harvest-24.02.2815-7mode / [node7.json]
OK - imported Harvest-24.02.2815-7mode / [shelf7.json]
OK - imported Harvest-24.02.2815-7mode / [volume7.json]
Imported 8 dashboards to [Harvest-24.02.2815-7mode] from [grafana/dashboards/7mode]
OK - imported Harvest-24.02.2815-StorageGrid / [fabricpool.json]
OK - imported Harvest-24.02.2815-StorageGrid / [overview.json]
OK - imported Harvest-24.02.2815-StorageGrid / [tenant.json]
Imported 3 dashboards to [Harvest-24.02.2815-StorageGrid] from [grafana/dashboards/storagegrid]
OK - imported Harvest-24.02.2815-cDOT / [aggregate.json]
OK - imported Harvest-24.02.2815-cDOT / [cdot.json]
OK - imported Harvest-24.02.2815-cDOT / [changelogMonitor.json]
OK - imported Harvest-24.02.2815-cDOT / [cluster.json]
OK - imported Harvest-24.02.2815-cDOT / [compliance.json]
OK - imported Harvest-24.02.2815-cDOT / [data_protection_snapshot.json]
OK - imported Harvest-24.02.2815-cDOT / [datacenter.json]
OK - imported Harvest-24.02.2815-cDOT / [disk.json]
OK - imported Harvest-24.02.2815-cDOT / [external_service_op.json]
OK - imported Harvest-24.02.2815-cDOT / [flexcache.json]
OK - imported Harvest-24.02.2815-cDOT / [flexgroup.json]
OK - imported Harvest-24.02.2815-cDOT / [fsa.json]
OK - imported Harvest-24.02.2815-cDOT / [headroom.json]
OK - imported Harvest-24.02.2815-cDOT / [health.json]
OK - imported Harvest-24.02.2815-cDOT / [lun.json]
OK - imported Harvest-24.02.2815-cDOT / [mcc_cluster.json]
OK - imported Harvest-24.02.2815-cDOT / [metadata.json]
OK - imported Harvest-24.02.2815-cDOT / [namespace.json]
OK - imported Harvest-24.02.2815-cDOT / [network.json]
OK - imported Harvest-24.02.2815-cDOT / [nfs4storePool.json]
OK - imported Harvest-24.02.2815-cDOT / [nfs_clients.json]
OK - imported Harvest-24.02.2815-cDOT / [node.json]
OK - imported Harvest-24.02.2815-cDOT / [power.json]
OK - imported Harvest-24.02.2815-cDOT / [qtree.json]
OK - imported Harvest-24.02.2815-cDOT / [quotaReport.json]
OK - imported Harvest-24.02.2815-cDOT / [s3ObjectStorage.json]
OK - imported Harvest-24.02.2815-cDOT / [security.json]
OK - imported Harvest-24.02.2815-cDOT / [shelf.json]
OK - imported Harvest-24.02.2815-cDOT / [smb.json]
OK - imported Harvest-24.02.2815-cDOT / [snapmirror.json]
OK - imported Harvest-24.02.2815-cDOT / [svm.json]
OK - imported Harvest-24.02.2815-cDOT / [volume.json]
OK - imported Harvest-24.02.2815-cDOT / [workload.json]
Imported 33 dashboards to [Harvest-24.02.2815-cDOT] from [grafana/dashboards/cmode]                                                                 
```

**3. other datasource in grafana**

<img width="1396" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/eba81350-cdc7-4ff3-99e1-55db96efbe0a">

**a. normal cli -> fail**
```
harvest % ./bin/harvest grafana import                         
using API token from config
A Prometheus-typed datasource named "prometheus" does not exist in Grafana. 
```

**b. normal cli with force -> pass but dashboard breaks as no matching datasource**

<img width="1776" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/f5f24eae-5c16-45bc-8151-d91015150649">

```
harvest % ./bin/harvest grafana import --force
using API token from config
connected to Grafana server (version: 10.3.1)
created Grafana folder [Harvest-24.02.2615-7mode] - OK
created Grafana folder [Harvest-24.02.2615-StorageGrid] - OK
created Grafana folder [Harvest-24.02.2615-cDOT] - OK
preparing to import dashboards...
OK - imported Harvest-24.02.2615-7mode / [aggregate7.json]
OK - imported Harvest-24.02.2615-7mode / [cluster7.json]
OK - imported Harvest-24.02.2615-7mode / [disk7.json]
OK - imported Harvest-24.02.2615-7mode / [lun7.json]
OK - imported Harvest-24.02.2615-7mode / [network7.json]
OK - imported Harvest-24.02.2615-7mode / [node7.json]
OK - imported Harvest-24.02.2615-7mode / [shelf7.json]
OK - imported Harvest-24.02.2615-7mode / [volume7.json]
Imported 8 dashboards to [Harvest-24.02.2615-7mode] from [grafana/dashboards/7mode]
OK - imported Harvest-24.02.2615-StorageGrid / [fabricpool.json]
OK - imported Harvest-24.02.2615-StorageGrid / [overview.json]
OK - imported Harvest-24.02.2615-StorageGrid / [tenant.json]
Imported 3 dashboards to [Harvest-24.02.2615-StorageGrid] from [grafana/dashboards/storagegrid]
OK - imported Harvest-24.02.2615-cDOT / [aggregate.json]
OK - imported Harvest-24.02.2615-cDOT / [cdot.json]
OK - imported Harvest-24.02.2615-cDOT / [changelogMonitor.json]
OK - imported Harvest-24.02.2615-cDOT / [cluster.json]
OK - imported Harvest-24.02.2615-cDOT / [compliance.json]
OK - imported Harvest-24.02.2615-cDOT / [data_protection_snapshot.json]
OK - imported Harvest-24.02.2615-cDOT / [datacenter.json]
OK - imported Harvest-24.02.2615-cDOT / [disk.json]
OK - imported Harvest-24.02.2615-cDOT / [external_service_op.json]
OK - imported Harvest-24.02.2615-cDOT / [flexcache.json]
OK - imported Harvest-24.02.2615-cDOT / [flexgroup.json]
OK - imported Harvest-24.02.2615-cDOT / [fsa.json]
OK - imported Harvest-24.02.2615-cDOT / [headroom.json]
OK - imported Harvest-24.02.2615-cDOT / [health.json]
OK - imported Harvest-24.02.2615-cDOT / [lun.json]
OK - imported Harvest-24.02.2615-cDOT / [mcc_cluster.json]
OK - imported Harvest-24.02.2615-cDOT / [metadata.json]
OK - imported Harvest-24.02.2615-cDOT / [namespace.json]
OK - imported Harvest-24.02.2615-cDOT / [network.json]
OK - imported Harvest-24.02.2615-cDOT / [nfs4storePool.json]
OK - imported Harvest-24.02.2615-cDOT / [nfs_clients.json]
OK - imported Harvest-24.02.2615-cDOT / [node.json]
OK - imported Harvest-24.02.2615-cDOT / [power.json]
OK - imported Harvest-24.02.2615-cDOT / [qtree.json]
OK - imported Harvest-24.02.2615-cDOT / [quotaReport.json]
OK - imported Harvest-24.02.2615-cDOT / [s3ObjectStorage.json]
OK - imported Harvest-24.02.2615-cDOT / [security.json]
OK - imported Harvest-24.02.2615-cDOT / [shelf.json]
OK - imported Harvest-24.02.2615-cDOT / [smb.json]
OK - imported Harvest-24.02.2615-cDOT / [snapmirror.json]
OK - imported Harvest-24.02.2615-cDOT / [svm.json]
OK - imported Harvest-24.02.2615-cDOT / [volume.json]
OK - imported Harvest-24.02.2615-cDOT / [workload.json]
Imported 33 dashboards to [Harvest-24.02.2615-cDOT] from [grafana/dashboards/cmode]
```

**c. normal cli with other datasource -> fail**
```
harvest % ./bin/harvest grafana import --datasource NewDatasource
using API token from config
A Prometheus-typed datasource named "NewDatasource" does not exist in Grafana.                                                                        
```

**d. normal cli with proper datasource with previous dashboards existed -> pass, but fail for overwrite as expected.**
```
harvest % ./bin/harvest grafana import --datasource NetProm      
using API token from config
connected to Grafana server (version: 10.3.1)
folder [Harvest-24.02.2615-cDOT] exists in Grafana - OK
folder [Harvest-24.02.2615-7mode] exists in Grafana - OK
folder [Harvest-24.02.2615-StorageGrid] exists in Grafana - OK
preparing to import dashboards...
error importing [aggregate7.json] to folder [Harvest-24.02.2615-7mode] - the server replied with [412 Precondition Failed]
That means you are trying to overwrite an existing dashboard.

If you want to overwrite, run with the --overwrite flag or choose a different Grafana folder with the --serverfolder flag.
NOTE: If the dashboard already exists, --overwrite will import the changes and increment the dashboard version number.

Server response follows:
    message => A dashboard with the same name in the folder already exists
    status => name-exists

error importing [fabricpool.json] to folder [Harvest-24.02.2615-StorageGrid] - the server replied with [412 Precondition Failed]
That means you are trying to overwrite an existing dashboard.

If you want to overwrite, run with the --overwrite flag or choose a different Grafana folder with the --serverfolder flag.
NOTE: If the dashboard already exists, --overwrite will import the changes and increment the dashboard version number.

Server response follows:
    status => name-exists
    message => A dashboard with the same name in the folder already exists

error importing [aggregate.json] to folder [Harvest-24.02.2615-cDOT] - the server replied with [412 Precondition Failed]
That means you are trying to overwrite an existing dashboard.

If you want to overwrite, run with the --overwrite flag or choose a different Grafana folder with the --serverfolder flag.
NOTE: If the dashboard already exists, --overwrite will import the changes and increment the dashboard version number.

Server response follows:
    message => A dashboard with the same name in the folder already exists
    status => name-exists
```

**e. deleted previous dashboards, normal cli with proper datasource -> pass, dashboards working as expected.**
```
harvest % ./bin/harvest grafana import --datasource NetProm
using API token from config
connected to Grafana server (version: 10.3.1)
created Grafana folder [Harvest-24.02.2615-StorageGrid] - OK
created Grafana folder [Harvest-24.02.2615-cDOT] - OK
created Grafana folder [Harvest-24.02.2615-7mode] - OK
preparing to import dashboards...
OK - imported Harvest-24.02.2615-StorageGrid / [fabricpool.json]
OK - imported Harvest-24.02.2615-StorageGrid / [overview.json]
OK - imported Harvest-24.02.2615-StorageGrid / [tenant.json]
Imported 3 dashboards to [Harvest-24.02.2615-StorageGrid] from [grafana/dashboards/storagegrid]
OK - imported Harvest-24.02.2615-cDOT / [aggregate.json]
OK - imported Harvest-24.02.2615-cDOT / [cdot.json]
OK - imported Harvest-24.02.2615-cDOT / [changelogMonitor.json]
OK - imported Harvest-24.02.2615-cDOT / [cluster.json]
OK - imported Harvest-24.02.2615-cDOT / [compliance.json]
OK - imported Harvest-24.02.2615-cDOT / [data_protection_snapshot.json]
OK - imported Harvest-24.02.2615-cDOT / [datacenter.json]
OK - imported Harvest-24.02.2615-cDOT / [disk.json]
OK - imported Harvest-24.02.2615-cDOT / [external_service_op.json]
OK - imported Harvest-24.02.2615-cDOT / [flexcache.json]
OK - imported Harvest-24.02.2615-cDOT / [flexgroup.json]
OK - imported Harvest-24.02.2615-cDOT / [fsa.json]
OK - imported Harvest-24.02.2615-cDOT / [headroom.json]
OK - imported Harvest-24.02.2615-cDOT / [health.json]
OK - imported Harvest-24.02.2615-cDOT / [lun.json]
OK - imported Harvest-24.02.2615-cDOT / [mcc_cluster.json]
OK - imported Harvest-24.02.2615-cDOT / [metadata.json]
OK - imported Harvest-24.02.2615-cDOT / [namespace.json]
OK - imported Harvest-24.02.2615-cDOT / [network.json]
OK - imported Harvest-24.02.2615-cDOT / [nfs4storePool.json]
OK - imported Harvest-24.02.2615-cDOT / [nfs_clients.json]
OK - imported Harvest-24.02.2615-cDOT / [node.json]
OK - imported Harvest-24.02.2615-cDOT / [power.json]
OK - imported Harvest-24.02.2615-cDOT / [qtree.json]
OK - imported Harvest-24.02.2615-cDOT / [quotaReport.json]
OK - imported Harvest-24.02.2615-cDOT / [s3ObjectStorage.json]
OK - imported Harvest-24.02.2615-cDOT / [security.json]
OK - imported Harvest-24.02.2615-cDOT / [shelf.json]
OK - imported Harvest-24.02.2615-cDOT / [smb.json]
OK - imported Harvest-24.02.2615-cDOT / [snapmirror.json]
OK - imported Harvest-24.02.2615-cDOT / [svm.json]
OK - imported Harvest-24.02.2615-cDOT / [volume.json]
OK - imported Harvest-24.02.2615-cDOT / [workload.json]
Imported 33 dashboards to [Harvest-24.02.2615-cDOT] from [grafana/dashboards/cmode]
OK - imported Harvest-24.02.2615-7mode / [aggregate7.json]
OK - imported Harvest-24.02.2615-7mode / [cluster7.json]
OK - imported Harvest-24.02.2615-7mode / [disk7.json]
OK - imported Harvest-24.02.2615-7mode / [lun7.json]
OK - imported Harvest-24.02.2615-7mode / [network7.json]
OK - imported Harvest-24.02.2615-7mode / [node7.json]
OK - imported Harvest-24.02.2615-7mode / [shelf7.json]
OK - imported Harvest-24.02.2615-7mode / [volume7.json]
Imported 8 dashboards to [Harvest-24.02.2615-7mode] from [grafana/dashboards/7mode]
```

**4 legacy datasource name(Prometheus) exist in grafana**

<img width="1248" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/a21ac30c-bcd9-406d-939e-b1c858711366">

**a. normal cli -> pass, working as expected in grafana**
```
harvest % ./bin/harvest grafana import                          
using API token from config
connected to Grafana server (version: 10.3.1)
created Grafana folder [Harvest-24.02.2815-cDOT] - OK
created Grafana folder [Harvest-24.02.2815-7mode] - OK
created Grafana folder [Harvest-24.02.2815-StorageGrid] - OK
preparing to import dashboards...
OK - imported Harvest-24.02.2815-StorageGrid / [fabricpool.json]
OK - imported Harvest-24.02.2815-StorageGrid / [overview.json]
OK - imported Harvest-24.02.2815-StorageGrid / [tenant.json]
Imported 3 dashboards to [Harvest-24.02.2815-StorageGrid] from [grafana/dashboards/storagegrid]
OK - imported Harvest-24.02.2815-cDOT / [aggregate.json]
OK - imported Harvest-24.02.2815-cDOT / [cdot.json]
OK - imported Harvest-24.02.2815-cDOT / [changelogMonitor.json]
OK - imported Harvest-24.02.2815-cDOT / [cluster.json]
OK - imported Harvest-24.02.2815-cDOT / [compliance.json]
OK - imported Harvest-24.02.2815-cDOT / [data_protection_snapshot.json]
OK - imported Harvest-24.02.2815-cDOT / [datacenter.json]
OK - imported Harvest-24.02.2815-cDOT / [disk.json]
OK - imported Harvest-24.02.2815-cDOT / [external_service_op.json]
OK - imported Harvest-24.02.2815-cDOT / [flexcache.json]
OK - imported Harvest-24.02.2815-cDOT / [flexgroup.json]
OK - imported Harvest-24.02.2815-cDOT / [fsa.json]
OK - imported Harvest-24.02.2815-cDOT / [headroom.json]
OK - imported Harvest-24.02.2815-cDOT / [health.json]
OK - imported Harvest-24.02.2815-cDOT / [lun.json]
OK - imported Harvest-24.02.2815-cDOT / [mcc_cluster.json]
OK - imported Harvest-24.02.2815-cDOT / [metadata.json]
OK - imported Harvest-24.02.2815-cDOT / [namespace.json]
OK - imported Harvest-24.02.2815-cDOT / [network.json]
OK - imported Harvest-24.02.2815-cDOT / [nfs4storePool.json]
OK - imported Harvest-24.02.2815-cDOT / [nfs_clients.json]
OK - imported Harvest-24.02.2815-cDOT / [node.json]
OK - imported Harvest-24.02.2815-cDOT / [power.json]
OK - imported Harvest-24.02.2815-cDOT / [qtree.json]
OK - imported Harvest-24.02.2815-cDOT / [quotaReport.json]
OK - imported Harvest-24.02.2815-cDOT / [s3ObjectStorage.json]
OK - imported Harvest-24.02.2815-cDOT / [security.json]
OK - imported Harvest-24.02.2815-cDOT / [shelf.json]
OK - imported Harvest-24.02.2815-cDOT / [smb.json]
OK - imported Harvest-24.02.2815-cDOT / [snapmirror.json]
OK - imported Harvest-24.02.2815-cDOT / [svm.json]
OK - imported Harvest-24.02.2815-cDOT / [volume.json]
OK - imported Harvest-24.02.2815-cDOT / [workload.json]
Imported 33 dashboards to [Harvest-24.02.2815-cDOT] from [grafana/dashboards/cmode]
OK - imported Harvest-24.02.2815-7mode / [aggregate7.json]
OK - imported Harvest-24.02.2815-7mode / [cluster7.json]
OK - imported Harvest-24.02.2815-7mode / [disk7.json]
OK - imported Harvest-24.02.2815-7mode / [lun7.json]
OK - imported Harvest-24.02.2815-7mode / [network7.json]
OK - imported Harvest-24.02.2815-7mode / [node7.json]
OK - imported Harvest-24.02.2815-7mode / [shelf7.json]
OK - imported Harvest-24.02.2815-7mode / [volume7.json]
Imported 8 dashboards to [Harvest-24.02.2815-7mode] from [grafana/dashboards/7mode]
```

**b. normal cli with datasource as Prometheus -> pass, working as expected**
```
harvest % ./bin/harvest grafana import --datasource Prometheus  
using API token from config
connected to Grafana server (version: 10.3.1)
created Grafana folder [Harvest-24.02.2815-cDOT] - OK
created Grafana folder [Harvest-24.02.2815-7mode] - OK
created Grafana folder [Harvest-24.02.2815-StorageGrid] - OK
preparing to import dashboards...
OK - imported Harvest-24.02.2815-StorageGrid / [fabricpool.json]
OK - imported Harvest-24.02.2815-StorageGrid / [overview.json]
OK - imported Harvest-24.02.2815-StorageGrid / [tenant.json]
Imported 3 dashboards to [Harvest-24.02.2815-StorageGrid] from [grafana/dashboards/storagegrid]
OK - imported Harvest-24.02.2815-cDOT / [aggregate.json]
OK - imported Harvest-24.02.2815-cDOT / [cdot.json]
OK - imported Harvest-24.02.2815-cDOT / [changelogMonitor.json]
OK - imported Harvest-24.02.2815-cDOT / [cluster.json]
OK - imported Harvest-24.02.2815-cDOT / [compliance.json]
OK - imported Harvest-24.02.2815-cDOT / [data_protection_snapshot.json]
OK - imported Harvest-24.02.2815-cDOT / [datacenter.json]
OK - imported Harvest-24.02.2815-cDOT / [disk.json]
OK - imported Harvest-24.02.2815-cDOT / [external_service_op.json]
OK - imported Harvest-24.02.2815-cDOT / [flexcache.json]
OK - imported Harvest-24.02.2815-cDOT / [flexgroup.json]
OK - imported Harvest-24.02.2815-cDOT / [fsa.json]
OK - imported Harvest-24.02.2815-cDOT / [headroom.json]
OK - imported Harvest-24.02.2815-cDOT / [health.json]
OK - imported Harvest-24.02.2815-cDOT / [lun.json]
OK - imported Harvest-24.02.2815-cDOT / [mcc_cluster.json]
OK - imported Harvest-24.02.2815-cDOT / [metadata.json]
OK - imported Harvest-24.02.2815-cDOT / [namespace.json]
OK - imported Harvest-24.02.2815-cDOT / [network.json]
OK - imported Harvest-24.02.2815-cDOT / [nfs4storePool.json]
OK - imported Harvest-24.02.2815-cDOT / [nfs_clients.json]
OK - imported Harvest-24.02.2815-cDOT / [node.json]
OK - imported Harvest-24.02.2815-cDOT / [power.json]
OK - imported Harvest-24.02.2815-cDOT / [qtree.json]
OK - imported Harvest-24.02.2815-cDOT / [quotaReport.json]
OK - imported Harvest-24.02.2815-cDOT / [s3ObjectStorage.json]
OK - imported Harvest-24.02.2815-cDOT / [security.json]
OK - imported Harvest-24.02.2815-cDOT / [shelf.json]
OK - imported Harvest-24.02.2815-cDOT / [smb.json]
OK - imported Harvest-24.02.2815-cDOT / [snapmirror.json]
OK - imported Harvest-24.02.2815-cDOT / [svm.json]
OK - imported Harvest-24.02.2815-cDOT / [volume.json]
OK - imported Harvest-24.02.2815-cDOT / [workload.json]
Imported 33 dashboards to [Harvest-24.02.2815-cDOT] from [grafana/dashboards/cmode]
OK - imported Harvest-24.02.2815-7mode / [aggregate7.json]
OK - imported Harvest-24.02.2815-7mode / [cluster7.json]
OK - imported Harvest-24.02.2815-7mode / [disk7.json]
OK - imported Harvest-24.02.2815-7mode / [lun7.json]
OK - imported Harvest-24.02.2815-7mode / [network7.json]
OK - imported Harvest-24.02.2815-7mode / [node7.json]
OK - imported Harvest-24.02.2815-7mode / [shelf7.json]
OK - imported Harvest-24.02.2815-7mode / [volume7.json]
Imported 8 dashboards to [Harvest-24.02.2815-7mode] from [grafana/dashboards/7mode]
```