### PR TITLE
build: fix lint issues

### DIFF
--- a/cmd/poller/collector/asup.go
+++ b/cmd/poller/collector/asup.go
@@ -418,7 +418,7 @@ func getCPUInfo() (string, uint8) {
 		}
 	}
 
-	return arch, uint8(cpuCount)
+	return arch, uint8(cpuCount) // #nosec G115
 }
 
 func getOSName() string {

--- a/cmd/poller/plugin/labelagent/parse_rules.go
+++ b/cmd/poller/plugin/labelagent/parse_rules.go
@@ -531,7 +531,7 @@ func (a *LabelAgent) parseValueToNumRule(rule string) {
 				return
 			}
 			r.hasDefault = true
-			r.defaultValue = uint8(v)
+			r.defaultValue = uint8(v) // #nosec G115
 		}
 
 		a.valueToNumRules = append(a.valueToNumRules, r)
@@ -577,7 +577,7 @@ func (a *LabelAgent) parseValueToNumRegexRule(rule string) {
 				return
 			}
 			r.hasDefault = true
-			r.defaultValue = uint8(v)
+			r.defaultValue = uint8(v) // #nosec G115
 		}
 
 		a.valueToNumRegexRules = append(a.valueToNumRegexRules, r)


### PR DESCRIPTION
cmd/poller/plugin/labelagent/parse_rules.go:534:26: G115: integer overflow conversion uint64 -> uint8 (gosec)
                        r.defaultValue = uint8(v)
                                              ^
cmd/poller/plugin/labelagent/parse_rules.go:580:26: G115: integer overflow conversion uint64 -> uint8 (gosec)
                        r.defaultValue = uint8(v)
                                              ^
cmd/poller/collector/asup.go:421:20: G115: integer overflow conversion int -> uint8 (gosec)
        return arch, uint8(cpuCount)
