### PR TITLE
fix: duplicate instance key issue quota metrics

### DIFF
--- a/cmd/collectors/zapi/plugins/qtree/qtree.go
+++ b/cmd/collectors/zapi/plugins/qtree/qtree.go
@@ -379,7 +379,7 @@ func (q *Qtree) handlingQuotaMetrics(quotas []*node.Node, quotaCount *int, numMe
 
 				// Ex. InstanceKey: SVMA.vol1Abc.qtree1.5.disk-limit
 				if q.client.IsClustered() {
-					quotaInstanceKey = vserver + "." + volume + "." + tree + "." + uName + "." + attribute
+					quotaInstanceKey = vserver + "." + volume + "." + tree + "." + uName + "." + attribute + "." + quotaType
 				} else {
 					quotaInstanceKey = volume + "." + tree + "." + uName + "." + attribute
 				}


### PR DESCRIPTION
2024-05-20T18:06:11+05:30 ERR collector/collector.go:453 > error="duplicate instance key => umeng-aff300-05-svm1.test1..root.file-limit" Poller=u2 collector=Zapi:Qtree plugin=Qtree
