### PR TITLE
fix: handled duplicate key in SecurityAuditDestination

### DIFF
--- a/conf/rest/9.12.0/security_audit_dest.yaml
+++ b/conf/rest/9.12.0/security_audit_dest.yaml
@@ -4,6 +4,8 @@ query:            api/security/audit/destinations
 object:           security_audit_destination
 
 counters:
+  - ^^address     => address
+  - ^^port        => port
   - ^^protocol    => protocol
 
 


### PR DESCRIPTION
Tried with these records, 
```
{
    "records": [
        {
            "address": "x.x.x.x",
            "port": 6414,
            "ipspace": {
                "name": "Default",
                "uuid": "d192470e-0580-11e8-bd9d-00a098d39e12"
            },
            "protocol": "tcp_encrypted",
            "facility": "user",
            "verify_server": true,
            "message_format": "legacy_netapp",
            "timestamp_format_override": "no_override",
            "hostname_format_override": "no_override",
            "_links": {
                "self": {
                    "href": "/api/security/audit/destinations/x.x.x.x/6414"
                }
            }
        },
        {
            "address": "x.x.x.x",
            "port": 6514,
            "ipspace": {
                "name": "Default",
                "uuid": "d192470e-0580-11e8-bd9d-00a098d39e12"
            },
            "protocol": "tcp_encrypted",
            "facility": "user",
            "verify_server": true,
            "message_format": "legacy_netapp",
            "timestamp_format_override": "no_override",
            "hostname_format_override": "no_override",
            "_links": {
                "self": {
                    "href": "/api/security/audit/destinations/x.x.x.x/6514"
                }
            }
        }
    ],
    "num_records": 2,
    "_links": {
        "self": {
            "href": "/api/security/audit/destinations?fields=*"
        }
    }
}
```

<img width="1777" alt="image" src="https://github.com/user-attachments/assets/9a08857c-fffd-4a83-af61-4898cb5ed0f2">
