### PR TITLE
refactor: rename VolumeTopClients MaxVolumeCount to max_volumes

### DIFF
--- a/cmd/collectors/restperf/plugins/volumetopclients/volumetopclients.go
+++ b/cmd/collectors/restperf/plugins/volumetopclients/volumetopclients.go
@@ -114,7 +114,9 @@ func (t *TopClients) Init() error {
 		return err
 	}
 
-	if maxVol := t.Params.GetChildContentS("MaxVolumeCount"); maxVol != "" {
+	t.maxVolumeCount = defaultTopN
+
+	if maxVol := t.Params.GetChildContentS("max_volumes"); maxVol != "" {
 		if maxVolCount, err := strconv.Atoi(maxVol); err != nil {
 			t.maxVolumeCount = defaultTopN
 		} else {

--- a/conf/restperf/9.12.0/volume.yaml
+++ b/conf/restperf/9.12.0/volume.yaml
@@ -47,13 +47,15 @@ plugins:
       - node
   - Volume:
       include_constituents: false
+
 #  - VolumeTopClients:
 #      # The maximum number of volumes to consider for top client metrics.
 #      # The actual maximum value is capped at 50, even if a higher number is specified.
 #      # When enabled, this plugin will collect read/write operations and throughput metrics for the top clients of each volume.
 #      - schedule:
 #          - data: 1h  # This value should be a multiple of the poll duration. By default, Harvest will check once an hour to see how many volumes have activity_tracking.state set to on.
-#      - MaxVolumeCount: 5
+#      - max_volumes: 5
+
 #  - LabelAgent:
 #      # To prevent visibility of transient volumes, uncomment the following lines
 #      exclude_regex:


### PR DESCRIPTION
refactor: default max_volumes to 5
refactor: add whitespace to make plugin stand-out