### PR TITLE
feat: handled duplicate instance issue in clustersoftware plugin

### DIFF
--- a/cmd/collectors/rest/plugins/clustersoftware/clustersoftware.go
+++ b/cmd/collectors/rest/plugins/clustersoftware/clustersoftware.go
@@ -103,6 +103,7 @@ func (c *ClusterSoftware) createStatusMetrics() error {
 	instanceKeys.NewChildS("", "node")
 	instanceKeys.NewChildS("", "name")
 	instanceKeys.NewChildS("", "startTime")
+	instanceKeys.NewChildS("", "endTime")
 
 	mat.SetExportOptions(exportOptions)
 
@@ -196,11 +197,12 @@ func (c *ClusterSoftware) handleStatusDetails(statusDetailsJSON gjson.Result, gl
 	// Set all global labels
 	c.data[statusMatrix].SetGlobalLabels(globalLabels)
 
-	for _, updateDetail := range statusDetailsJSON.Array() {
-		name := updateDetail.Get("name").ClonedString()
-		state := updateDetail.Get("state").ClonedString()
-		nodeName := updateDetail.Get("node.name").ClonedString()
-		startTime := updateDetail.Get("start_time").ClonedString()
+	for _, statusDetail := range statusDetailsJSON.Array() {
+		name := statusDetail.Get("name").ClonedString()
+		state := statusDetail.Get("state").ClonedString()
+		nodeName := statusDetail.Get("node.name").ClonedString()
+		startTime := statusDetail.Get("start_time").ClonedString()
+		endTime := statusDetail.Get("end_time").ClonedString()
 		key = name + state + nodeName + startTime
 
 		if clusterStatusInstance, err = c.data[statusMatrix].NewInstance(key); err != nil {
@@ -211,6 +213,7 @@ func (c *ClusterSoftware) handleStatusDetails(statusDetailsJSON gjson.Result, gl
 		clusterStatusInstance.SetLabel("state", state)
 		clusterStatusInstance.SetLabel("name", name)
 		clusterStatusInstance.SetLabel("startTime", startTime)
+		clusterStatusInstance.SetLabel("endTime", endTime)
 
 		// populate numeric data
 		value := 0.0
@@ -240,9 +243,9 @@ func (c *ClusterSoftware) handleValidationDetails(validationDetailsJSON gjson.Re
 	// Set all global labels
 	c.data[validationMatrix].SetGlobalLabels(globalLabels)
 
-	for _, updateDetail := range validationDetailsJSON.Array() {
-		updateCheck := updateDetail.Get("update_check").ClonedString()
-		status := updateDetail.Get("status").ClonedString()
+	for _, validationDetail := range validationDetailsJSON.Array() {
+		updateCheck := validationDetail.Get("update_check").ClonedString()
+		status := validationDetail.Get("status").ClonedString()
 		key = updateCheck + status
 
 		if clusterValidationInstance, err = c.data[validationMatrix].NewInstance(key); err != nil {

--- a/cmd/collectors/rest/plugins/clustersoftware/clustersoftware.go
+++ b/cmd/collectors/rest/plugins/clustersoftware/clustersoftware.go
@@ -102,6 +102,7 @@ func (c *ClusterSoftware) createStatusMetrics() error {
 	instanceKeys.NewChildS("", "state")
 	instanceKeys.NewChildS("", "node")
 	instanceKeys.NewChildS("", "name")
+	instanceKeys.NewChildS("", "startTime")
 
 	mat.SetExportOptions(exportOptions)
 
@@ -199,7 +200,8 @@ func (c *ClusterSoftware) handleStatusDetails(statusDetailsJSON gjson.Result, gl
 		name := updateDetail.Get("name").ClonedString()
 		state := updateDetail.Get("state").ClonedString()
 		nodeName := updateDetail.Get("node.name").ClonedString()
-		key = name + state + nodeName
+		startTime := updateDetail.Get("start_time").ClonedString()
+		key = name + state + nodeName + startTime
 
 		if clusterStatusInstance, err = c.data[statusMatrix].NewInstance(key); err != nil {
 			c.SLogger.Error("Failed to create instance", slogx.Err(err), slog.String("key", key))
@@ -208,6 +210,7 @@ func (c *ClusterSoftware) handleStatusDetails(statusDetailsJSON gjson.Result, gl
 		clusterStatusInstance.SetLabel("node", nodeName)
 		clusterStatusInstance.SetLabel("state", state)
 		clusterStatusInstance.SetLabel("name", name)
+		clusterStatusInstance.SetLabel("startTime", startTime)
 
 		// populate numeric data
 		value := 0.0

--- a/grafana/dashboards/cmode/cluster.json
+++ b/grafana/dashboards/cmode/cluster.json
@@ -4819,6 +4819,30 @@
                     "value": "color-background"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Start Time"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "dateTimeAsIso"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "End Time"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "dateTimeAsIso"
+                  }
+                ]
               }
             ]
           },
@@ -4865,7 +4889,9 @@
                     "cluster",
                     "name",
                     "node",
-                    "datacenter"
+                    "datacenter",
+                    "startTime",
+                    "endTime"
                   ]
                 }
               }
@@ -4877,12 +4903,16 @@
                 "indexByName": {
                   "cluster": 1,
                   "datacenter": 0,
+                  "endtime": 6,
                   "name": 3,
                   "node": 2,
+                  "startTime": 5,
                   "state": 4
                 },
                 "renameByName": {
+                  "endTime": "End Time",
                   "name": "Job Name",
+                  "startTime": "Start Time",
                   "state": "Status"
                 }
               }


### PR DESCRIPTION
In case of this type of update_detail response, It's already discarding them with non-empty node name check at line 156.
```
"update_details": [
    {
      "phase": "ONTAP updates"
    },
    {
      "phase": "ONTAP updates"
    }
  ],
```

In case of this type of status_details, All the fields are same but start_time, so using it to differentiate them. 
```
{
      "node": {
        "name": "cl-01"
      },
      "name": "do-download-job",
      "state": "failed",
      "issue": {
        "message": "Image update failed to start. Reason: Software update/install already in progress",
        "code": 10551404
      },
      "action": {
        "message": "Use the \"cluster show\" command to verify that all nodes in the cluster are healthy. Use the \"cluster image package show-repository\" command to verify that the downloaded image has the correct version. If all nodes are healthy and the image has the correct version, wait a few minutes, and then use the \"cluster image resume-update\" command to resume the update",
        "code": 10551397
      },
      "start_time": "2024-06-18T15:29:13+02:00",
      "end_time": "2024-06-18T15:30:11+02:00"
    },
    {
      "node": {
        "name": "cl-01"
      },
      "name": "do-download-job",
      "state": "failed",
      "issue": {
        "message": "Image update failed to start. Reason: Software update/install already in progress",
        "code": 10551404
      },
      "action": {
        "message": "Use the \"cluster show\" command to verify that all nodes in the cluster are healthy. Use the \"cluster image package show-repository\" command to verify that the downloaded image has the correct version. If all nodes are healthy and the image has the correct version, wait a few minutes, and then use the \"cluster image resume-update\" command to resume the update",
        "code": 10551397
      },
      "start_time": "2024-06-18T15:29:16+02:00",
      "end_time": "2024-06-18T15:30:11+02:00"
    },
```

<img width="1769" alt="image" src="https://github.com/user-attachments/assets/b1021912-bf47-419a-8c34-87c5be38ae40" />
