### PR TITLE
fix: QosPolicyFixed should ignore missing min-throughput

### DIFF
--- a/cmd/collectors/zapi/plugins/qospolicyfixed/qospolicyfixed.go
+++ b/cmd/collectors/zapi/plugins/qospolicyfixed/qospolicyfixed.go
@@ -100,7 +100,7 @@ type MaxXput struct {
 func ZapiXputToRest(zapi string) (MaxXput, error) {
 	lower := strings.ToLower(zapi)
 	empty := MaxXput{IOPS: "0", Mbps: "0"}
-	if lower == "inf" || lower == "0" {
+	if lower == "inf" || lower == "0" || lower == "" {
 		return empty, nil
 	}
 

--- a/cmd/collectors/zapi/plugins/qospolicyfixed/qospolicyfixed_test.go
+++ b/cmd/collectors/zapi/plugins/qospolicyfixed/qospolicyfixed_test.go
@@ -19,6 +19,7 @@ func Test_zapiXputToRest(t *testing.T) {
 		{zapi: "100iops", want: MaxXput{IOPS: "100", Mbps: "0"}},
 		{zapi: "111111IOPS", want: MaxXput{IOPS: "111111", Mbps: "0"}},
 		{zapi: "0", want: MaxXput{IOPS: "0", Mbps: "0"}},
+		{zapi: "", want: MaxXput{IOPS: "0", Mbps: "0"}},
 		{zapi: "INF", want: MaxXput{IOPS: "0", Mbps: "0"}},
 
 		{zapi: "1GB/s", want: MaxXput{IOPS: "0", Mbps: "1000"}},
@@ -35,8 +36,8 @@ func Test_zapiXputToRest(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			got, err := ZapiXputToRest(tt.zapi)
-			if tt.isErr && err == nil {
-				t.Errorf("ZapiXputToRest(%s) got=%+v, want err but got err=%s", tt.zapi, got, err)
+			if err != nil && !tt.isErr {
+				t.Errorf("ZapiXputToRest(%s) got=%+v, want no err but got err=%s", tt.zapi, got, err)
 				return
 			}
 			if got.IOPS != tt.want.IOPS || got.Mbps != tt.want.Mbps {


### PR DESCRIPTION
This happens on ONTAP 9.1.X

```
qos policy-group show -fields ?
  policy-group                Policy Group Name
  vserver                     Vserver
  uuid                        Uuid
  class                       Policy Group Class
  pgid                        Policy Group ID
  max-throughput              Maximum Throughput
  num-workloads               Number of Workloads
  throughput-policy           Throughput Policy
```