### PR TITLE
feat: Harvest should log template loading errors

### DIFF
--- a/cmd/collectors/rest/plugins/securityaccount/securityaccount.go
+++ b/cmd/collectors/rest/plugins/securityaccount/securityaccount.go
@@ -35,12 +35,12 @@ func (s *SecurityAccount) Init() error {
 	}
 
 	clientTimeout := s.ParentParams.GetChildContentS("client_timeout")
-	timeout, _ := time.ParseDuration(rest.DefaultTimeout)
-	duration, err := time.ParseDuration(clientTimeout)
-	if err == nil {
-		timeout = duration
-	} else {
-		s.Logger.Info().Str("timeout", timeout.String()).Msg("Using default timeout")
+	if clientTimeout == "" {
+		clientTimeout = rest.DefaultTimeout
+	}
+	timeout, err := time.ParseDuration(clientTimeout)
+	if err != nil {
+		s.Logger.Info().Str("timeout", rest.DefaultTimeout).Msg("Using default timeout")
 	}
 	if s.client, err = rest.New(conf.ZapiPoller(s.ParentParams), timeout, s.Auth); err != nil {
 		return fmt.Errorf("failed to connect err=%w", err)

--- a/cmd/poller/collector/helpers.go
+++ b/cmd/poller/collector/helpers.go
@@ -59,6 +59,7 @@ func (c *AbstractCollector) ImportSubTemplate(model, filename, jitter string, ve
 		customTemplateErr             error
 		finalTemplate                 *node.Node
 		customTemplate                *node.Node
+		importErrs                    []error
 	)
 
 	if filename == "" {
@@ -100,6 +101,7 @@ nextFile:
 					finalTemplate.PreprocessTemplate()
 					continue nextFile
 				}
+				importErrs = append(importErrs, fmt.Errorf("failed to import template: %s file: %w", templatePath, err))
 			} else {
 				// any errors w.r.t customTemplate are warnings and should not be returned to caller
 				customTemplate, customTemplateErr = tree.ImportYaml(templatePath)
@@ -119,7 +121,8 @@ nextFile:
 			if c.Object == "Status_7mode" && model == "cdot" {
 				return nil, "", errs.New(errs.ErrWrongTemplate, "unable to load status_7.yaml on cdot")
 			}
-			return nil, "", fmt.Errorf("no best-fit template for %s on %s", filename, c.Options.ConfPath)
+			return nil, "", fmt.Errorf("no best-fit template for %s on confPath %s %w",
+				filename, c.Options.ConfPath, errors.Join(importErrs...))
 		}
 	}
 


### PR DESCRIPTION
refactor: securityaccount.go should only log default timeout when there is an error