### PR TITLE
fix: Vscanpool plugin should only ask for fields it uses

### DIFF
--- a/cmd/collectors/rest/plugins/vscanpool/vscanpool.go
+++ b/cmd/collectors/rest/plugins/vscanpool/vscanpool.go
@@ -131,7 +131,7 @@ func (v *VscanPool) getVScanServerInfo() (map[string]map[string]string, error) {
 
 	serverMap := make(map[string][]ServerData)
 	vserverServerStateMap := make(map[string]map[string]string)
-	fields := []string{"node.name", "svm.name", "ip", "update_time", "state", "interface.name"}
+	fields := []string{"svm.name", "ip", "update_time", "state"}
 	query := "api/protocols/vscan/server-status"
 	href := rest.NewHrefBuilder().
 		APIPath(query).
@@ -145,7 +145,11 @@ func (v *VscanPool) getVScanServerInfo() (map[string]map[string]string, error) {
 
 	for _, vscanServer := range result {
 		svmName := vscanServer.Get("svm.name").ClonedString()
-		serverMap[svmName] = append(serverMap[svmName], ServerData{ip: vscanServer.Get("ip").ClonedString(), state: vscanServer.Get("state").ClonedString(), updateTime: collectors.HandleTimestamp(vscanServer.Get("update_time").ClonedString())})
+		serverMap[svmName] = append(serverMap[svmName], ServerData{
+			ip:         vscanServer.Get("ip").ClonedString(),
+			state:      vscanServer.Get("state").ClonedString(),
+			updateTime: collectors.HandleTimestamp(vscanServer.Get("update_time").ClonedString()),
+		})
 	}
 
 	for svm, serverData := range serverMap {


### PR DESCRIPTION
Noticed on `.74`

This is happening because the plugin is asking for a field that does not exist on ONTAP version 9.9.1.

time=2025-05-16T11:34:13.431-04:00 level=ERROR source=vscanpool.go:91 msg="Failed to collect vscan server info data" Poller=umeng_aff300 plugin=Rest:VscanPool object=Vscan error="failed to fetchAll href=api/protocols/vscan/server-status..., hrefLength=131 err=error making request StatusCode: 400, Message: The value \"interface.name\" is invalid for field \"fields\" (<field,...>), Code: 262197, Target: fields, API: /api/protocols/vscan/server-status?fields=interface.name%2Cip%2Cnode.name%2Cstate%2Csvm.name%2Cupdate_time&max_records=500&return_records=true"