### PR TITLE
fix: handled empty scanner and export false case for vscan

### DIFF
--- a/cmd/collectors/commonutils.go
+++ b/cmd/collectors/commonutils.go
@@ -346,11 +346,14 @@ func AggregatePerScanner(logger *slog.Logger, data *matrix.Matrix, latencyKey st
 			continue
 		}
 		scanner := i.GetLabel("scanner")
+		// scanner is key for cache matrix, skip when the scanner would be empty
+		if scanner == "" {
+			continue
+		}
 		if cache.GetInstance(scanner) == nil {
 			s, _ := cache.NewInstance(scanner)
 			s.SetLabel("scanner", scanner)
 		}
-		i.SetExportable(false)
 	}
 
 	// aggregate per scanner
@@ -360,7 +363,12 @@ func AggregatePerScanner(logger *slog.Logger, data *matrix.Matrix, latencyKey st
 		if !i.IsExportable() {
 			continue
 		}
+		i.SetExportable(false)
 		scanner := i.GetLabel("scanner")
+		// scanner is key for cache matrix, skip when the scanner would be empty
+		if scanner == "" {
+			continue
+		}
 		ps := cache.GetInstance(scanner)
 		if ps == nil {
 			logger.Error("Failed to find scanner instance in cache", slog.String("scanner", scanner))

--- a/cmd/collectors/restperf/plugins/vscan/test_nonvalid_vscan.json
+++ b/cmd/collectors/restperf/plugins/vscan/test_nonvalid_vscan.json
@@ -1,0 +1,104 @@
+{
+  "records": [
+    {
+      "counter_table": {
+        "name": "vscan"
+      },
+      "id": "dcfast11:tstsvm01",
+      "properties": [
+        {
+          "name": "node.name",
+          "value": "dcfast11"
+        },
+        {
+          "name": "server.id",
+          "value": "tstsvm01:10.10.33.118"
+        }
+      ],
+      "counters": [
+        {
+          "name": "scan.requests",
+          "value": 719
+        },
+        {
+          "name": "scan.latency",
+          "value": 15034279
+        },
+        {
+          "name": "scan.request_dispatched_rate",
+          "value": 719
+        },
+        {
+          "name": "scanner.stats_percent_cpu_used",
+          "value": 1
+        },
+        {
+          "name": "scanner.stats_percent_mem_used",
+          "value": 48
+        },
+        {
+          "name": "scanner.stats_percent_network_used",
+          "value": 0
+        }
+      ],
+      "_links": {
+        "self": {
+          "href": "/api/cluster/counter/tables/vscan/rows/dcfast11%3Atstsvm01%3A10.10.33.118"
+        }
+      }
+    },
+    {
+      "counter_table": {
+        "name": "vscan"
+      },
+      "id": "dcfast11",
+      "properties": [
+        {
+          "name": "node.name",
+          "value": "dcfast11"
+        },
+        {
+          "name": "server.id",
+          "value": "tstsvm01:10.10.33.128"
+        }
+      ],
+      "counters": [
+        {
+          "name": "scan.requests",
+          "value": 720
+        },
+        {
+          "name": "scan.latency",
+          "value": 15001939
+        },
+        {
+          "name": "scan.request_dispatched_rate",
+          "value": 720
+        },
+        {
+          "name": "scanner.stats_percent_cpu_used",
+          "value": 0
+        },
+        {
+          "name": "scanner.stats_percent_mem_used",
+          "value": 42
+        },
+        {
+          "name": "scanner.stats_percent_network_used",
+          "value": 1
+        }
+      ],
+      "_links": {
+        "self": {
+          "href": "/api/cluster/counter/tables/vscan/rows/dcfast11%3Atstsvm01%3A10.10.33.128"
+        }
+      }
+    }
+  ],
+  "num_records": 2,
+  "_links": {
+    "self": {
+      "href": "/api/cluster/counter/tables/vscan/rows?return_records=true&fields=*"
+    }
+  }
+}

--- a/cmd/collectors/restperf/plugins/vscan/test_valid_vscan.json
+++ b/cmd/collectors/restperf/plugins/vscan/test_valid_vscan.json
@@ -1,0 +1,198 @@
+{
+  "records": [
+    {
+      "counter_table": {
+        "name": "vscan"
+      },
+      "id": "dcfast11:tstsvm01:10.10.33.118",
+      "properties": [
+        {
+          "name": "node.name",
+          "value": "dcfast11"
+        },
+        {
+          "name": "server.id",
+          "value": "tstsvm01:10.10.33.118"
+        }
+      ],
+      "counters": [
+        {
+          "name": "scan.requests",
+          "value": 719
+        },
+        {
+          "name": "scan.latency",
+          "value": 15034279
+        },
+        {
+          "name": "scan.request_dispatched_rate",
+          "value": 719
+        },
+        {
+          "name": "scanner.stats_percent_cpu_used",
+          "value": 1
+        },
+        {
+          "name": "scanner.stats_percent_mem_used",
+          "value": 48
+        },
+        {
+          "name": "scanner.stats_percent_network_used",
+          "value": 0
+        }
+      ],
+      "_links": {
+        "self": {
+          "href": "/api/cluster/counter/tables/vscan/rows/dcfast11%3Atstsvm01%3A10.10.33.118"
+        }
+      }
+    },
+    {
+      "counter_table": {
+        "name": "vscan"
+      },
+      "id": "dcfast11:tstsvm01:10.10.33.128",
+      "properties": [
+        {
+          "name": "node.name",
+          "value": "dcfast11"
+        },
+        {
+          "name": "server.id",
+          "value": "tstsvm01:10.10.33.128"
+        }
+      ],
+      "counters": [
+        {
+          "name": "scan.requests",
+          "value": 720
+        },
+        {
+          "name": "scan.latency",
+          "value": 15001939
+        },
+        {
+          "name": "scan.request_dispatched_rate",
+          "value": 720
+        },
+        {
+          "name": "scanner.stats_percent_cpu_used",
+          "value": 0
+        },
+        {
+          "name": "scanner.stats_percent_mem_used",
+          "value": 42
+        },
+        {
+          "name": "scanner.stats_percent_network_used",
+          "value": 1
+        }
+      ],
+      "_links": {
+        "self": {
+          "href": "/api/cluster/counter/tables/vscan/rows/dcfast11%3Atstsvm01%3A10.10.33.128"
+        }
+      }
+    },
+    {
+      "counter_table": {
+        "name": "vscan"
+      },
+      "id": "dcfast11:tstsvm02:10.10.33.118",
+      "properties": [
+        {
+          "name": "node.name",
+          "value": "dcfast11"
+        },
+        {
+          "name": "server.id",
+          "value": "tstsvm02:10.10.33.118"
+        }
+      ],
+      "counters": [
+        {
+          "name": "scan.requests",
+          "value": 0
+        },
+        {
+          "name": "scan.latency",
+          "value": 0
+        },
+        {
+          "name": "scan.request_dispatched_rate",
+          "value": 0
+        },
+        {
+          "name": "scanner.stats_percent_cpu_used",
+          "value": 0
+        },
+        {
+          "name": "scanner.stats_percent_mem_used",
+          "value": 0
+        },
+        {
+          "name": "scanner.stats_percent_network_used",
+          "value": 0
+        }
+      ],
+      "_links": {
+        "self": {
+          "href": "/api/cluster/counter/tables/vscan/rows/dcfast11%3Atstsvm02%3A10.10.33.118"
+        }
+      }
+    },
+    {
+      "counter_table": {
+        "name": "vscan"
+      },
+      "id": "dcfast11:tstsvm02:10.10.33.128",
+      "properties": [
+        {
+          "name": "node.name",
+          "value": "dcfast11"
+        },
+        {
+          "name": "server.id",
+          "value": "tstsvm02:10.10.33.128"
+        }
+      ],
+      "counters": [
+        {
+          "name": "scan.requests",
+          "value": 0
+        },
+        {
+          "name": "scan.latency",
+          "value": 0
+        },
+        {
+          "name": "scan.request_dispatched_rate",
+          "value": 0
+        },
+        {
+          "name": "scanner.stats_percent_cpu_used",
+          "value": 0
+        },
+        {
+          "name": "scanner.stats_percent_mem_used",
+          "value": 0
+        },
+        {
+          "name": "scanner.stats_percent_network_used",
+          "value": 0
+        }
+      ],
+      "_links": {
+        "self": {
+          "href": "/api/cluster/counter/tables/vscan/rows/dcfast11%3Atstsvm02%3A10.10.33.128"
+        }
+      }
+    }
+  ],
+  "num_records": 4,
+  "_links": {
+    "self": {
+      "href": "/api/cluster/counter/tables/vscan/rows?return_records=true&fields=*"
+    }
+  }
+}

--- a/cmd/collectors/restperf/plugins/vscan/vscan_test.go
+++ b/cmd/collectors/restperf/plugins/vscan/vscan_test.go
@@ -1,0 +1,109 @@
+package vscan
+
+import (
+	"encoding/json"
+	"github.com/netapp/harvest/v2/cmd/poller/options"
+	"github.com/netapp/harvest/v2/cmd/poller/plugin"
+	"github.com/netapp/harvest/v2/pkg/matrix"
+	"github.com/netapp/harvest/v2/pkg/tree/node"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+type VscanRecords struct {
+	VscanRecords []VscanRecord `json:"records"`
+}
+
+type VscanRecord struct {
+	ID string `json:"id"`
+}
+
+func runTest(t *testing.T, createRestVscan func(params *node.Node) plugin.Plugin, testFile string, metricsPerScanner string, cacheExportedInstanceCount int, dataExportedInstanceCount int) {
+	params := node.NewS("Vscan")
+	params.NewChildS("metricsPerScanner", metricsPerScanner)
+	v := createRestVscan(params)
+	data := readTestFile(testFile)
+
+	dataMap := map[string]*matrix.Matrix{
+		data.Object: data,
+	}
+	// run the plugin
+	results, _, err := v.Run(dataMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if metricsPerScanner == "false" {
+		if results != nil {
+			t.Fatalf("result should be nil")
+		} else {
+			return
+		}
+	}
+
+	// Verify the cacheData
+	cacheData := results[0]
+	if len(cacheData.GetInstances()) != cacheExportedInstanceCount {
+		t.Fatalf("expected %d cacheExportedInstance count, got %d", cacheExportedInstanceCount, len(cacheData.GetInstances()))
+	}
+
+	exportedInstance := 0
+	for _, instance := range data.GetInstances() {
+		if instance.IsExportable() {
+			exportedInstance++
+		}
+	}
+	if exportedInstance != dataExportedInstanceCount {
+		t.Fatalf("expected %d dataExportedInstance count, got %d", dataExportedInstanceCount, len(data.GetInstances()))
+	}
+}
+
+func TestRunForAllImplementations(t *testing.T) {
+	type test struct {
+		name                       string
+		testFilePath               string
+		metricsPerScanner          string
+		cacheExportedInstanceCount int
+		dataExportedInstanceCount  int
+	}
+
+	tests := []test{
+		{name: "TestMetricScannerTrueValidData", metricsPerScanner: "true", testFilePath: "test_valid_vscan.json", cacheExportedInstanceCount: 2, dataExportedInstanceCount: 0},
+		{name: "TestMetricScannerTrueNonValidData", metricsPerScanner: "true", testFilePath: "test_nonvalid_vscan.json", cacheExportedInstanceCount: 0, dataExportedInstanceCount: 0},
+		{name: "TestMetricScannerFalseValidData", metricsPerScanner: "false", testFilePath: "test_valid_vscan.json", cacheExportedInstanceCount: 0, dataExportedInstanceCount: 4},
+		{name: "TestMetricScannerFalseNonValidData", metricsPerScanner: "false", testFilePath: "test_nonvalid_vscan.json", cacheExportedInstanceCount: 0, dataExportedInstanceCount: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runTest(t, createRestVscan, tt.testFilePath, tt.metricsPerScanner, tt.cacheExportedInstanceCount, tt.dataExportedInstanceCount)
+		})
+	}
+}
+
+func createRestVscan(params *node.Node) plugin.Plugin {
+	o := options.Options{IsTest: true}
+	v := &Vscan{AbstractPlugin: plugin.New("vscan", &o, params, nil, "vscan", nil)}
+	v.SLogger = slog.Default()
+	return v
+}
+
+func readTestFile(testFilePath string) *matrix.Matrix {
+	data := matrix.New("vscan", "vscan", "vscan")
+	var vscanRecords VscanRecords
+
+	file, _ := os.Open(testFilePath)
+	err := json.NewDecoder(file).Decode(&vscanRecords)
+	if err != nil {
+		return nil
+	}
+
+	for i := range len(vscanRecords.VscanRecords) {
+		id := vscanRecords.VscanRecords[i].ID
+		instance, _ := data.NewInstance(id)
+		instance.SetLabel("id", id)
+	}
+
+	return data
+}


### PR DESCRIPTION
This change would be handling 2 cases,
1. When aggregation is enabled(which is default), Making each instance to false in 2nd loop instead of 1st loop.
2. When scanner value is empty, don't proceed and jump to next iteration for both the loops. -> Earlier no instances were created for this kind of bad data in 1st loop and 2nd loop would fail when no instance has been found.