### PR TITLE
fix: convert QOS Adaptive Policy Configuration ops to TB

### DIFF
--- a/cmd/collectors/zapi/plugins/qospolicyfixed/qospolicyfixed_test.go
+++ b/cmd/collectors/zapi/plugins/qospolicyfixed/qospolicyfixed_test.go
@@ -13,6 +13,7 @@ func Test_zapiXputToRest(t *testing.T) {
 	}{
 		// Adaptive QOS uses this form, test it here too
 		{zapi: "6144IOPS/TB", want: MaxXput{IOPS: "6144", Mbps: "0"}},
+		{zapi: "6144IOPS/GB", want: MaxXput{IOPS: "6144000", Mbps: "0"}},
 
 		{zapi: "100IOPS", want: MaxXput{IOPS: "100", Mbps: "0"}},
 		{zapi: "100iops", want: MaxXput{IOPS: "100", Mbps: "0"}},


### PR DESCRIPTION
ONTAP CLI:

<img width="547" alt="image" src="https://github.com/NetApp/harvest/assets/25551691/09f61154-6c96-467c-a426-55c7945ff5ed">


**Before**: qos_policy_adaptive_labels

<img width="1914" alt="image" src="https://github.com/NetApp/harvest/assets/25551691/b8c9503b-5662-4ae3-9d5a-98aca623b63e">



**After:** qos_policy_adaptive_labels

<img width="962" alt="image" src="https://github.com/NetApp/harvest/assets/25551691/d7cf3e5e-26d2-4f7a-a521-238860e4d769">


**Before**: qos_policy_adaptive_peak_iops

<img width="1915" alt="image" src="https://github.com/NetApp/harvest/assets/25551691/c8926244-2664-411c-959f-f5d8837beddc">

**After:** qos_policy_adaptive_peak_iops

<img width="1907" alt="image" src="https://github.com/NetApp/harvest/assets/25551691/e4f525f7-054c-46c3-999b-a00e986f01f3">

**Before**: qos_policy_adaptive_expected_iops

<img width="1914" alt="image" src="https://github.com/NetApp/harvest/assets/25551691/0169989d-3b5d-43d4-a23e-9109421a0574">


**After:** qos_policy_adaptive_expected_iops

<img width="1916" alt="image" src="https://github.com/NetApp/harvest/assets/25551691/25080e8b-dd36-4c78-9802-466255195131">

