### PR TITLE
fix: parity of id value in disk restperf and zapiperf

### DIFF
--- a/conf/restperf/9.12.0/disk.yaml
+++ b/conf/restperf/9.12.0/disk.yaml
@@ -3,7 +3,7 @@ query:                    api/cluster/counter/tables/disk:constituent
 object:                   disk
 
 counters:
-  - ^^id
+  - ^^id                     => instance_uuid
   - ^name                    => partition
   - ^node.name               => node
   - ^physical_disk_id        => disk_uuid
@@ -33,6 +33,10 @@ plugins:
   - LabelAgent:
       split:
         - raid_group `/` ,aggr,plex,raid
+      split_regex:
+        # Example: umeng-aff300-01:1.1.12.P3:
+        # output: instance_uuid value will be 6002538A:4775FAC0:500A0981:00000003:00000000:00000000:00000000:00000000:00000000:00000000
+        - instance_uuid `^[^:]*:[^:]*:(.+)` instance_uuid
   - Aggregator:
     # plugin will create summary/average for each object
     # any names after the object names will be treated as

--- a/conf/restperf/9.12.0/disk.yaml
+++ b/conf/restperf/9.12.0/disk.yaml
@@ -34,7 +34,7 @@ plugins:
       split:
         - raid_group `/` ,aggr,plex,raid
       split_regex:
-        # Example: umeng-aff300-01:1.1.12.P3:
+        # Example: umeng-aff300-01:1.1.12.P3:6002538A:4775FAC0:500A0981:00000003:00000000:00000000:00000000:00000000:00000000:00000000
         # output: instance_uuid value will be 6002538A:4775FAC0:500A0981:00000003:00000000:00000000:00000000:00000000:00000000:00000000
         - instance_uuid `^[^:]*:[^:]*:(.+)` instance_uuid
   - Aggregator:


### PR DESCRIPTION
job v3 are restperf records and job v4 are zapiperf records.

**Prior:**
<img width="1904" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/a318c039-1eaa-4968-b98c-33a761dc27f5">


**With fix:**
<img width="1906" alt="image" src="https://github.com/NetApp/harvest/assets/83282894/87c7ae7a-7ca4-4538-8407-3751217ca3ad">
