### PR TITLE
fix: Remove '*' as 'All' option in workload dropdown on workload dashboard

### DIFF
--- a/grafana/dashboards/cmode/workload.json
+++ b/grafana/dashboards/cmode/workload.json
@@ -6204,7 +6204,7 @@
         "type": "custom"
       },
       {
-        "allValue": ".*",
+        "allValue": "",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values(qos_workload_labels{datacenter=~\"$Datacenter\",cluster=~\"$Cluster\", class=~\"$WorkloadClass\"}, workload)",


### PR DESCRIPTION
The `WorkloadClass` dropdown affects the data displayed in the `Workload` dropdown, so using "All" as the default option is not correct.