### PR TITLE
feat: adding description to panels

### DIFF
--- a/cmd/tools/grafana/dashboard_test.go
+++ b/cmd/tools/grafana/dashboard_test.go
@@ -1468,7 +1468,8 @@ func checkDescription(t *testing.T, path string, data []byte, count *int) {
 		// These are from fsa
 		"Volume Access ($Activity) History", "Volume Access ($Activity) History By Percent", "Volume Modify ($Activity) History", "Volume Modify ($Activity) History By Percent",
 		// This is from workload
-		"Service Latency by Resources",
+		"Top $TopResources Workloads by Service Time from sync_repl", "Top $TopResources Workloads by Service Time from flexcache_ral", "Top $TopResources Workloads by Service Time from flexcache_spinhi",
+		"Top $TopResources Workloads by Latency from sync_repl", "Top $TopResources Workloads by Latency from flexcache_ral", "Top $TopResources Workloads by Latency from flexcache_spinhi", "Service Latency by Resources",
 		// These are from svm
 		"NFSv3 Latency Heatmap", "NFSv3 Read Latency Heatmap", "NFSv3 Write Latency Heatmap", "NFSv3 Latency by Op Type", "NFSv3 IOPs per Type",
 		"NFSv4 Latency Heatmap", "NFSv4 Read Latency Heatmap", "NFSv4 Write Latency Heatmap", "NFSv4 Latency by Op Type", "NFSv4 IOPs per Type",
@@ -1479,7 +1480,7 @@ func checkDescription(t *testing.T, path string, data []byte, count *int) {
 		// This is from lun
 		"IO Size",
 		// This is from nfs4storePool
-		"Allocations over 50%", "All nodes with 1% or more allocations in $Datacenter",
+		"Allocations over 50%", "All nodes with 1% or more allocations in $Datacenter", "SessionConnectionHolderAlloc", "ConnectionParentSessionReferenceAlloc", "SessionHolderAlloc", "SessionAlloc", "StateRefHistoryAlloc",
 	}
 
 	VisitAllPanels(data, func(_ string, _, value gjson.Result) {
@@ -1501,9 +1502,8 @@ func checkDescription(t *testing.T, path string, data []byte, count *int) {
 				expr := targetsSlice[0].Get("expr").String()
 				if strings.Contains(expr, "/") || strings.Contains(expr, "+") || strings.Contains(expr, "-") || strings.Contains(expr, " on ") {
 					// This indicates expressions with arithmetic operations, After adding appropriate description, this will be uncommented.
-					// *count++
-					// t.Errorf(`dashboard=%s panel="%s" has arithmetic operations %d`, dashPath, value.Get("title").String(), *count)
-					fmt.Printf(`dashboard=%s panel="%s" has arithmetic operations \n`, dashPath, title)
+					*count++
+					t.Errorf(`dashboard=%s panel="%s" has arithmetic operations %d`, dashPath, value.Get("title").String(), *count)
 				} else {
 					*count++
 					t.Errorf(`dashboard=%s panel="%s" does not have panel description %d`, dashPath, title, *count)
@@ -1519,7 +1519,7 @@ func checkDescription(t *testing.T, path string, data []byte, count *int) {
 				}
 			}
 		} else if !strings.HasPrefix(description, "$") && !strings.HasSuffix(description, ".") {
-			// Few panels have description text from variable, which would be ignored.
+			// Few panels have description text from variable, which would be ignored and description must end with period(.)
 			t.Errorf(`dashboard=%s panel="%s" description hasn't ended with period`, dashPath, title)
 		}
 	})

--- a/grafana/dashboards/cmode/aggregate.json
+++ b/grafana/dashboards/cmode/aggregate.json
@@ -1490,7 +1490,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows detail of Percentage saved by compacting the data and Percentage of space saved by storage efficiency.",
+      "description": "This panel displays detail of Percentage saved by compacting the data and Percentage of space saved by storage efficiency.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1681,7 +1681,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows detail of Number of user-visible files used in the referenced file system and Maximum number of user-visible files that this referenced file system can currently hold.",
+      "description": "This panel displays detail of Number of user-visible files used in the referenced file system and Maximum number of user-visible files that this referenced file system can currently hold.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1777,7 +1777,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows detail of number of files that can currently be stored on disk for system metadata files and number of files that can currently be stored on disk for user-visible files.",
+      "description": "This panel displays detail of number of files that can currently be stored on disk for system metadata files and number of files that can currently be stored on disk for user-visible files.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1873,7 +1873,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows detail of space used by snapshot copies and available space for Snapshot copies in bytes.",
+      "description": "This panel displays detail of space used by snapshot copies and available space for Snapshot copies in bytes.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2247,7 +2247,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows detail of total files allowed in snapshot copies and total files created in snapshot copies.",
+      "description": "This panel displays detail of total files allowed in snapshot copies and total files created in snapshot copies.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2344,7 +2344,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows detail of files in use by snapshot copies, the largest value to which the maxfiles-available parameter can be increased by reconfiguration, on the referenced file system and maximum files available for snapshot copies.",
+      "description": "This panel displays detail of files in use by snapshot copies, the largest value to which the maxfiles-available parameter can be increased by reconfiguration, on the referenced file system and maximum files available for snapshot copies.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3422,7 +3422,7 @@
       "panels": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of percentage of HDD read operations replace by SSD and number of HDD read operations replaced by SSD reads per second.",
+          "description": "This panel displays detail of percentage of HDD read operations replace by SSD and number of HDD read operations replaced by SSD reads per second.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3559,7 +3559,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of average of RAID I/O latency on read hit and average read miss latency.",
+          "description": "This panel displays detail of average of RAID I/O latency on read hit and average read miss latency.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3657,7 +3657,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of total read/write/total cached SSD blocks.",
+          "description": "This panel displays detail of total read/write/total cached SSD blocks.",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/grafana/dashboards/cmode/data_protection_snapshot.json
+++ b/grafana/dashboards/cmode/data_protection_snapshot.json
@@ -205,7 +205,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "Total number of volumes which are being protected.",
+          "description": "Total number of volumes that are protected.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -433,7 +433,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "Total number of volumes which are not being protected.",
+          "description": "Total number of volumes that are not protected.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -581,7 +581,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows volumes detail with protected status and snapshot policy.",
+          "description": "This panel displays volumes detail with protected status and snapshot policy.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1257,7 +1257,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows volumes detail with snapshot count.",
+          "description": "This panel displays volumes detail with snapshot count.",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/grafana/dashboards/cmode/data_protection_snapshot.json
+++ b/grafana/dashboards/cmode/data_protection_snapshot.json
@@ -205,7 +205,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "Total number of volumes which are being protected.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -370,7 +370,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "Total number of volumes whose snapshot size used is breached the snapshot reserve size.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -433,7 +433,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "Total number of volumes which are not being protected.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -507,7 +507,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "Total number of volumes whose snapshot size used is not breached the snapshot reserve size.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -581,6 +581,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
+          "description": "This panel shows volumes detail with protected status and snapshot policy.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1004,7 +1005,7 @@
       "panels": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "Total number of volumes whose snapshot count is < 10.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1067,7 +1068,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "Total number of volumes whose snapshot count is between 10 to 100.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1130,7 +1131,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "Total number of volumes whose snapshot count is between 101 to 500.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1193,7 +1194,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "Total number of volumes whose snapshot count is > 500.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1256,6 +1257,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
+          "description": "This panel shows volumes detail with snapshot count.",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/grafana/dashboards/cmode/datacenter.json
+++ b/grafana/dashboards/cmode/datacenter.json
@@ -1266,7 +1266,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows error detail of disk, shelf, node, network port, license compliance, HA down and sensor failure alerts.",
+          "description": "This panel displays error detail of disk, shelf, node, network port, license compliance, HA down and sensor failure alerts.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1386,7 +1386,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows warning detail of disk, shelf, health monitor, lif, volume move and volume anti-ransomware alerts.",
+          "description": "This panel displays warning detail of disk, shelf, health monitor, lif, volume move and volume anti-ransomware alerts.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2143,7 +2143,7 @@
         {
           "cacheTimeout": null,
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows total power of nodes and shelves.",
+          "description": "This panel displays total power of nodes and shelves.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2594,7 +2594,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of power consumed by a node/shelf/total in Watts.",
+          "description": "This panel displays detail of power consumed by a node/shelf/total in Watts.",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/grafana/dashboards/cmode/datacenter.json
+++ b/grafana/dashboards/cmode/datacenter.json
@@ -2143,7 +2143,7 @@
         {
           "cacheTimeout": null,
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "This panel shows total power of nodes and shelves.",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/grafana/dashboards/cmode/details/volumeBySVM.json
+++ b/grafana/dashboards/cmode/details/volumeBySVM.json
@@ -73,7 +73,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows volume performance detail.",
+      "description": "This panel displays volume performance detail.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/cmode/details/volumeDeepDive.json
+++ b/grafana/dashboards/cmode/details/volumeDeepDive.json
@@ -352,6 +352,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
+      "description": "This panel shows detail of average amount of data read per read operation.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -408,6 +409,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
+      "description": "This panel shows detail of average amount of data write per write operation.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/cmode/details/volumeDeepDive.json
+++ b/grafana/dashboards/cmode/details/volumeDeepDive.json
@@ -90,7 +90,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows volume performance details.",
+      "description": "This panel displays volume performance details.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -352,7 +352,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows detail of average amount of data read per read operation.",
+      "description": "This panel displays detail of average amount of data read per read operation.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -409,7 +409,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows detail of average amount of data write per write operation.",
+      "description": "This panel displays detail of average amount of data write per write operation.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2659,7 +2659,7 @@
       "panels": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of physical size, physical space used, logical space used and size used of the volume, in bytes.",
+          "description": "This panel displays detail of physical size, physical space used, logical space used and size used of the volume, in bytes.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2776,7 +2776,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of physical used %, logical used % and size used % of the volume.",
+          "description": "This panel displays detail of physical used %, logical used % and size used % of the volume.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2890,7 +2890,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of snapshot available size, snapshot reserve size, snapshot reserve available and snapshots size used of the volume.",
+          "description": "This panel displays detail of snapshot available size, snapshot reserve size, snapshot reserve available and snapshots size used of the volume.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3011,7 +3011,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of snapshot reserve %, snapshot reserve used % and size used % of the volume.",
+          "description": "This panel displays detail of snapshot reserve %, snapshot reserve used % and size used % of the volume.",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/grafana/dashboards/cmode/disk.json
+++ b/grafana/dashboards/cmode/disk.json
@@ -2230,7 +2230,7 @@
       "panels": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of number of disk kilobytes (KB) read/written per second.",
+          "description": "This panel displays detail of number of disk kilobytes (KB) read/written per second.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2328,7 +2328,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of bytes written/read through a host adapter.",
+          "description": "This panel displays detail of bytes written/read through a host adapter.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2426,7 +2426,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of array of counts of different types of Consistency Points (CP) and average latency in microseconds for the WAFL filesystem to process write request to the volume.",
+          "description": "This panel displays detail of array of counts of different types of Consistency Points (CP) and average latency in microseconds for the WAFL filesystem to process write request to the volume.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2565,7 +2565,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of external cache hit rate and estimated number of disk reads per second replaced by cache.",
+          "description": "This panel displays detail of external cache hit rate and estimated number of disk reads per second replaced by cache.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2695,7 +2695,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of percentage of HDD read operations replace by SSD and number of HDD read operations replaced by SSD reads per second.",
+          "description": "This panel displays detail of percentage of HDD read operations replace by SSD and number of HDD read operations replaced by SSD reads per second.",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/grafana/dashboards/cmode/external_service_op.json
+++ b/grafana/dashboards/cmode/external_service_op.json
@@ -268,7 +268,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows Number of 'Not Found' responses for the operations.",
+      "description": "This panel displays Number of 'Not Found' responses for the operations.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -355,7 +355,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows cumulative count of all request failures.",
+      "description": "This panel displays cumulative count of all request failures.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -442,7 +442,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows Number of requests sent to the service.",
+      "description": "This panel displays Number of requests sent to the service.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -529,7 +529,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows Number of responses received from the server (does not include timeouts).",
+      "description": "This panel displays Number of responses received from the server (does not include timeouts).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -616,7 +616,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows Number of successful responses to the operation.",
+      "description": "This panel displays Number of successful responses to the operation.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -703,7 +703,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows Number of times requests to the server for this operation timed out.",
+      "description": "This panel displays Number of times requests to the server for this operation timed out.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/cmode/lun.json
+++ b/grafana/dashboards/cmode/lun.json
@@ -3933,7 +3933,7 @@
       "panels": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panels shows average read/write latency in microseconds for all operations on the LUN.",
+          "description": "This panels displays average read/write latency in microseconds for all operations on the LUN.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4028,7 +4028,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows Read/Write bytes data.",
+          "description": "This panel displays Read/Write bytes data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4123,7 +4123,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows number of read/write operations.",
+          "description": "This panel displays number of read/write operations.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4219,7 +4219,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of I/O to or from a LUN which is not owned by the storage system handling the I/O and number of operations received by a storage system that does not own the LUN targeted by the operations.",
+          "description": "This panel displays detail of I/O to or from a LUN which is not owned by the storage system handling the I/O and number of operations received by a storage system that does not own the LUN targeted by the operations.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4327,7 +4327,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of number of compare and write requests, number of unmap command requests, number of write same command requests, number of write same commands requests with unmap bit set and total number of xcopy operations on the LUN.",
+          "description": "This panel displays detail of number of compare and write requests, number of unmap command requests, number of write same command requests, number of write same commands requests with unmap bit set and total number of xcopy operations on the LUN.",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/grafana/dashboards/cmode/mcc_cluster.json
+++ b/grafana/dashboards/cmode/mcc_cluster.json
@@ -3458,7 +3458,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows cluster level diagnostics status detail of Metrocluster.",
+          "description": "This panel displays cluster level diagnostics status detail of Metrocluster.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3561,7 +3561,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows node level diagnostics status detail of Metrocluster.",
+          "description": "This panel displays node level diagnostics status detail of Metrocluster.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3666,7 +3666,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows aggregate level diagnostics status detail of Metrocluster.",
+          "description": "This panel displays aggregate level diagnostics status detail of Metrocluster.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3773,7 +3773,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows volume level diagnostics status detail of Metrocluster.",
+          "description": "This panel displays volume level diagnostics status detail of Metrocluster.",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/grafana/dashboards/cmode/network.json
+++ b/grafana/dashboards/cmode/network.json
@@ -162,7 +162,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows detail of total number of FC-NVMe/FCP operations and amount of FC-NVMe/FCP traffic to and from the storage system.",
+      "description": "This panel displays detail of total number of FC-NVMe/FCP operations and amount of FC-NVMe/FCP traffic to and from the storage system.",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -367,7 +367,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows detail of number of FC-NVMe/FC read operations and amount of data read from the storage system (FC-NVMe/FC).",
+      "description": "This panel displays detail of number of FC-NVMe/FC read operations and amount of data read from the storage system (FC-NVMe/FC).",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -460,7 +460,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows detail of Number of FC-NVMe/FC write operations and amount of data written to the storage system (FC-NVMe/FC).",
+      "description": "This panel displays detail of Number of FC-NVMe/FC write operations and amount of data written to the storage system (FC-NVMe/FC).",
       "fieldConfig": {
         "defaults": {
           "mappings": [],

--- a/grafana/dashboards/cmode/nfsTroubleshooting.json
+++ b/grafana/dashboards/cmode/nfsTroubleshooting.json
@@ -764,7 +764,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows SVM performance detail.",
+      "description": "This panel displays SVM performance detail.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/cmode/node.json
+++ b/grafana/dashboards/cmode/node.json
@@ -1921,7 +1921,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "This panel shows total bytes received & sent in ethernet ports.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2011,7 +2011,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "This panel shows detail of amount of data read from the storage system/written to the storage system in FC ports.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4125,7 +4125,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "This panel shows detail of amount of data read from the storage system/written to the storage system.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4542,7 +4542,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "This panel shows detail of amount of data read from the storage system/written to the storage system in NVMe/FC.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4808,7 +4808,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "This panel shows detail of iSCSI read/write/other operations per second on this logical interface (LIF).",
           "fieldConfig": {
             "defaults": {
               "mappings": [],
@@ -4957,7 +4957,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "This panel shows detail of amount of data read from the storage system/written to the storage system in bytes.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -5049,7 +5049,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "This panel shows detail of iSCSI read/write/other operations per second on this logical interface (LIF).",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/grafana/dashboards/cmode/node.json
+++ b/grafana/dashboards/cmode/node.json
@@ -1921,7 +1921,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows total bytes received & sent in ethernet ports.",
+          "description": "This panel displays total bytes received & sent in ethernet ports.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2011,7 +2011,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of amount of data read from the storage system/written to the storage system in FC ports.",
+          "description": "This panel displays detail of amount of data read from the storage system/written to the storage system in FC ports.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2116,7 +2116,7 @@
       "panels": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of average latency in microseconds for the WAFL filesystem to process read/write/other request to the volume and aggregated to node level.",
+          "description": "This panel displays detail of average latency in microseconds for the WAFL filesystem to process read/write/other request to the volume and aggregated to node level.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2217,7 +2217,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of bytes read/written per second and aggregated at node level.",
+          "description": "This panel displays detail of bytes read/written per second and aggregated at node level.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2317,7 +2317,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of Number of read/write/other operations per second from the volume and aggregated at node level.",
+          "description": "This panel displays detail of Number of read/write/other operations per second from the volume and aggregated at node level.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2423,7 +2423,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of system utilization based on cpu busy, cpu domain busy, disk busy and array of percentage time spent in different phases of Consistency Point (CP).",
+          "description": "This panel displays detail of system utilization based on cpu busy, cpu domain busy, disk busy and array of percentage time spent in different phases of Consistency Point (CP).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2666,7 +2666,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of CIFS/NFS/FCP/ISCSI/NVMF operation per second.",
+          "description": "This panel displays detail of CIFS/NFS/FCP/ISCSI/NVMF operation per second.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3008,7 +3008,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of rate of NFSv3 total/write/read data transfers per second.",
+          "description": "This panel displays detail of rate of NFSv3 total/write/read data transfers per second.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3124,7 +3124,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows number of NFS total/other/write/read operations per second.",
+          "description": "This panel displays number of NFS total/other/write/read operations per second.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3253,7 +3253,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of average latency of read/write procedure requests.",
+          "description": "This panel displays detail of average latency of read/write procedure requests.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3349,7 +3349,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of rate of NFSv3 read/write data transfers per second.",
+          "description": "This panel displays detail of rate of NFSv3 read/write data transfers per second.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3445,7 +3445,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of total observed NFSv3 total/read/write operations per second.",
+          "description": "This panel displays detail of total observed NFSv3 total/read/write operations per second.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3783,7 +3783,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows CIFS connection detail.",
+          "description": "This panel displays CIFS connection detail.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4125,7 +4125,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of amount of data read from the storage system/written to the storage system.",
+          "description": "This panel displays detail of amount of data read from the storage system/written to the storage system.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4542,7 +4542,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of amount of data read from the storage system/written to the storage system in NVMe/FC.",
+          "description": "This panel displays detail of amount of data read from the storage system/written to the storage system in NVMe/FC.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4808,7 +4808,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of iSCSI read/write/other operations per second on this logical interface (LIF).",
+          "description": "This panel displays detail of iSCSI read/write/other operations per second on this logical interface (LIF).",
           "fieldConfig": {
             "defaults": {
               "mappings": [],
@@ -4957,7 +4957,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of amount of data read from the storage system/written to the storage system in bytes.",
+          "description": "This panel displays detail of amount of data read from the storage system/written to the storage system in bytes.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -5049,7 +5049,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows detail of iSCSI read/write/other operations per second on this logical interface (LIF).",
+          "description": "This panel displays detail of iSCSI read/write/other operations per second on this logical interface (LIF).",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/grafana/dashboards/cmode/power.json
+++ b/grafana/dashboards/cmode/power.json
@@ -136,7 +136,7 @@
     {
       "cacheTimeout": null,
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows total power of nodes and shelves.",
+      "description": "This panel displays total power of nodes and shelves.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -587,7 +587,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows total power consumed by Node, Shelf and both.",
+      "description": "This panel displays total power consumed by Node, Shelf and both.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/cmode/power.json
+++ b/grafana/dashboards/cmode/power.json
@@ -136,7 +136,7 @@
     {
       "cacheTimeout": null,
       "datasource": "${DS_PROMETHEUS}",
-      "description": "",
+      "description": "This panel shows total power of nodes and shelves.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/cmode/security.json
+++ b/grafana/dashboards/cmode/security.json
@@ -731,7 +731,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows cluster compliant detail.",
+      "description": "This panel displays cluster compliant detail.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -915,7 +915,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows SVM compliant detail.",
+      "description": "This panel displays SVM compliant detail.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1083,7 +1083,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows volume encryption detail.",
+      "description": "This panel displays volume encryption detail.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1279,7 +1279,7 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "This panel shows SVM anti ransomware detail.",
+      "description": "This panel displays SVM anti ransomware detail.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/cmode/snapmirror.json
+++ b/grafana/dashboards/cmode/snapmirror.json
@@ -1540,6 +1540,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
+          "description": "This panel shows count of snapmirror relationships by source node.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2298,7 +2299,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "Total number of volume snapmirror relationships.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2361,7 +2362,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "Total number of snapmirror relationships which are being protected by both volume and Storage VM.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2545,7 +2546,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "Total number of snapmirror relationships having lag time <= 15 minutes.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2608,7 +2609,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "Total number of snapmirror relationships having lag time between 16 minutes to 30 minutes.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2671,7 +2672,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "Total number of Storage VM snapmirror relationships.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2734,7 +2735,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "Total number of volumes which are not being protected.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2808,7 +2809,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "Total number of snapmirror relationships having lag time between 31 minutes to 60 minutes.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2871,7 +2872,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "Total number of snapmirror relationships having lag time >= 60 minutes.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2934,6 +2935,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
+          "description": "This panel shows local & remote snapmirrors with protected by details.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3114,6 +3116,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
+          "description": "This panel shows snapmirror relationships with lag duration details.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3336,7 +3339,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "",
+          "description": "This panel shows volumes details which are not being protected.",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/grafana/dashboards/cmode/snapmirror.json
+++ b/grafana/dashboards/cmode/snapmirror.json
@@ -1308,7 +1308,7 @@
       "panels": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows count of snapmirror relationships by destination node.",
+          "description": "This panel displays count of snapmirror relationships by destination node.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1723,7 +1723,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows count of snapmirror relationships by source node.",
+          "description": "This panel displays the count of snapmirror relationships by source node.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2152,7 +2152,7 @@
       "panels": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows count of snapmirror relationships by source SVM.",
+          "description": "This panel displays count of snapmirror relationships by source SVM.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2248,7 +2248,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows count of snapmirror relationships by destination SVM.",
+          "description": "This panel displays count of snapmirror relationships by destination SVM.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2545,7 +2545,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "Total number of snapmirror relationships which are being protected by both volume and Storage VM.",
+          "description": "Total number of snapmirror relationships that are protected by both volume and Storage VM.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2729,7 +2729,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "Total number of snapmirror relationships having lag time <= 15 minutes.",
+          "description": "Total number of snapmirror relationships with a lag time of 15 minutes or less.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2918,7 +2918,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "Total number of volumes which are not being protected.",
+          "description": "Total number of volumes that are not protected.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3055,7 +3055,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "Total number of snapmirror relationships having lag time >= 60 minutes.",
+          "description": "Total number of snapmirror relationships with a lag time of 60 minutes or more.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3118,7 +3118,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows local & remote snapmirrors with protected by details.",
+          "description": "This panel displays local & remote snapmirrors with protected by details.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3299,7 +3299,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows snapmirror relationships with lag duration details.",
+          "description": "This panel displays snapmirror relationships with lag duration details.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3522,7 +3522,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows volumes details which are not being protected.",
+          "description": "This panel displays details of volumes that are not protected.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3628,7 +3628,7 @@
       "panels": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows volume relationship count based on the relationship type.",
+          "description": "This panel displays volume relationship count based on the relationship type.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3746,7 +3746,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows volume relationship count based on the relationship health.",
+          "description": "This panel displays volume relationship count based on the relationship health.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3850,7 +3850,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows volume relationship count based on the relationship type.",
+          "description": "This panel displays volume relationship count based on the relationship type.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4101,7 +4101,7 @@
       "panels": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows consistency group relationship count based on the relationship type.",
+          "description": "This panel displays consistency group relationship count based on the relationship type.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4219,7 +4219,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows consistency group relationship count based on the relationship health.",
+          "description": "This panel displays consistency group relationship count based on the relationship health.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4323,7 +4323,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "This panel shows volume relationship count based on the relationship health.",
+          "description": "This panel displays volume relationship count based on the relationship health.",
           "fieldConfig": {
             "defaults": {
               "color": {


### PR DESCRIPTION
With this PR change, Only these panels are pending and we can target them in next release

```
        // we don't get description for below panels, we need to manually formed them as per our need.
	ignoreList := []string{
		// These are from fsa
		"Volume Access ($Activity) History", "Volume Access ($Activity) History By Percent", "Volume Modify ($Activity) History", "Volume Modify ($Activity) History By Percent",
		// This is from workload
		"Top $TopResources Workloads by Service Time from sync_repl", "Top $TopResources Workloads by Service Time from flexcache_ral", "Top $TopResources Workloads by Service Time from flexcache_spinhi",
		"Top $TopResources Workloads by Latency from sync_repl", "Top $TopResources Workloads by Latency from flexcache_ral", "Top $TopResources Workloads by Latency from flexcache_spinhi", "Service Latency by Resources",
		// These are from svm
		"NFSv3 Latency Heatmap", "NFSv3 Read Latency Heatmap", "NFSv3 Write Latency Heatmap", "NFSv3 Latency by Op Type", "NFSv3 IOPs per Type",
		"NFSv4 Latency Heatmap", "NFSv4 Read Latency Heatmap", "NFSv4 Write Latency Heatmap", "NFSv4 Latency by Op Type", "NFSv4 IOPs per Type",
		"NFSv4.1 Latency Heatmap", "NFSv4.1 Read Latency Heatmap", "NFSv4.1 Write Latency Heatmap", "NFSv4.1 Latency by Op Type", "NFSv4.1 IOPs per Type",
		"NFSv4.2 Latency by Op Type", "NFSv4.2 IOPs per Type", "SVM NVMe/FC Throughput", "Copy Manager Requests",
		// This is from volume
		"Top $TopResources Volumes by Number of Compress Attempts", "Top $TopResources Volumes by Number of Compress Fail", "Volume Latency by Op Type", "Volume IOPs per Type",
		// This is from lun
		"IO Size",
		// This is from nfs4storePool
		"Allocations over 50%", "All nodes with 1% or more allocations in $Datacenter", "SessionConnectionHolderAlloc", "ConnectionParentSessionReferenceAlloc", "SessionHolderAlloc", "SessionAlloc", "StateRefHistoryAlloc",
	}
```