### PR TITLE
feat: Harvest should handle ONTAP counter manager rejection errors

### DIFF
--- a/cmd/collectors/restperf/restperf.go
+++ b/cmd/collectors/restperf/restperf.go
@@ -1544,9 +1544,6 @@ func (r *RestPerf) handleError(err error, href string) (map[string]*matrix.Matri
 		// the table or API does not exist. return ErrAPIRequestRejected so the task goes to stand-by
 		return nil, fmt.Errorf("polling href=[%s] err: %w", href, errs.New(errs.ErrAPIRequestRejected, err.Error()))
 	}
-	// if errs.IsRestErr(err, errs.CMReject) {
-	// 	return nil, fmt.Errorf("CM reject href=[%s] err: %w", href, errs.New(errs.ErrNoInstance, err.Error()))
-	// }
 	return nil, fmt.Errorf("failed to fetch data. href=[%s] err: %w", href, err)
 }
 

--- a/cmd/collectors/restperf/restperf.go
+++ b/cmd/collectors/restperf/restperf.go
@@ -688,8 +688,7 @@ func (r *RestPerf) PollData() (map[string]*matrix.Matrix, error) {
 
 	err = rest.FetchRestPerfData(r.Client, href, &perfRecords)
 	if err != nil {
-		r.Logger.Error().Err(err).Str("href", href).Msg("Failed to fetch data")
-		return nil, err
+		return nil, fmt.Errorf("failed to fetch href=%s %w", href, err)
 	}
 
 	return r.pollData(startTime, perfRecords)
@@ -1545,6 +1544,9 @@ func (r *RestPerf) handleError(err error, href string) (map[string]*matrix.Matri
 		// the table or API does not exist. return ErrAPIRequestRejected so the task goes to stand-by
 		return nil, fmt.Errorf("polling href=[%s] err: %w", href, errs.New(errs.ErrAPIRequestRejected, err.Error()))
 	}
+	// if errs.IsRestErr(err, errs.CMReject) {
+	// 	return nil, fmt.Errorf("CM reject href=[%s] err: %w", href, errs.New(errs.ErrNoInstance, err.Error()))
+	// }
 	return nil, fmt.Errorf("failed to fetch data. href=[%s] err: %w", href, err)
 }
 

--- a/pkg/errs/ontap.go
+++ b/pkg/errs/ontap.go
@@ -93,6 +93,7 @@ var (
 	APINotFound               = OntapRestCode{"API not found", 3}
 	TableNotFound             = OntapRestCode{"Table is not found", 8585320}
 	MetroClusterNotConfigured = OntapRestCode{"MetroCluster is not configured in cluster", 2426405}
+	CMReject                  = OntapRestCode{"CM reject", 8585368}
 )
 
 func IsRestErr(err error, sentinel OntapRestCode) bool {


### PR DESCRIPTION
The collector will retry after 30 to 60 seconds