### PR TITLE
chore: bump hashicorp go-version

### DIFF
--- a/cmd/collectors/storagegrid/rest/client.go
+++ b/cmd/collectors/storagegrid/rest/client.go
@@ -332,9 +332,9 @@ func (c *Client) SetVersion(v string) error {
 	return nil
 }
 
-func check(i int64) int {
+func check(i int) int {
 	if i > 0 && i <= math.MaxInt32 {
-		return int(i)
+		return i
 	}
 	return 0
 }

--- a/third_party/go-version/LICENSE
+++ b/third_party/go-version/LICENSE
@@ -1,3 +1,4 @@
+Copyright (c) 2014 HashiCorp, Inc.
 Mozilla Public License, version 2.0
 
 1. Definitions

--- a/third_party/go-version/README.md
+++ b/third_party/go-version/README.md
@@ -1,5 +1,5 @@
 # Versioning Library for Go
-[![Build Status](https://circleci.com/gh/hashicorp/go-version/tree/main.svg?style=svg)](https://circleci.com/gh/hashicorp/go-version/tree/main)
+![Build Status](https://github.com/hashicorp/go-version/actions/workflows/go-tests.yml/badge.svg)
 [![GoDoc](https://godoc.org/github.com/hashicorp/go-version?status.svg)](https://godoc.org/github.com/hashicorp/go-version)
 
 go-version is a library for parsing versions and version constraints,

--- a/third_party/go-version/constraint.go
+++ b/third_party/go-version/constraint.go
@@ -1,8 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package version
 
 import (
 	"fmt"
-	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -199,7 +200,7 @@ func prereleaseCheck(v, c *Version) bool {
 	case cPre && vPre:
 		// A constraint with a pre-release can only match a pre-release version
 		// with the same base segments.
-		return reflect.DeepEqual(c.Segments64(), v.Segments64())
+		return v.equalSegments(c)
 
 	case !cPre && vPre:
 		// A constraint without a pre-release can only match a version without a

--- a/third_party/go-version/version.go
+++ b/third_party/go-version/version.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"database/sql/driver"
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -357,9 +358,16 @@ func (v *Version) Prerelease() string {
 func (v *Version) Segments() []int {
 	segmentSlice := make([]int, len(v.segments))
 	for i, v := range v.segments {
-		segmentSlice[i] = int(v)
+		segmentSlice[i] = check(v)
 	}
 	return segmentSlice
+}
+
+func check(i int64) int {
+	if i > 0 && i <= math.MaxInt32 {
+		return int(i)
+	}
+	return 0
 }
 
 // Segments64 returns the numeric segments of the version as a slice of int64s.

--- a/third_party/go-version/version.go
+++ b/third_party/go-version/version.go
@@ -1,9 +1,12 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package version
 
 import (
 	"bytes"
+	"database/sql/driver"
 	"fmt"
-	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -117,11 +120,8 @@ func (v *Version) Compare(other *Version) int {
 		return 0
 	}
 
-	segmentsSelf := v.Segments64()
-	segmentsOther := other.Segments64()
-
 	// If the segments are the same, we must compare on prerelease info
-	if reflect.DeepEqual(segmentsSelf, segmentsOther) {
+	if v.equalSegments(other) {
 		preSelf := v.Prerelease()
 		preOther := other.Prerelease()
 		if preSelf == "" && preOther == "" {
@@ -137,6 +137,8 @@ func (v *Version) Compare(other *Version) int {
 		return comparePrereleases(preSelf, preOther)
 	}
 
+	segmentsSelf := v.Segments64()
+	segmentsOther := other.Segments64()
 	// Get the highest specificity (hS), or if they're equal, just use segmentSelf length
 	lenSelf := len(segmentsSelf)
 	lenOther := len(segmentsOther)
@@ -178,6 +180,21 @@ func (v *Version) Compare(other *Version) int {
 
 	// if we got this far, they're equal
 	return 0
+}
+
+func (v *Version) equalSegments(other *Version) bool {
+	segmentsSelf := v.Segments64()
+	segmentsOther := other.Segments64()
+
+	if len(segmentsSelf) != len(segmentsOther) {
+		return false
+	}
+	for i, v := range segmentsSelf {
+		if v != segmentsOther[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func allZero(segs []int64) bool {
@@ -337,10 +354,10 @@ func (v *Version) Prerelease() string {
 // This excludes any metadata or pre-release information. For example,
 // for a version "1.2.3-beta", segments will return a slice of
 // 1, 2, 3.
-func (v *Version) Segments() []int64 {
-	segmentSlice := make([]int64, len(v.segments))
+func (v *Version) Segments() []int {
+	segmentSlice := make([]int, len(v.segments))
 	for i, v := range v.segments {
-		segmentSlice[i] = v
+		segmentSlice[i] = int(v)
 	}
 	return segmentSlice
 }
@@ -404,4 +421,21 @@ func (v *Version) UnmarshalText(b []byte) error {
 // MarshalText implements encoding.TextMarshaler interface.
 func (v *Version) MarshalText() ([]byte, error) {
 	return []byte(v.String()), nil
+}
+
+// Scan implements the sql.Scanner interface.
+func (v *Version) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case string:
+		return v.UnmarshalText([]byte(src))
+	case nil:
+		return nil
+	default:
+		return fmt.Errorf("cannot scan %T as Version", src)
+	}
+}
+
+// Value implements the driver.Valuer interface.
+func (v *Version) Value() (driver.Value, error) {
+	return v.String(), nil
 }

--- a/third_party/go-version/version_collection.go
+++ b/third_party/go-version/version_collection.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package version
 
 // Collection is a type that implements the sort.Interface interface


### PR DESCRIPTION
Bumps to https://github.com/hashicorp/go-version/releases/tag/v1.7.0