### PR TITLE
feat: remove duplicate quota metrics

### DIFF
--- a/cmd/collectors/rest/plugins/qtree/qtree.go
+++ b/cmd/collectors/rest/plugins/qtree/qtree.go
@@ -28,6 +28,7 @@ type Qtree struct {
 	query            string
 	quotaType        []string
 	historicalLabels bool // supports labels, metrics for 22.05
+	qtreeMetrics     bool // supports quota metrics with qtree prefix
 }
 
 func New(p *plugin.AbstractPlugin) plugin.Plugin {
@@ -79,6 +80,10 @@ func (q *Qtree) Init() error {
 	q.instanceKeys = make(map[string]string)
 	q.instanceLabels = make(map[string]map[string]string)
 	q.historicalLabels = false
+
+	if q.Params.HasChildS("qtreeMetrics") {
+		q.qtreeMetrics = true
+	}
 
 	if q.Params.HasChildS("historicalLabels") {
 		exportOptions := node.NewS("export_options")
@@ -189,12 +194,15 @@ func (q *Qtree) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, *util.
 		Int("metrics", numMetrics).
 		Msg("Collected")
 
-	// metrics with qtree prefix and quota prefix are available to support backward compatibility
-	qtreePluginData := q.data.Clone(matrix.With{Data: true, Metrics: true, Instances: true, ExportInstances: true})
-	qtreePluginData.UUID = q.Parent + ".Qtree"
-	qtreePluginData.Object = "qtree"
-	qtreePluginData.Identifier = "qtree"
-	return []*matrix.Matrix{qtreePluginData, q.data}, q.client.Metadata, nil
+	if q.qtreeMetrics || q.historicalLabels {
+		// metrics with qtree prefix and quota prefix are available to support backward compatibility
+		qtreePluginData := q.data.Clone(matrix.With{Data: true, Metrics: true, Instances: true, ExportInstances: true})
+		qtreePluginData.UUID = q.Parent + ".Qtree"
+		qtreePluginData.Object = "qtree"
+		qtreePluginData.Identifier = "qtree"
+		return []*matrix.Matrix{qtreePluginData, q.data}, q.client.Metadata, nil
+	}
+	return []*matrix.Matrix{q.data}, q.client.Metadata, nil
 }
 
 func (q *Qtree) handlingHistoricalMetrics(result []gjson.Result, data *matrix.Matrix, cluster string, quotaIndex *int, numMetrics *int) error {


### PR DESCRIPTION
```yaml

plugins:
  - LabelAgent:
      exclude_equals:
        - qtree ``
  - Qtree:
      qtreeMetrics: true                            # <== Add this for backward compatibility
      objects:
        - disk-limit
        - disk-used
        - disk-used-pct-disk-limit
        - disk-used-pct-soft-disk-limit
        - disk-used-pct-threshold
        - file-limit
        - files-used
        - files-used-pct-file-limit
        - files-used-pct-soft-file-limit
        - soft-disk-limit
        - soft-file-limit
        - threshold
      quotaType:
        - tree
#        - user
#        - group
#      batch_size: "50"

```