### PR TITLE
fix: Harvest should collect power metrics from a1000 and a900 clusters

### DIFF
--- a/cmd/collectors/power.go
+++ b/cmd/collectors/power.go
@@ -79,11 +79,11 @@ type environmentMetric struct {
 
 var ambientRegex = regexp.MustCompile(`^(Ambient Temp|Ambient Temp \d|PSU\d AmbTemp|PSU\d Inlet|PSU\d Inlet Temp|In Flow Temp|Front Temp|Bat_Ambient \d|Riser Inlet Temp)$`)
 
-var powerInRegex = regexp.MustCompile(`^PSU\d (InPwr Monitor|InPower|PIN|Power In)$`)
+var powerInRegex = regexp.MustCompile(`^PSU\d (InPwr Monitor|InPower|PIN|Power In|In Pwr)$`)
 
-var voltageRegex = regexp.MustCompile(`^PSU\d (\d+V|InVoltage|VIN|AC In Volt)$`)
+var voltageRegex = regexp.MustCompile(`^PSU\d (\d+V|InVoltage|VIN|AC In Volt|In Volt)$`)
 
-var CurrentRegex = regexp.MustCompile(`^PSU\d (\d+V Curr|Curr|InCurrent|Curr IIN|AC In Curr)$`)
+var currentRegex = regexp.MustCompile(`^PSU\d (\d+V Curr|Curr|InCurrent|Curr IIN|AC In Curr|In Curr)$`)
 
 var eMetrics = []string{
 	"average_ambient_temperature",
@@ -128,7 +128,7 @@ func calculateEnvironmentMetrics(data *matrix.Matrix, logger *logging.Logger, va
 			isAmbientMatch := ambientRegex.MatchString(sensorName)
 			isPowerMatch := powerInRegex.MatchString(sensorName)
 			isVoltageMatch := voltageRegex.MatchString(sensorName)
-			isCurrentMatch := CurrentRegex.MatchString(sensorName)
+			isCurrentMatch := currentRegex.MatchString(sensorName)
 
 			if sensorType == "thermal" && isAmbientMatch {
 				if value, ok := metric.GetValueFloat64(instance); ok {

--- a/cmd/collectors/testdata/rest-sensors-a1000.json
+++ b/cmd/collectors/testdata/rest-sensors-a1000.json
@@ -1,0 +1,296 @@
+{
+  "records": [
+    {
+      "node": {
+        "uuid": "52ad059c-349b-11ef-b340-d039eaa9ee10",
+        "name": "a1k-01",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/52ad059c-349b-11ef-b340-d039eaa9ee10"
+          }
+        }
+      },
+      "index": 81,
+      "name": "PSU1 In Volt",
+      "type": "voltage",
+      "value": 210000,
+      "value_units": "mV",
+      "threshold_state": "normal",
+      "critical_low_threshold": 84000,
+      "warning_low_threshold": 90000,
+      "warning_high_threshold": 264000,
+      "critical_high_threshold": 276000,
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/52ad059c-349b-11ef-b340-d039eaa9ee10/81"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "52ad059c-349b-11ef-b340-d039eaa9ee10",
+        "name": "a1k-01",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/52ad059c-349b-11ef-b340-d039eaa9ee10"
+          }
+        }
+      },
+      "index": 82,
+      "name": "PSU1 In Curr",
+      "type": "current",
+      "value": 2100,
+      "value_units": "mA",
+      "threshold_state": "normal",
+      "critical_low_threshold": 0,
+      "warning_high_threshold": 14100,
+      "critical_high_threshold": 15000,
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/52ad059c-349b-11ef-b340-d039eaa9ee10/82"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "52ad059c-349b-11ef-b340-d039eaa9ee10",
+        "name": "a1k-01",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/52ad059c-349b-11ef-b340-d039eaa9ee10"
+          }
+        }
+      },
+      "index": 85,
+      "name": "PSU1 In Pwr",
+      "type": "unknown",
+      "value": 448,
+      "value_units": "W",
+      "threshold_state": "normal",
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/52ad059c-349b-11ef-b340-d039eaa9ee10/85"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "52ad059c-349b-11ef-b340-d039eaa9ee10",
+        "name": "a1k-01",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/52ad059c-349b-11ef-b340-d039eaa9ee10"
+          }
+        }
+      },
+      "index": 91,
+      "name": "PSU2 In Volt",
+      "type": "voltage",
+      "value": 210000,
+      "value_units": "mV",
+      "threshold_state": "normal",
+      "critical_low_threshold": 84000,
+      "warning_low_threshold": 90000,
+      "warning_high_threshold": 264000,
+      "critical_high_threshold": 276000,
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/52ad059c-349b-11ef-b340-d039eaa9ee10/91"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "52ad059c-349b-11ef-b340-d039eaa9ee10",
+        "name": "a1k-01",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/52ad059c-349b-11ef-b340-d039eaa9ee10"
+          }
+        }
+      },
+      "index": 92,
+      "name": "PSU2 In Curr",
+      "type": "current",
+      "value": 2100,
+      "value_units": "mA",
+      "threshold_state": "normal",
+      "critical_low_threshold": 0,
+      "warning_high_threshold": 14100,
+      "critical_high_threshold": 15000,
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/52ad059c-349b-11ef-b340-d039eaa9ee10/92"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "52ad059c-349b-11ef-b340-d039eaa9ee10",
+        "name": "a1k-01",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/52ad059c-349b-11ef-b340-d039eaa9ee10"
+          }
+        }
+      },
+      "index": 95,
+      "name": "PSU2 In Pwr",
+      "type": "unknown",
+      "value": 456,
+      "value_units": "W",
+      "threshold_state": "normal",
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/52ad059c-349b-11ef-b340-d039eaa9ee10/95"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "800c0fcb-349b-11ef-8a0d-d039eaa9edb6",
+        "name": "a1k-02",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/800c0fcb-349b-11ef-8a0d-d039eaa9edb6"
+          }
+        }
+      },
+      "index": 81,
+      "name": "PSU1 In Volt",
+      "type": "voltage",
+      "value": 212000,
+      "value_units": "mV",
+      "threshold_state": "normal",
+      "critical_low_threshold": 84000,
+      "warning_low_threshold": 90000,
+      "warning_high_threshold": 264000,
+      "critical_high_threshold": 276000,
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/800c0fcb-349b-11ef-8a0d-d039eaa9edb6/81"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "800c0fcb-349b-11ef-8a0d-d039eaa9edb6",
+        "name": "a1k-02",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/800c0fcb-349b-11ef-8a0d-d039eaa9edb6"
+          }
+        }
+      },
+      "index": 82,
+      "name": "PSU1 In Curr",
+      "type": "current",
+      "value": 2100,
+      "value_units": "mA",
+      "threshold_state": "normal",
+      "critical_low_threshold": 0,
+      "warning_high_threshold": 14100,
+      "critical_high_threshold": 15000,
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/800c0fcb-349b-11ef-8a0d-d039eaa9edb6/82"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "800c0fcb-349b-11ef-8a0d-d039eaa9edb6",
+        "name": "a1k-02",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/800c0fcb-349b-11ef-8a0d-d039eaa9edb6"
+          }
+        }
+      },
+      "index": 85,
+      "name": "PSU1 In Pwr",
+      "type": "unknown",
+      "value": 448,
+      "value_units": "W",
+      "threshold_state": "normal",
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/800c0fcb-349b-11ef-8a0d-d039eaa9edb6/85"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "800c0fcb-349b-11ef-8a0d-d039eaa9edb6",
+        "name": "a1k-02",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/800c0fcb-349b-11ef-8a0d-d039eaa9edb6"
+          }
+        }
+      },
+      "index": 91,
+      "name": "PSU2 In Volt",
+      "type": "voltage",
+      "value": 210000,
+      "value_units": "mV",
+      "threshold_state": "normal",
+      "critical_low_threshold": 84000,
+      "warning_low_threshold": 90000,
+      "warning_high_threshold": 264000,
+      "critical_high_threshold": 276000,
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/800c0fcb-349b-11ef-8a0d-d039eaa9edb6/91"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "800c0fcb-349b-11ef-8a0d-d039eaa9edb6",
+        "name": "a1k-02",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/800c0fcb-349b-11ef-8a0d-d039eaa9edb6"
+          }
+        }
+      },
+      "index": 92,
+      "name": "PSU2 In Curr",
+      "type": "current",
+      "value": 2100,
+      "value_units": "mA",
+      "threshold_state": "normal",
+      "critical_low_threshold": 0,
+      "warning_high_threshold": 14100,
+      "critical_high_threshold": 15000,
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/800c0fcb-349b-11ef-8a0d-d039eaa9edb6/92"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "800c0fcb-349b-11ef-8a0d-d039eaa9edb6",
+        "name": "a1k-02",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/800c0fcb-349b-11ef-8a0d-d039eaa9edb6"
+          }
+        }
+      },
+      "index": 95,
+      "name": "PSU2 In Pwr",
+      "type": "unknown",
+      "value": 464,
+      "value_units": "W",
+      "threshold_state": "normal",
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/800c0fcb-349b-11ef-8a0d-d039eaa9edb6/95"
+        }
+      }
+    }
+  ]
+}

--- a/cmd/collectors/testdata/rest-sensors-a900.json
+++ b/cmd/collectors/testdata/rest-sensors-a900.json
@@ -1,0 +1,200 @@
+{
+  "records": [
+    {
+      "node": {
+        "uuid": "2a094823-3352-11ef-bdec-d039ea48b049",
+        "name": "a900-1-01",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/2a094823-3352-11ef-bdec-d039ea48b049"
+          }
+        }
+      },
+      "index": 73,
+      "name": "PSU2 AC In Volt",
+      "type": "voltage",
+      "value": 213000,
+      "value_units": "mV",
+      "threshold_state": "normal",
+      "critical_low_threshold": 88000,
+      "warning_low_threshold": 90000,
+      "critical_high_threshold": 255000,
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/2a094823-3352-11ef-bdec-d039ea48b049/73"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "2a094823-3352-11ef-bdec-d039ea48b049",
+        "name": "a900-1-01",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/2a094823-3352-11ef-bdec-d039ea48b049"
+          }
+        }
+      },
+      "index": 74,
+      "name": "PSU2 AC In Curr",
+      "type": "current",
+      "value": 2450,
+      "value_units": "mA",
+      "threshold_state": "normal",
+      "warning_high_threshold": 14000,
+      "critical_high_threshold": 14980,
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/2a094823-3352-11ef-bdec-d039ea48b049/74"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "2a094823-3352-11ef-bdec-d039ea48b049",
+        "name": "a900-1-01",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/2a094823-3352-11ef-bdec-d039ea48b049"
+          }
+        }
+      },
+      "index": 78,
+      "name": "PSU4 AC In Volt",
+      "type": "voltage",
+      "value": 213000,
+      "value_units": "mV",
+      "threshold_state": "normal",
+      "critical_low_threshold": 88000,
+      "warning_low_threshold": 90000,
+      "critical_high_threshold": 255000,
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/2a094823-3352-11ef-bdec-d039ea48b049/78"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "2a094823-3352-11ef-bdec-d039ea48b049",
+        "name": "a900-1-01",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/2a094823-3352-11ef-bdec-d039ea48b049"
+          }
+        }
+      },
+      "index": 79,
+      "name": "PSU4 AC In Curr",
+      "type": "current",
+      "value": 2240,
+      "value_units": "mA",
+      "threshold_state": "normal",
+      "warning_high_threshold": 14000,
+      "critical_high_threshold": 14980,
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/2a094823-3352-11ef-bdec-d039ea48b049/79"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "853459cb-3352-11ef-bd03-d039ea482ffa",
+        "name": "a900-1-02",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/853459cb-3352-11ef-bd03-d039ea482ffa"
+          }
+        }
+      },
+      "index": 73,
+      "name": "PSU1 AC In Volt",
+      "type": "voltage",
+      "value": 213000,
+      "value_units": "mV",
+      "threshold_state": "normal",
+      "critical_low_threshold": 88000,
+      "warning_low_threshold": 90000,
+      "critical_high_threshold": 255000,
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/853459cb-3352-11ef-bd03-d039ea482ffa/73"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "853459cb-3352-11ef-bd03-d039ea482ffa",
+        "name": "a900-1-02",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/853459cb-3352-11ef-bd03-d039ea482ffa"
+          }
+        }
+      },
+      "index": 74,
+      "name": "PSU1 AC In Curr",
+      "type": "current",
+      "value": 2450,
+      "value_units": "mA",
+      "threshold_state": "normal",
+      "warning_high_threshold": 14000,
+      "critical_high_threshold": 14980,
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/853459cb-3352-11ef-bd03-d039ea482ffa/74"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "853459cb-3352-11ef-bd03-d039ea482ffa",
+        "name": "a900-1-02",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/853459cb-3352-11ef-bd03-d039ea482ffa"
+          }
+        }
+      },
+      "index": 78,
+      "name": "PSU3 AC In Volt",
+      "type": "voltage",
+      "value": 213000,
+      "value_units": "mV",
+      "threshold_state": "normal",
+      "critical_low_threshold": 88000,
+      "warning_low_threshold": 90000,
+      "critical_high_threshold": 255000,
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/853459cb-3352-11ef-bd03-d039ea482ffa/78"
+        }
+      }
+    }
+    {
+      "node": {
+        "uuid": "853459cb-3352-11ef-bd03-d039ea482ffa",
+        "name": "a900-1-02",
+        "_links": {
+          "self": {
+            "href": "/api/cluster/nodes/853459cb-3352-11ef-bd03-d039ea482ffa"
+          }
+        }
+      },
+      "index": 79,
+      "name": "PSU3 AC In Curr",
+      "type": "current",
+      "value": 2240,
+      "value_units": "mA",
+      "threshold_state": "normal",
+      "warning_high_threshold": 14000,
+      "critical_high_threshold": 14980,
+      "_links": {
+        "self": {
+          "href": "/api/cluster/sensors/853459cb-3352-11ef-bd03-d039ea482ffa/79"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Those platforms have sensors with slightly different names that Harvest needs to accommodate.

Fixes: #3062