### PR TITLE
ci: ignore volume_top_files_ counters

### DIFF
--- a/cmd/tools/generate/counter.go
+++ b/cmd/tools/generate/counter.go
@@ -464,10 +464,15 @@ func processCounters(counterContents []string, model *template2.Model, path, que
 	var (
 		staticCounterDef keyperf.ObjectCounters
 		err              error
+		defLocation      string
 	)
 	if api == keyPerfAPI {
 		logger := logging.Get()
-		staticCounterDef, err = keyperf.LoadStaticCounterDefinitions(model.Object, "conf/keyperf/static_counter_definitions.yaml", logger)
+		// CLI conf/keyperf/9.15.0/aggr.yaml
+		// CI  ../../conf/keyperf/9.15.0/volume.yaml
+		defLocation = filepath.Join(filepath.Dir(filepath.Dir(path)), "static_counter_definitions.yaml")
+
+		staticCounterDef, err = keyperf.LoadStaticCounterDefinitions(model.Object, defLocation, logger)
 		if err != nil {
 			fmt.Printf("Failed to load static counter definitions=%s\n", err)
 		}

--- a/integration/test/dashboard_json_test.go
+++ b/integration/test/dashboard_json_test.go
@@ -59,6 +59,7 @@ var restCounterMap = map[string]struct{}{
 // excludeCounters consists of counters which should be excluded from both Zapi/Rest in CI test
 var excludeCounters = []string{
 	"aggr_physical_",
+	"change_log",
 	"cifs_session",
 	"cluster_peer",
 	"efficiency_savings",
@@ -77,12 +78,16 @@ var excludeCounters = []string{
 	"logical_used",
 	"metadata_exporter_count",
 	"metadata_target_ping",
+	"metrocluster_check_",
+	"ndmp_session_",
+	"nfs_clients_",
 	"nfs_clients_idle_duration",
 	"nic_",
 	"node_cifs_",
 	"node_nfs",
 	"node_nvmf_ops",
 	"nvme_lif",
+	"ontaps3_svm_",
 	"path_",
 	"poller",
 	"qos_detail_resource_latency",
@@ -100,12 +105,8 @@ var excludeCounters = []string{
 	"svm_read_total",
 	"svm_vscan",
 	"svm_write_total",
-	"change_log",
-	"nfs_clients_",
-	"ndmp_session_",
-	"metrocluster_check_",
 	"volume_top_clients_",
-	"ontaps3_svm_",
+	"volume_top_files_",
 }
 
 var flakyCounters = []string{


### PR DESCRIPTION
ci: integration tests should read KeyPerf definitions from the correct directory