### PR TITLE
perf: reduce allocs when rendering metrics

### DIFF
--- a/pkg/matrix/metric.go
+++ b/pkg/matrix/metric.go
@@ -280,7 +280,14 @@ func (m *Metric) GetValueFloat64(i *Instance) (float64, bool) {
 
 func (m *Metric) GetValueString(i *Instance) (string, bool) {
 	v := m.values[i.index]
-	return strconv.FormatFloat(v, 'f', -1, 64), m.record[i.index]
+	isValid := m.record[i.index]
+	switch v {
+	case 0:
+		return "0", isValid
+	case 1:
+		return "1", isValid
+	}
+	return strconv.FormatFloat(v, 'f', -1, 64), isValid
 }
 
 func (m *Metric) GetValueBytes(i *Instance) ([]byte, bool) {


### PR DESCRIPTION
This PR reduces allocations by an order of magnitude through two optimizations:
1. Avoiding slice reallocations
2. Rendering metrics into a shared buffer

## Scenario

- Poll sar with single RestPerf volume collector
- Changed collector.go to export each matrix 240 times
- Take heap dump and report on `alloc_space` bytes for `Prometheus.render`

## Results

Before change:
1.41 GB is alloced from `render`

After change:
124.64 MB is alloced from `render`

Thanks to ChrisGautcher for reporting