### PR TITLE
fix: fix query indent

### DIFF
--- a/grafana/dashboards/cmode/switch.json
+++ b/grafana/dashboards/cmode/switch.json
@@ -1062,7 +1062,7 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "min_over_time(\nethernet_switch_port_new_status{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",speed!=\"auto-speed\",switch=~\"$Switch\"}[1d]\n  )\n==\n  0",
+              "expr": "min_over_time(\n    ethernet_switch_port_new_status{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",speed!=\"auto-speed\",switch=~\"$Switch\"}[1d]\n  )\n==\n  0",
               "format": "time_series",
               "instant": false,
               "interval": "",


### PR DESCRIPTION
--- FAIL: TestFormatQueries (58.73s)
    promtool_metrics_test.go:140: [query not formatted in dashboard cmode/switch.json panel `Down (Last 24h)`, it should be 
         min_over_time(
            ethernet_switch_port_new_status{cluster=~"$Cluster",datacenter=~"$Datacenter",interface=~"$Interface",speed!="auto-speed",switch=~"$Switch"}[1d]
          )
        ==
          0
        ] 
        Formatted version created at path=/tmp/cmode/switch.json.
        cp /tmp/cmode/switch.json grafana/dashboards/cmode/switch.json