### PR TITLE
revert: disable integration go.mod with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     ":semanticCommitScopeDisabled",
     "docker:disable"
   ],
+  "ignorePaths": ["**/integration/**"],
   "schedule": ["before 4am on monday"],
   "groupName": "all dependencies",
   "groupSlug": "all",


### PR DESCRIPTION
Command failed: go get -d -t ./...
go: errors parsing go.mod:
go.mod:12:2: require github.com/netapp/harvest/v24: version "v24.0.0-20240221144546-8f9201cc6915" invalid: go.mod has non-.../v24 module path "github.com/netapp/harvest/v2" (and .../v24/go.mod does not exist) at revision 8f9201cc6915


Seems to have been fixed as per issue
https://github.com/renovatebot/renovate/issues/6647#issuecomment-1518539743
 
Reverting for now.