### PR TITLE
fix: The unix poller should detect poller names with spaces

### DIFF
--- a/cmd/collectors/unix/main.go
+++ b/cmd/collectors/unix/main.go
@@ -382,9 +382,9 @@ func (u *Unix) PollData() (map[string]*matrix.Matrix, error) {
 		}
 
 		poller := instance.GetLabel("poller")
-		cmd := proc.Cmdline()
+		cmd := proc.CmdlineSlice()
 
-		if !set.NewFrom(strings.Fields(cmd)).Has(poller) {
+		if !set.NewFrom(cmd).Has(poller) {
 			u.Logger.Debug().Msgf("skip instance [%s]: PID (%d) not matched with [%s]", key, pid, cmd)
 			continue
 		}

--- a/cmd/collectors/unix/process.go
+++ b/cmd/collectors/unix/process.go
@@ -17,22 +17,23 @@ import (
 // Process - identity and stats about resource usage of a process
 // most values are simple counters; elapsedTime & cpuTotal are the exception: they are deltas
 type Process struct {
-	pid         int
-	dirpath     string
-	cmdline     string
-	name        string
-	state       string
-	startTime   float64
-	elapsedTime float64
-	timestamp   float64
-	numThreads  uint64
-	numFds      uint64
-	cpuTotal    float64
-	cpu         map[string]float64
-	mem         map[string]uint64
-	io          map[string]uint64
-	net         map[string]uint64
-	ctx         map[string]uint64
+	pid          int
+	dirpath      string
+	cmdline      string
+	cmdlineslice []string
+	name         string
+	state        string
+	startTime    float64
+	elapsedTime  float64
+	timestamp    float64
+	numThreads   uint64
+	numFds       uint64
+	cpuTotal     float64
+	cpu          map[string]float64
+	mem          map[string]uint64
+	io           map[string]uint64
+	net          map[string]uint64
+	ctx          map[string]uint64
 }
 
 // NewProcess - returns an initialized instance of Process
@@ -55,6 +56,11 @@ func (p *Process) Name() string {
 // Cmdline - command-line vector of the process
 func (p *Process) Cmdline() string {
 	return p.cmdline
+}
+
+// CmdlineSlice - command-line slice of the process
+func (p *Process) CmdlineSlice() []string {
+	return p.cmdlineslice
 }
 
 // State - state of the process
@@ -123,6 +129,9 @@ func (p *Process) loadCmdline() error {
 		return errs.New(ErrFileRead, err.Error())
 	}
 	p.cmdline = string(bytes.ReplaceAll(data, []byte("\x00"), []byte(" ")))
+
+	p.cmdlineslice = strings.Split(string(data), "\x00")
+
 	return nil
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -77,7 +77,6 @@ func AllSame(elements [][]string, k int) bool {
 	return true
 }
 
-var pollerRegex = regexp.MustCompile(`poller\s+--poller\s+(.*?)\s`)
 var profRegex = regexp.MustCompile(`--profiling (\d+)`)
 var promRegex = regexp.MustCompile(`--promPort (\d+)`)
 
@@ -98,12 +97,29 @@ func GetPollerStatuses() ([]PollerStatus, error) {
 		if !strings.Contains(line, "poller --poller ") {
 			continue
 		}
-		matches := pollerRegex.FindStringSubmatch(line)
-		if len(matches) != 2 {
+
+		args, err := p.CmdlineSlice()
+
+		if err != nil {
+			if !errors.Is(err, unix.EINVAL) && !errors.Is(err, unix.ENOENT) {
+				fmt.Printf("Unable to read process cmdline pid=%d err=%v\n", p.Pid, err)
+			}
+			continue
+		}
+
+		name := ""
+		for i, arg := range args {
+			if arg == "--poller" && i+1 < len(args) {
+				name = args[i+1]
+				break
+			}
+		}
+
+		if name == "" {
 			continue
 		}
 		s := PollerStatus{
-			Name:   matches[1],
+			Name:   name,
 			Pid:    p.Pid,
 			Status: "running",
 		}
@@ -147,7 +163,7 @@ func CheckCert(certPath string, name string, configPath string, logger zerolog.L
 }
 
 // SaveConfig adds or updates the Grafana token in the harvest.yml config
-// and saves it to fp. The Yaml marshaller is ued so comments are preserved
+// and saves it to fp. The Yaml marshaller is used so comments are preserved
 func SaveConfig(fp string, token string) error {
 	contents, err := os.ReadFile(fp)
 	if err != nil {
@@ -160,9 +176,9 @@ func SaveConfig(fp string, token string) error {
 	}
 
 	// Three cases to consider:
-	//	1. Tools is missing
-	//  2. Tools is present but empty (nil)
-	//  3. Tools is present - overwrite value
+	//	1. Tools are missing
+	//  2. Tools are present but empty (nil)
+	//  3. Tools are present - overwrite value
 	tokenSet := false
 	if len(root.Content) > 0 {
 		nodes := root.Content[0].Content
@@ -244,7 +260,7 @@ func Intersection(a []string, b []string) ([]string, []string) {
 }
 
 // ParseMetric parses display name and type of field and metric type from the raw name of the metric as defined in (sub)template.
-// Users can rename a metric with "=>" (e.g. some_long_metric_name => short).
+// Users can rename a metric with "=>" (e.g., some_long_metric_name => short).
 // Trailing "^" characters are ignored/cleaned as they have special meaning in some collectors.
 func ParseMetric(rawName string) (string, string, string, string) {
 	var (
@@ -294,7 +310,7 @@ func SumNumbers(s []float64) float64 {
 	return total
 }
 
-// Max returns 0 when passed an empty slice, slices.Max panics if input is empty
+// Max returns 0 when passed an empty slice, slices.Max panics if input is empty,
 // This function can be removed once all callers are checked for empty slices
 func Max(input []float64) float64 {
 	if len(input) > 0 {
@@ -303,7 +319,7 @@ func Max(input []float64) float64 {
 	return 0
 }
 
-// Min returns 0 when passed an empty slice, slices.Min panics if input is empty
+// Min returns 0 when passed an empty slice, slices.Min panics if input is empty,
 // This function can be removed once all callers are checked for empty slices
 func Min(input []float64) float64 {
 	if len(input) > 0 {


### PR DESCRIPTION
Thanks to Yann Bizeul for reporting and fixing this in #2771