### PR TITLE
fix: add All to svm dropdown in volume deep dive dashboard

### DIFF
--- a/grafana/dashboards/cmode/details/volumeDeepDive.json
+++ b/grafana/dashboards/cmode/details/volumeDeepDive.json
@@ -3510,7 +3510,7 @@
         "description": null,
         "error": null,
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "label": null,
         "multi": true,
         "name": "SVM",
@@ -3587,5 +3587,5 @@
   "timezone": "",
   "title": "ONTAP: Volume Deep Dive",
   "uid": "IkXhW11Iz",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
This change also enables a direct workflow for users when they open the 'Volume by SVM' dashboard and then tries to navigate to the 'Volume Deep Dive' dashboard.