### PR TITLE
feat: adding uptime in lif perf templates

### DIFF
--- a/conf/restperf/9.12.0/lif.yaml
+++ b/conf/restperf/9.12.0/lif.yaml
@@ -14,6 +14,7 @@ counters:
   - sent_data
   - sent_errors
   - sent_packets             => sent_packet
+  - up_time                  => uptime
 
 export_options:
   instance_keys:
@@ -21,3 +22,6 @@ export_options:
     - node
     - port
     - svm
+
+override:
+  up_time: raw

--- a/conf/zapiperf/cdot/9.8.0/lif.yaml
+++ b/conf/zapiperf/cdot/9.8.0/lif.yaml
@@ -14,7 +14,9 @@ counters:
   - sent_data
   - sent_errors
   - sent_packet
+  - up_time                  => uptime
   - vserver_name             => svm
+
 
 export_options:
   instance_keys:
@@ -22,3 +24,6 @@ export_options:
     - node
     - port
     - svm
+
+override:
+  up_time: raw


### PR DESCRIPTION
Dashboard changes are in-progress as there are many lif_labels which have svm empty and joining them with lif_uptime may cause issue in table.