### PR TITLE
feat: changed plugin generated metric naming for lock object

### DIFF
--- a/conf/rest/9.10.0/lock.yaml
+++ b/conf/rest/9.10.0/lock.yaml
@@ -20,10 +20,10 @@ plugins:
       # plugin will create summary/average for each object
       # any names after the object names will be treated as
       # label names that will be added to instances
-      - node
-      - svm
-      - lif
-      - volume
+      - node<>lock_node
+      - svm<>lock_svm
+      - lif<>lock_lif
+      - volume<>lock_volume
 
 # only export node/aggr aggregations from plugin
 # set this true or comment, to get data for each lock

--- a/conf/zapi/cdot/9.8.0/lock.yaml
+++ b/conf/zapi/cdot/9.8.0/lock.yaml
@@ -23,10 +23,10 @@ plugins:
     # plugin will create summary/average for each object
     # any names after the object names will be treated as
     # label names that will be added to instances
-    - node
-    - svm
-    - lif
-    - volume
+    - node<>lock_node
+    - svm<>lock_svm
+    - lif<>lock_lif
+    - volume<>lock_volume
 
 # only export node/aggr aggregations from plugin
 # set this true or comment, to get data for each lock


### PR DESCRIPTION

```
harvest % ./bin/poller -p sarzapi -o Lock --promPort 13001
2024-03-15T15:31:45+05:30 INF poller/poller.go:215 > Init Poller=sarzapi asup=false confPath=conf config=harvest.yml configPath=harvest.yml daemon=false debug=false homePath= hostname=hardikl-mac-0 logLevel=info logPath=/var/log/harvest/ profiling=0 promPort=13002 version="harvest version 24.03.15-1 (commit b3963467) (build date 2024-03-15T15:27:08+0530) darwin/amd64"
2024-03-15T15:31:45+05:30 INF poller/poller.go:239 > started in foreground Poller=sarzapi pid=7336
2024-03-15T15:31:48+05:30 INF collector/helpers.go:84 > best-fit template Poller=sarzapi collector=Zapi:Lock path=conf/zapi/cdot/9.8.0/lock.yaml v=9.13.1
2024-03-15T15:31:49+05:30 WRN poller/poller.go:687 > init collector-object error="no best-fit template for  on conf" Poller=sarzapi collector=ZapiPerf object=Lock
2024-03-15T15:31:49+05:30 INF poller/poller.go:357 > Autosupport scheduled. Poller=sarzapi asupSchedule=24h
2024-03-15T15:31:49+05:30 INF prometheus/httpd.go:40 > server listen Poller=sarzapi exporter=prometheus1 url=http://:13002/metrics
2024-03-15T15:31:49+05:30 INF poller/poller.go:366 > poller start-up complete Poller=sarzapi
2024-03-15T15:31:49+05:30 INF poller/poller.go:523 > updated status, up collectors: 1 (of 1), up exporters: 1 (of 1) Poller=sarzapi
2024-03-15T15:31:52+05:30 INF collector/collector.go:598 > Collected Poller=sarzapi apiMs=2555 bytesRx=16875 calcMs=0 collector=Zapi:Lock exportMs=0 instances=49 instancesExported=5 metrics=343 metricsExported=13 numCalls=1 parseMs=2 pluginMs=0 pollMs=2559 zBegin=1710496909612
```
```
harvest %  curl -s http://localhost:13001/metrics | grep -Ev "#|metadata_" 
lock_svm_count{cluster="umeng-aff300-01-02",datacenter="zapi",svm="astra_301"} 49
lock_lif_count{cluster="umeng-aff300-01-02",datacenter="zapi",lif="astra_301_lif"} 49
lock_volume_count{cluster="umeng-aff300-01-02",datacenter="zapi",volume="trident_pvc_cf16c72a_044e_4e3c_9b04_d2cf06efd0c4"} 28
lock_volume_count{cluster="umeng-aff300-01-02",datacenter="zapi",volume="trident_pvc_7ae88770_5935_4fb5_9d26_0f230688f8b3"} 21
lock_node_count{cluster="umeng-aff300-01-02",datacenter="zapi",node="umeng-aff300-02"} 49
```

```
harvest % ./bin/poller -p sar -o Lock --promPort 13002 
2024-03-15T15:32:09+05:30 INF poller/poller.go:215 > Init Poller=sar asup=false confPath=conf config=harvest.yml configPath=harvest.yml daemon=false debug=false homePath= hostname=hardikl-mac-0 logLevel=info logPath=/var/log/harvest/ profiling=0 promPort=13002 version="harvest version 24.03.15-1 (commit b3963467) (build date 2024-03-15T15:27:08+0530) darwin/amd64"
2024-03-15T15:32:10+05:30 INF poller/poller.go:239 > started in foreground Poller=sar pid=7365
2024-03-15T15:32:11+05:30 INF collector/helpers.go:84 > best-fit template Poller=sar collector=Rest:Lock path=conf/rest/9.10.0/lock.yaml v=9.13.1
2024-03-15T15:32:12+05:30 WRN poller/poller.go:687 > init collector-object error="no best-fit template for  on conf" Poller=sar collector=RestPerf object=Lock
2024-03-15T15:32:12+05:30 INF poller/poller.go:357 > Autosupport scheduled. Poller=sar asupSchedule=24h
2024-03-15T15:32:12+05:30 INF poller/poller.go:366 > poller start-up complete Poller=sar
2024-03-15T15:32:12+05:30 INF prometheus/httpd.go:40 > server listen Poller=sar exporter=prometheus1 url=http://:13002/metrics
2024-03-15T15:32:12+05:30 INF poller/poller.go:523 > updated status, up collectors: 1 (of 1), up exporters: 1 (of 1) Poller=sar
2024-03-15T15:32:15+05:30 INF collector/collector.go:598 > Collected Poller=sar apiMs=3354 bytesRx=53788 calcMs=0 collector=Rest:Lock exportMs=0 instances=49 instancesExported=5 metrics=343 metricsExported=13 numCalls=1 parseMs=1 pluginMs=0 pollMs=3355 zBegin=1710496932594
```




```
harvest %  curl -s http://localhost:13002/metrics | grep -Ev "#|metadata_" 
lock_lif_count{cluster="umeng-aff300-01-02",datacenter="rest",lif="astra_301_lif"} 49
lock_volume_count{cluster="umeng-aff300-01-02",datacenter="rest",volume="trident_pvc_cf16c72a_044e_4e3c_9b04_d2cf06efd0c4"} 28
lock_volume_count{cluster="umeng-aff300-01-02",datacenter="rest",volume="trident_pvc_7ae88770_5935_4fb5_9d26_0f230688f8b3"} 21
lock_node_count{cluster="umeng-aff300-01-02",datacenter="rest",node="umeng-aff300-02"} 49
lock_svm_count{cluster="umeng-aff300-01-02",datacenter="rest",svm="astra_301"} 49
```

