### PR TITLE
style: improving Debug Log Clarity and Reducing Noise

### DIFF
--- a/cmd/collectors/commonutils.go
+++ b/cmd/collectors/commonutils.go
@@ -110,7 +110,7 @@ func GetClusterTime(client *rest.Client, returnTimeOut *int, logger *logging.Log
 		}
 	}
 
-	logger.Debug().Str("cluster time", clusterTime.String()).Send()
+	logger.Trace().Str("cluster time", clusterTime.String()).Send()
 	return clusterTime, nil
 }
 

--- a/cmd/collectors/ems/ems.go
+++ b/cmd/collectors/ems/ems.go
@@ -360,7 +360,7 @@ func (e *Ems) PollData() (map[string]*matrix.Matrix, error) {
 		records              []gjson.Result
 	)
 
-	e.Logger.Debug().Msg("starting data poll")
+	e.Logger.Trace().Msg("starting data poll")
 
 	// Update cache for bookend ems
 	e.updateMatrix(time.Now())

--- a/cmd/collectors/storagegrid/storagegrid.go
+++ b/cmd/collectors/storagegrid/storagegrid.go
@@ -150,7 +150,7 @@ func (s *StorageGrid) pollPrometheusMetrics() (map[string]*matrix.Matrix, error)
 	)
 
 	metrics := make(map[string]*matrix.Matrix)
-	s.Logger.Debug().Msg("starting data poll")
+	s.Logger.Trace().Msg("starting data poll")
 	s.Matrix[s.Object].Reset()
 	startTime = time.Now()
 
@@ -259,7 +259,7 @@ func (s *StorageGrid) pollRest() (map[string]*matrix.Matrix, error) {
 		records      []gjson.Result
 	)
 
-	s.Logger.Debug().Msg("starting data poll")
+	s.Logger.Trace().Msg("starting data poll")
 	s.Matrix[s.Object].Reset()
 	startTime = time.Now()
 

--- a/cmd/collectors/zapi/plugins/aggregate/aggregate.go
+++ b/cmd/collectors/zapi/plugins/aggregate/aggregate.go
@@ -53,7 +53,7 @@ func (a *Aggregate) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, *u
 	// invoke aggr-object-store-get-iter zapi and populate cloud stores info
 	if err := a.getCloudStores(); err != nil {
 		if errors.Is(err, errs.ErrNoInstance) {
-			a.Logger.Debug().Err(err).Msg("Failed to collect cloud store data")
+			a.Logger.Trace().Err(err).Msg("Failed to collect cloud store data")
 		}
 	}
 

--- a/cmd/collectors/zapi/plugins/svm/svm.go
+++ b/cmd/collectors/zapi/plugins/svm/svm.go
@@ -128,7 +128,7 @@ func (my *SVM) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, *util.M
 		// invoke fileservice-audit-config-get-iter zapi and get audit protocols
 		if my.auditProtocols, err = my.GetAuditProtocols(); err != nil {
 			if errors.Is(err, errs.ErrNoInstance) {
-				my.Logger.Debug().Err(err).Msg("Failed to collect audit protocols")
+				my.Logger.Trace().Err(err).Msg("Failed to collect audit protocols")
 			} else {
 				my.Logger.Error().Err(err).Msg("Failed to collect audit protocols")
 			}
@@ -137,7 +137,7 @@ func (my *SVM) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, *util.M
 		// invoke cifs-security-get-iter zapi and get cifs protocols
 		if my.cifsProtocols, err = my.GetCifsProtocols(); err != nil {
 			if errors.Is(err, errs.ErrNoInstance) {
-				my.Logger.Debug().Err(err).Msg("Failed to collect cifs protocols")
+				my.Logger.Trace().Err(err).Msg("Failed to collect cifs protocols")
 			} else {
 				my.Logger.Error().Err(err).Msg("Failed to collect cifs protocols")
 			}
@@ -146,7 +146,7 @@ func (my *SVM) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, *util.M
 		// invoke nameservice-nsswitch-get-iter zapi and get nsswitch info
 		if my.nsswitchInfo, err = my.GetNSSwitchInfo(); err != nil {
 			if errors.Is(err, errs.ErrNoInstance) {
-				my.Logger.Debug().Err(err).Msg("Failed to collect nsswitch info")
+				my.Logger.Trace().Err(err).Msg("Failed to collect nsswitch info")
 			} else {
 				my.Logger.Error().Err(err).Msg("Failed to collect nsswitch info")
 			}
@@ -155,7 +155,7 @@ func (my *SVM) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, *util.M
 		// invoke nis-get-iter zapi and get nisdomain info
 		if my.nisInfo, err = my.GetNisInfo(); err != nil {
 			if errors.Is(err, errs.ErrNoInstance) {
-				my.Logger.Debug().Err(err).Msg("Failed to collect nisdomain info")
+				my.Logger.Trace().Err(err).Msg("Failed to collect nisdomain info")
 			} else {
 				my.Logger.Error().Err(err).Msg("Failed to collect nisdomain info")
 			}
@@ -164,7 +164,7 @@ func (my *SVM) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, *util.M
 		// invoke cifs-server-get-iter zapi and get cifsenabled info
 		if my.cifsEnabled, err = my.GetCifsEnabled(); err != nil {
 			if errors.Is(err, errs.ErrNoInstance) {
-				my.Logger.Debug().Err(err).Msg("Failed to collect cifsenabled info")
+				my.Logger.Trace().Err(err).Msg("Failed to collect cifsenabled info")
 			} else {
 				my.Logger.Error().Err(err).Msg("Failed to collect cifsenabled info")
 			}
@@ -173,7 +173,7 @@ func (my *SVM) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, *util.M
 		// invoke nfs-service-get-iter zapi and get cifsenabled info
 		if my.nfsEnabled, err = my.GetNfsEnabled(); err != nil {
 			if errors.Is(err, errs.ErrNoInstance) {
-				my.Logger.Debug().Err(err).Msg("Failed to collect nfsenabled info")
+				my.Logger.Trace().Err(err).Msg("Failed to collect nfsenabled info")
 			} else {
 				my.Logger.Error().Err(err).Msg("Failed to collect nfsenabled info")
 			}
@@ -182,7 +182,7 @@ func (my *SVM) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, *util.M
 		// invoke security-ssh-get-iter zapi and get ssh data
 		if my.sshData, err = my.GetSSHData(); err != nil {
 			if errors.Is(err, errs.ErrNoInstance) {
-				my.Logger.Debug().Err(err).Msg("Failed to collect ssh data")
+				my.Logger.Trace().Err(err).Msg("Failed to collect ssh data")
 			} else {
 				my.Logger.Error().Err(err).Msg("Failed to collect ssh data")
 			}
@@ -191,7 +191,7 @@ func (my *SVM) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, *util.M
 		// invoke iscsi-initiator-auth-get-iter zapi and get iscsi_authentication_type
 		if my.iscsiAuth, err = my.GetIscsiInitiatorAuth(); err != nil {
 			if errors.Is(err, errs.ErrNoInstance) {
-				my.Logger.Debug().Err(err).Msg("Failed to collect iscsi authentication type")
+				my.Logger.Trace().Err(err).Msg("Failed to collect iscsi authentication type")
 			} else {
 				my.Logger.Error().Err(err).Msg("Failed to collect iscsi authentication type")
 			}
@@ -200,7 +200,7 @@ func (my *SVM) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, *util.M
 		// invoke iscsi-service-get-iter zapi and get iscsi_service_enabled
 		if my.iscsiService, err = my.GetIscsiService(); err != nil {
 			if errors.Is(err, errs.ErrNoInstance) {
-				my.Logger.Debug().Err(err).Msg("Failed to collect iscsi service")
+				my.Logger.Trace().Err(err).Msg("Failed to collect iscsi service")
 			} else {
 				my.Logger.Error().Err(err).Msg("Failed to collect iscsi service")
 			}
@@ -209,7 +209,7 @@ func (my *SVM) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, *util.M
 		// invoke fpolicy-policy-status-get-iter zapi and get fpolicy_enabled, fpolicy_name
 		if my.fpolicyData, err = my.GetFpolicy(); err != nil {
 			if errors.Is(err, errs.ErrNoInstance) {
-				my.Logger.Debug().Err(err).Msg("Failed to collect fpolicy detail")
+				my.Logger.Trace().Err(err).Msg("Failed to collect fpolicy detail")
 			} else {
 				my.Logger.Error().Err(err).Msg("Failed to collect fpolicy detail")
 			}
@@ -218,7 +218,7 @@ func (my *SVM) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, *util.M
 		// invoke ldap-client-get-iter zapi and get ldap_session_security
 		if my.ldapData, err = my.GetLdapData(); err != nil {
 			if errors.Is(err, errs.ErrNoInstance) {
-				my.Logger.Debug().Err(err).Msg("Failed to collect ldap session")
+				my.Logger.Trace().Err(err).Msg("Failed to collect ldap session")
 			} else {
 				my.Logger.Error().Err(err).Msg("Failed to collect ldap session")
 			}
@@ -227,7 +227,7 @@ func (my *SVM) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, *util.M
 		// invoke kerberos-config-get-iter zapi and get nfs_kerberos_protocol_enabled
 		if my.kerberosConfig, err = my.GetKerberosConfig(); err != nil {
 			if errors.Is(err, errs.ErrNoInstance) {
-				my.Logger.Debug().Err(err).Msg("Failed to collect kerberos config")
+				my.Logger.Trace().Err(err).Msg("Failed to collect kerberos config")
 			} else {
 				my.Logger.Error().Err(err).Msg("Failed to collect kerberos config")
 			}

--- a/cmd/collectors/zapiperf/plugins/disk/disk.go
+++ b/cmd/collectors/zapiperf/plugins/disk/disk.go
@@ -894,11 +894,19 @@ func (d *Disk) handleCMode(shelves []*node.Node) ([]*matrix.Matrix, error) {
 
 							if value := strings.Split(obj.GetChildContentS(metricKey), " ")[0]; value != "" {
 								if err := m.SetValueString(instance, value); err != nil {
-									d.Logger.Debug().
-										Str("metricKey", metricKey).
-										Str("value", value).
-										Err(err).
-										Msg("failed to parse value")
+									if value != "-" {
+										d.Logger.Debug().
+											Str("metricKey", metricKey).
+											Str("value", value).
+											Err(err).
+											Msg("failed to parse value")
+									} else {
+										d.Logger.Trace().
+											Str("metricKey", metricKey).
+											Str("value", value).
+											Err(err).
+											Msg("failed to parse value")
+									}
 								} else {
 									d.Logger.Trace().
 										Str("metricKey", metricKey).
@@ -907,7 +915,6 @@ func (d *Disk) handleCMode(shelves []*node.Node) ([]*matrix.Matrix, error) {
 								}
 							}
 						}
-
 					} else {
 						d.Logger.Debug().Msgf("instance without [%s], skipping", d.instanceKeys[attribute])
 					}

--- a/cmd/collectors/zapiperf/zapiperf.go
+++ b/cmd/collectors/zapiperf/zapiperf.go
@@ -1708,7 +1708,7 @@ func (z *ZapiPerf) PollInstance() (map[string]*matrix.Matrix, error) {
 	newSize = len(mat.GetInstances())
 	added = newSize - (oldSize - removed)
 
-	z.Logger.Debug().Int("new", added).Int("removed", removed).Int("total", newSize).Msg("instances")
+	z.Logger.Trace().Int("new", added).Int("removed", removed).Int("total", newSize).Msg("instances")
 
 	// update metadata for collector logs
 	_ = z.Metadata.LazySetValueInt64("api_time", "instance", apiD.Microseconds())

--- a/cmd/poller/collector/collector.go
+++ b/cmd/poller/collector/collector.go
@@ -459,7 +459,7 @@ func (c *AbstractCollector) Start(wg *sync.WaitGroup) {
 							}
 							if pluginData != nil {
 								results = append(results, pluginData...)
-								c.Logger.Debug().
+								c.Logger.Trace().
 									Str("pluginName", plg.GetName()).
 									Int("dataLength", len(pluginData)).
 									Msg("plugin added data")
@@ -523,7 +523,7 @@ func (c *AbstractCollector) Start(wg *sync.WaitGroup) {
 					exporterStats.InstancesExported += stats.InstancesExported
 					exporterStats.MetricsExported += stats.MetricsExported
 				} else {
-					c.Logger.Debug().Str("UUID", data.UUID).Str("object", data.Object).Msg("skipped non-exportable data")
+					c.Logger.Trace().Str("UUID", data.UUID).Str("object", data.Object).Msg("skipped non-exportable data")
 				}
 			}
 		}


### PR DESCRIPTION
Based on the logs shared by Tony earlier, found that the following logs are being generated frequently and do not seem useful at the debug level.


2516825 nabox-harvest2 | 2024-03-12T08:17:11Z DBG disk/disk.go:901 > failed to parse value error="strconv.ParseFloat: parsing \"-\": invalid syntax" Poller=metricKey=fan-rpm object=Disk plugin=ZapiPerf:Disk value=-
 569724 nabox-harvest2 | --- DBG --- > --- --- data --- --- --- --- ---
 417831 nabox-harvest2 | 2024-03-12T08:15:57Z DBG zapiperf/zapiperf.go:1669 > instances Poller=collector=ZapiPerf:FCVI new=0 removed=0 total=0
 261276 nabox-harvest2 | --- DBG --- > --- --- --- --- --- ---
 131129 nabox-harvest2 | 2024-03-12T08:15:59Z DBG collector/collector.go:509 > skipped non-exportable data Poller=UUID=Rest collector=Rest:Health object=health
 102820 nabox-harvest2 | 2024-03-12T08:15:56Z DBG poller/poller.go:493 > exporter (nabox-prometheus) status: (0 - up) initialized Poller=
 101148 nabox-harvest2 | 2024-03-12T08:16:57Z DBG volume/volume.go:129 > extracted 0 flexgroup volumes Poller=object=Volume plugin=ZapiPerf:Volume
  47628 nabox-harvest2 | 2024-03-12T08:15:56Z DBG svm/svm.go:128 > Failed to collect audit protocols error="no instances => no records found" Poller=object=SVM plugin=Zapi:SVM
  35907 nabox-harvest2 | 2024-03-12T08:15:56Z DBG zapiperf/zapiperf.go:1194 > Adding missing base counter Poller=collector=ZapiPerf:HeadroomAggr name=current_utilization_total
  33806 nabox-harvest2 | 2024-03-12T08:15:56Z DBG aggregate/aggregate.go:54 > Failed to collect cloud store data error="no instances => no records found" Poller=object=Aggregate plugin=Zapi:Aggregate
  33565 nabox-harvest2 | 2024-03-12T08:15:57Z DBG qtree/qtree.go:203 > no quota instances found Poller=object=Qtree plugin=Zapi:Qtree
  23354 nabox-harvest2 | --- DBG --- > --- --- --- --- --- ---
  20639 nabox-harvest2 | 2024-03-12T08:15:56Z DBG collector/collector.go:354 > handling error during [data] poll... Poller=collector=Zapi:CloudTarget
  17414 nabox-harvest2 | 2024-03-12T08:15:50Z DBG zapiperf/zapiperf.go:344 > using batch_size = [500] (default) Poller=collector=ZapiPerf:NFSv4
  16898 nabox-harvest2 | 2024-03-12T08:16:00Z DBG ems/ems.go:363 > starting data poll Poller=collector=Ems:Ems
