### PR TITLE
ci: Handle ems_events error for ZAPI datacenter

### DIFF
--- a/cmd/tools/generate/counter.go
+++ b/cmd/tools/generate/counter.go
@@ -174,6 +174,7 @@ var (
 		"netstat_",
 		"flexcache_",
 		"quota_disk_used_pct_threshold",
+		"ems_events",
 	}
 
 	// Exclude extra metrics for REST


### PR DESCRIPTION
Extra Zapi metrics in Prometheus but not documented: [ems_events]
