### PR TITLE
ci: remove container files post build

### DIFF
--- a/jenkins/artifacts/jenkinsfile
+++ b/jenkins/artifacts/jenkinsfile
@@ -397,10 +397,16 @@ def void stopAndRemoveDockers() {
         mkdir -p /opt/home/nightly/
 
         # Stop and remove all containers
-        docker ps -aq | xargs docker rm -f
+        containers=$(docker ps -aq)
+        if [ -n "$containers" ]; then
+            echo "$containers" | xargs docker rm -f
+        fi
 
         # Remove all images
-        docker images -q | xargs docker rmi -f
+        images=$(docker images -q)
+        if [ -n "$images" ]; then
+            echo "$images" | xargs docker rmi -f
+        fi
 
         # Prune all unused volumes
         docker volume prune --force


### PR DESCRIPTION
```
#11 40.87 github.com/netapp/harvest/v2/cmd/exporters/influxdb: mkdir /tmp/go-build356246316/b361/: no space left on device
#11 40.89 go: failed to trim cache: write /root/.cache/go-build/trim.txt: no space left on device
#11 40.94 make: *** [Makefile:104: harvest] Error 1
#11 ERROR: process "/bin/bash -c if [[ -n \"$ASUP_MAKE_TARGET\" && -f \"/run/secrets/git_token\" ]]; then     make build asup VERSION=$VERSION RELEASE=$RELEASE ASUP_MAKE_TARGET=$ASUP_MAKE_TARGET GIT_TOKEN=$(cat /run/secrets/git_token);     else     make build VERSION=$VERSION RELEASE=$RELEASE BIN_PLATFORM=linux;     fi" did not complete successfully: exit code: 2
------
 > [builder 5/6] RUN --mount=type=secret,id=git_token     if [[ -n "production" && -f "/run/secrets/git_token" ]]; then     make build asup VERSION=25.06.09 RELEASE=nightly ASUP_MAKE_TARGET=production GIT_TOKEN=$(cat /run/secrets/git_token);     else     make build VERSION=25.06.09 RELEASE=nightly BIN_PLATFORM=linux;     fi:
40.86 github.com/netapp/harvest/v2/pkg/slice: mkdir /tmp/go-build356246316/b318/: no space left on device
40.87 github.com/netapp/harvest/v2/cmd/collectors/restperf/plugins/fcp: mkdir /tmp/go-build356246316/b322/: no space left on device
40.87 github.com/netapp/harvest/v2/cmd/collectors/restperf/plugins/headroom: mkdir /tmp/go-build356246316/b324/: no space left on device
40.87 github.com/netapp/harvest/v2/cmd/collectors/zapi/plugins/snapshotpolicy: mkdir /tmp/go-build356246316/b344/: no space left on device
40.87 github.com/netapp/harvest/v2/cmd/collectors/zapiperf/plugins/externalserviceoperation: mkdir /tmp/go-build356246316/b351/: no space left on device
40.87 github.com/netapp/harvest/v2/cmd/collectors/zapiperf/plugins/fcp: mkdir /tmp/go-build356246316/b353/: no space left on device
40.87 github.com/netapp/harvest/v2/cmd/collectors/zapiperf/plugins/headroom: mkdir /tmp/go-build356246316/b356/: no space left on device
40.87 github.com/netapp/harvest/v2/cmd/exporters/influxdb: mkdir /tmp/go-build356246316/b361/: no space left on device
40.89 go: failed to trim cache: write /root/.cache/go-build/trim.txt: no space left on device
40.94 make: *** [Makefile:104: harvest] Error 1
```