### PR TITLE
fix: cloud target template should not export access_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ In case you missed the previous `24.11.1` dot release, here are the features inc
 
 @Falcon667, @IvanZenger, @cheese1, @embusalacchi, @mamoep, @roybatty2019, @summertony15, AdiZ, Amir, MatthiasS, Yann, ttlexceeded
 
-:seedling: This release includes 18 features, 22 bug fixes, 8 documentation, 1 performance, 1 refactoring, 6 miscellaneous, and 12 ci pull requests.
+:seedling: This release includes 18 features, 23 bug fixes, 8 documentation, 1 performance, 1 refactoring, 6 miscellaneous, and 12 ci pull requests.
 
 ### :rocket: Features
 - Hide Transient Volumes ([#3337](https://github.com/NetApp/harvest/pull/3337))
@@ -114,6 +114,7 @@ In case you missed the previous `24.11.1` dot release, here are the features inc
 - Handle Only Labels In Zapi Snapshotpolicy ([#3444](https://github.com/NetApp/harvest/pull/3444))
 - "Top Ethernet Ports By Utilization %" Panel Legend Should Not In… ([#3451](https://github.com/NetApp/harvest/pull/3451))
 - Handle Cp Labels In Dashboard ([#3455](https://github.com/NetApp/harvest/pull/3455))
+- Cloud Target Template Should Not Export Access_Key ([#3468](https://github.com/NetApp/harvest/pull/3468))
 
 ### :closed_book: Documentation
 - Fix Release Announcements ([#3330](https://github.com/NetApp/harvest/pull/3330))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ In case you missed the previous `24.11.1` dot release, here are the features inc
 - Handle Only Labels In Zapi Snapshotpolicy ([#3444](https://github.com/NetApp/harvest/pull/3444))
 - "Top Ethernet Ports By Utilization %" Panel Legend Should Not In… ([#3451](https://github.com/NetApp/harvest/pull/3451))
 - Handle Cp Labels In Dashboard ([#3455](https://github.com/NetApp/harvest/pull/3455))
-- Cloud Target Template Should Not Export Access_Key ([#3468](https://github.com/NetApp/harvest/pull/3468))
+- Cloud Target Template Should Not Export Access_Key ([#3470](https://github.com/NetApp/harvest/pull/3470))
 
 ### :closed_book: Documentation
 - Fix Release Announcements ([#3330](https://github.com/NetApp/harvest/pull/3330))

--- a/autosupport/README.md
+++ b/autosupport/README.md
@@ -2221,7 +2221,6 @@ An example payload sent by Harvest looks like this. You can see exactly what Har
      "ipspace.name",
      "scope",
      "ssl_enabled",
-     "access_key",
      "port",
      "provider_type",
      "server",

--- a/conf/rest/9.11.0/cloud_target.yaml
+++ b/conf/rest/9.11.0/cloud_target.yaml
@@ -5,7 +5,6 @@ object:             cloud_target
   
 counters:
   - ^^uuid                          => uuid
-  - ^access_key                     => access_key
   - ^authentication_type            => authentication_type
   - ^certificate_validation_enabled => certificate_validation_enabled
   - ^container                      => container
@@ -24,7 +23,6 @@ export_options:
     - name
     - server
   instance_labels:
-    - access_key
     - authentication_type
     - certificate_validation_enabled
     - ipspace

--- a/conf/rest/9.12.0/cloud_target.yaml
+++ b/conf/rest/9.12.0/cloud_target.yaml
@@ -5,7 +5,6 @@ object:             cloud_target
   
 counters:
   - ^^uuid                          => uuid
-  - ^access_key                     => access_key
   - ^authentication_type            => authentication_type
   - ^certificate_validation_enabled => certificate_validation_enabled
   - ^container                      => container
@@ -25,7 +24,6 @@ export_options:
     - name
     - server
   instance_labels:
-    - access_key
     - authentication_type
     - certificate_validation_enabled
     - ipspace

--- a/conf/zapi/cdot/9.10.0/aggr_object_store_config.yaml
+++ b/conf/zapi/cdot/9.10.0/aggr_object_store_config.yaml
@@ -6,7 +6,6 @@ object:             cloud_target
 counters:
   aggr-object-store-config-info:
     - ^^object-store-uuid                => uuid
-    - ^access-key                        => access_key
     - ^auth-type                         => authentication_type
     - ^ipspace                           => ipspace
     - ^is-certificate-validation-enabled => certificate_validation_enabled
@@ -24,7 +23,6 @@ export_options:
     - name
     - server
   instance_labels:
-    - access_key
     - authentication_type
     - certificate_validation_enabled
     - ipspace


### PR DESCRIPTION
access_key is considered personally identifiable information

Thanks to Piyush Gaur for reporting.

Fixes: #3469
