### PR TITLE
feat: update units and comment

### DIFF
--- a/conf/keyperf/9.15.0/ethernet_switch_port.yaml
+++ b/conf/keyperf/9.15.0/ethernet_switch_port.yaml
@@ -1,4 +1,4 @@
-
+# This template is in beta, It would be updated later.
 name:               EthernetSwitchPort
 query:              api/network/ethernet/switch/ports
 object:             ethernet_switch_port

--- a/conf/rest/9.8.0/ethernet_switch_port.yaml
+++ b/conf/rest/9.8.0/ethernet_switch_port.yaml
@@ -1,4 +1,4 @@
-
+# This template is in beta, It would be updated later.
 name:               EthernetSwitchPort
 query:              api/network/ethernet/switch/ports
 object:             ethernet_switch_port

--- a/grafana/dashboards/cisco/cisco.json
+++ b/grafana/dashboards/cisco/cisco.json
@@ -1276,7 +1276,7 @@
       "panels": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "Displays total transmit traffic per interface.",
+          "description": "Displays total transmit traffic per interface per second.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1325,7 +1325,7 @@
                   }
                 ]
               },
-              "unit": "bytes"
+              "unit": "Bps"
             },
             "overrides": []
           },
@@ -1368,7 +1368,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "Displays total receive traffic per interface.",
+          "description": "Displays total receive traffic per interface per second.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1417,7 +1417,7 @@
                   }
                 ]
               },
-              "unit": "bytes"
+              "unit": "Bps"
             },
             "overrides": []
           },
@@ -1460,7 +1460,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "Displays drop traffic per interface.",
+          "description": "Displays drop packets per interface per second.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1509,7 +1509,7 @@
                   }
                 ]
               },
-              "unit": "bytes"
+              "unit": "pps"
             },
             "overrides": []
           },
@@ -1559,7 +1559,7 @@
         },
         {
           "datasource": "${DS_PROMETHEUS}",
-          "description": "Displays traffic data per interface.",
+          "description": "Displays errors per interface per second.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1593,7 +1593,7 @@
                   "mode": "off"
                 }
               },
-              "decimals": 2,
+              "decimals": 0,
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
@@ -1608,7 +1608,7 @@
                   }
                 ]
               },
-              "unit": "bytes"
+              "unit": "errors/s"
             },
             "overrides": []
           },
@@ -1653,7 +1653,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Top $TopResources Interface Transmit Errors",
+          "title": "Top $TopResources Interface Errors",
           "type": "timeseries"
         },
         {
@@ -1692,7 +1692,7 @@
                   "mode": "off"
                 }
               },
-              "decimals": 2,
+              "decimals": 0,
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
@@ -1707,7 +1707,7 @@
                   }
                 ]
               },
-              "unit": "bytes"
+              "unit": "errors/s"
             },
             "overrides": []
           },
@@ -1745,7 +1745,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Top $TopResources CRC error per Interface",
+          "title": "Top $TopResources Interface CRC error",
           "type": "timeseries"
         }
       ],


### PR DESCRIPTION
Units were update this way,

Top $TopResources Interface Transmit Traffic -> bytes/sec
Top $TopResources Interface Receive Traffic -> bytes/sec
Top $TopResources Interface Receive Drops -> packets/sec
Top $TopResources Interface Errors -> errors/s
Top $TopResources Interface CRC error -> errors/s

For, switch name and hostname same issue, 
we fetched hostname and saved in `remote.name`, https://github.com/NetApp/harvest/blob/main/cmd/collectors/cisco/rest/client.go#L191
And then assign the value to global var `Switch` here, https://github.com/NetApp/harvest/blob/main/cmd/collectors/cisco/cisco.go#L105
That's why it's always be same.
