### PR TITLE
feat: enable request/response logging for Rest and RestPerf plugins

### DIFF
--- a/cmd/collectors/restperf/restperf.go
+++ b/cmd/collectors/restperf/restperf.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/exp/maps"
 	"path"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -212,6 +213,7 @@ func (r *RestPerf) loadWorkloadClassQuery(defaultValue string) string {
 				Send()
 			return defaultValue
 		}
+		slices.Sort(v)
 		s := strings.Join(v, "|")
 		r.Logger.Debug().
 			Str("name", name).
@@ -699,7 +701,11 @@ func (r *RestPerf) PollData() (map[string]*matrix.Matrix, error) {
 	dataQuery := path.Join(r.Prop.Query, "rows")
 
 	var filter []string
-	filter = append(filter, "counters.name="+strings.Join(maps.Keys(r.Prop.Metrics), "|"))
+	// Sort filters so that the href is deterministic
+	metrics := maps.Keys(r.Prop.Metrics)
+	slices.Sort(metrics)
+
+	filter = append(filter, "counters.name="+strings.Join(metrics, "|"))
 
 	href := rest.NewHrefBuilder().
 		APIPath(dataQuery).

--- a/cmd/tools/rest/client.go
+++ b/cmd/tools/rest/client.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"os"
+	"slices"
 	"strings"
 	"time"
 )
@@ -89,17 +90,17 @@ func New(poller *conf.Poller, timeout time.Duration, credentials *auth.Credentia
 	httpclient = &http.Client{Transport: transport, Timeout: timeout}
 	client.client = httpclient
 
+	if poller.LogSet != nil {
+		client.logRest = slices.Contains(*poller.LogSet, "Rest")
+	}
+
 	return &client, nil
 }
 
 func (c *Client) TraceLogSet(collectorName string, config *node.Node) {
 	// check for log sets and enable Rest request logging if collectorName is in the set
 	if llogs := config.GetChildS("log"); llogs != nil {
-		for _, log := range llogs.GetAllChildContentS() {
-			if strings.EqualFold(log, collectorName) {
-				c.logRest = true
-			}
-		}
+		c.logRest = slices.Contains(llogs.GetAllChildContentS(), collectorName)
 	}
 }
 

--- a/cmd/tools/rest/href_builder.go
+++ b/cmd/tools/rest/href_builder.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -74,8 +75,16 @@ func (b *HrefBuilder) Build() string {
 	href.WriteString(b.apiPath)
 
 	href.WriteString("?return_records=true")
+
+	// Sort fields so that the href is deterministic
+	slices.Sort(b.fields)
+
 	addArg(&href, "&fields=", strings.Join(b.fields, ","))
 	addArg(&href, "&counter_schemas=", b.counterSchema)
+
+	// Sort filters so that the href is deterministic
+	slices.Sort(b.filter)
+
 	for _, f := range b.filter {
 		addArg(&href, "&", f)
 	}


### PR DESCRIPTION
refactor: href builder should sort fields and filters for deterministic hrefs