### PR TITLE
fix: filter label for ems destination is missing

### DIFF
--- a/conf/rest/9.12.0/ems_destination.yaml
+++ b/conf/rest/9.12.0/ems_destination.yaml
@@ -8,7 +8,7 @@ counters:
   - ^^name             => name
   - ^^type             => type
   - ^certificate.ca    => certificate
-  - ^filter            => filter
+  - ^filters.#.name    => filter
   - ^syslog            => syslog
   - ^system_defined    => system_defined
   - filter:


### PR DESCRIPTION
time=2025-05-05T13:03:49.844+05:30 level=ERROR source=collector.go:436 msg="" Poller=vsim collector=Rest:EmsDestination error="failed to fetch data: error making request StatusCode: 400, Message: The value \"filter\" is invalid for field \"fields\" (<field,...>), Code: 262197, Target: fields, API: /api/support/ems/destinations?fields=certificate.ca%2Cdestination%2Cfilter%2Cname%2Csyslog%2Csystem_defined%2Ctype&max_records=500&return_records=true&system_defined=false" task=data
