### PR TITLE
fix: panic if no volumes have analytics enabled

### DIFF
--- a/cmd/collectors/restperf/plugins/volumetopmetrics/volumetopmetrics.go
+++ b/cmd/collectors/restperf/plugins/volumetopmetrics/volumetopmetrics.go
@@ -186,19 +186,23 @@ func (t *TopMetrics) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, *
 
 	metricsData, err := t.processTopMetrics(data)
 	if err != nil {
-		return nil, nil, err
+		return nil, t.client.Metadata, err
+	}
+
+	if metricsData == nil {
+		return nil, t.client.Metadata, nil
 	}
 
 	if t.clientMetricsEnabled {
 		err = t.processTopClients(metricsData)
 		if err != nil {
-			return nil, nil, err
+			return nil, t.client.Metadata, err
 		}
 	}
 	if t.fileMetricsEnabled {
 		err = t.processTopFiles(metricsData)
 		if err != nil {
-			return nil, nil, err
+			return nil, t.client.Metadata, err
 		}
 	}
 


### PR DESCRIPTION
time=2024-11-25T16:21:54.877+05:30 level=ERROR source=collector.go:305 msg="Collector panicked" Poller=fsx collector=RestPerf:Volume err="runtime error: invalid memory address or nil pointer dereference\n" stack="goroutine 126 [running]:\nruntime/debug.Stack()\n\t/opt/homebrew/opt/go/libexec/src/runtime/debug/stack.go:26 +0x64\ngithub.com/netapp/harvest/v2/cmd/poller/collector.(*AbstractCollector).Start.func1()\n\t/Users//GolandProjects/harvest/cmd/poller/collector/collector.go:308 +0x108\npanic({0x1031b1500?, 0x10366af40?})\n\t/opt/homebrew/opt/go/libexec/src/runtime/panic.go:785 +0xf0\ngithub.com/netapp/harvest/v2/cmd/collectors/restperf/plugins/volumetopmetrics.(*TopMetrics).processTopClients(0x140001739a0, 0x0)\n\t/Users//GolandProjects/harvest/cmd/collectors/restperf/plugins/volumetopmetrics/volumetopmetrics.go:247 +0x2c\ngithub.com/netapp/harvest/v2/cmd/collectors/restperf/plugins/volumetopmetrics.(*TopMetrics).Run(0x140001739a0, 0x14002064690)\n\t/Users//GolandProjects/harvest/cmd/collectors/restperf/plugins/volumetopmetrics/volumetopmetrics.go:193 +0x2b8\ngithub.com/netapp/harvest/v2/cmd/poller/collector.(*AbstractCollector).Start(0x1400059e240, 0x140003fc5a0)\n\t/Users//GolandProjects/harvest/cmd/poller/collector/collector.go:472 +0x2b68\ncreated by main.(*Poller).Start in goroutine 1\n\t/Users//GolandProjects/harvest/cmd/poller/poller.go:516 +0x1cc\n"
