### PR TITLE
feat: adding Rwctx template for RestPerf in 9.16.0

### DIFF
--- a/conf/restperf/9.16.0/rwctx.yaml
+++ b/conf/restperf/9.16.0/rwctx.yaml
@@ -1,0 +1,17 @@
+
+name:                     Rwctx
+query:                    api/cluster/counter/tables/rewind_context
+object:                   rw_ctx
+
+counters:
+  - ^^id
+  - ^node.name           => node
+  - cifs_give_ups        => cifs_giveups
+  - cifs_rewinds         => cifs_rewinds
+  - nfs_give_ups         => nfs_giveups
+  - nfs_rewinds          => nfs_rewinds
+
+
+export_options:
+  instance_keys:
+    - node

--- a/conf/restperf/default.yaml
+++ b/conf/restperf/default.yaml
@@ -25,6 +25,7 @@ objects:
   NicCommon:         nic_common.yaml
   Path:              path.yaml
   Qtree:             qtree.yaml
+  Rwctx:             rwctx.yaml
   SystemNode:        system_node.yaml
 #  TokenManager:      token_manager.yaml
   VolumeNode:        volume_node.yaml


### PR DESCRIPTION
**Fixed in 9.16.0**
<img width="244" alt="image" src="https://github.com/user-attachments/assets/4e65e823-9bea-4fd0-a501-b4aa3f36ede0">

<img width="1021" alt="image" src="https://github.com/user-attachments/assets/9c0ae0a9-31a2-420b-9a86-af968cff640f">

<img width="1274" alt="image" src="https://github.com/user-attachments/assets/6324dfa9-cd4a-425f-8691-8a8ad99fb834">

-----------------
Cluster is 9.16.1 supporting both Zapi and Rest, Whereas vsim is 9.17.1 and only supporting Rest.
For RestPerf, Qos_xxx counters were not included.

<img width="1784" alt="image" src="https://github.com/user-attachments/assets/de17618b-0e6c-4f48-8239-aadb1bc66b93">


For ZapiPerf, 
<img width="1787" alt="image" src="https://github.com/user-attachments/assets/99419a8f-370c-4ada-a591-ace52f442d0b">

<img width="1783" alt="image" src="https://github.com/user-attachments/assets/bb7b45df-baff-4bb8-9c82-f178944153aa">

<img width="1777" alt="image" src="https://github.com/user-attachments/assets/3d54c8d4-2338-4587-821a-a2d1f3f85582">



