### PR TITLE
fix: update instance key in snapshot policy

### DIFF
--- a/conf/rest/9.12.0/snapshotpolicy.yaml
+++ b/conf/rest/9.12.0/snapshotpolicy.yaml
@@ -3,13 +3,14 @@ query:                    api/storage/snapshot-policies
 object:                   snapshot_policy
 
 counters:
+  - ^^svm.name        => svm
   - ^^uuid            => uuid
   - ^comment          => comment
   - ^copies           => copies
   - ^enabled          => enabled
   - ^name             => snapshot_policy
   - ^scope            => scope
-  - ^svm.name         => svm
+
 
 plugins:
   - SnapshotPolicy
@@ -17,11 +18,11 @@ plugins:
 export_options:
   instance_keys:
     - snapshot_policy
+    - svm
   instance_labels:
     - comment
     - copies
     - enabled
     - schedules
     - scope
-    - svm
 

--- a/conf/zapi/cdot/9.8.0/snapshotpolicy.yaml
+++ b/conf/zapi/cdot/9.8.0/snapshotpolicy.yaml
@@ -25,12 +25,12 @@ plugins:
 export_options:
   instance_keys:
     - snapshot_policy
+    - svm
   instance_labels:
     - comment
     - copies
     - enabled
     - schedules
     - scope
-    - svm
 
 


### PR DESCRIPTION
Cluster has total 16 snapshot policies.

Before this PR  changes, due to duplication warning, 3 instances were not exported.
```
harvest % ./bin/poller -p CG1 -c Rest -o SnapshotPolicy  
time=2025-06-11T19:24:10.917+05:30 level=INFO source=poller.go:235 msg=Init Poller=CG1 logLevel=INFO configPath=harvest.yml cwd=/Users/hardikl/Documents/Harvest/harvest version="harvest version 25.06.11-1 (commit 5f853401) (build date 2025-06-11T14:41:44+0530) darwin/amd64" fips=false options="&{Poller:CG1 Daemon:false Debug:false PromPort:0 Config:harvest.yml HomePath: LogPath:/var/log/harvest/ LogFormat:plain LogLevel:2 LogToFile:false Version:25.06.11 Hostname:hardikl-mac-1 Collectors:[Rest] Objects:[SnapshotPolicy] Profiling:0 Asup:false IsTest:false ConfPath:conf ConfPaths:[conf]}"
time=2025-06-11T19:24:10.918+05:30 level=INFO source=poller.go:274 msg="started in foreground" Poller=CG1 pid=95248
time=2025-06-11T19:24:12.638+05:30 level=INFO source=poller.go:1533 msg="Cluster info" Poller=CG1 remote="{Name:Cluster1 Model:cdot UUID:5b22a81c-bf7a-11ed-82e7-00a098f7d731 Version:9.15.1 Release:NetApp Release 9.15.1P1: Tue Jul 30 05:15:49 UTC 2024 Serial: IsSanOptimized:false IsDisaggregated:false ZAPIsExist:true HasREST:true IsClustered:true}"
time=2025-06-11T19:24:12.645+05:30 level=INFO source=helpers.go:109 msg="best-fit template" Poller=CG1 collector=Rest:SnapshotPolicy path=conf/rest/9.12.0/snapshotpolicy.yaml v=9.15.1 jitter=none
time=2025-06-11T19:24:12.646+05:30 level=ERROR source=prometheus.go:161 msg="missing Prometheus port" Poller=CG1 exporter=prometheus1
time=2025-06-11T19:24:12.646+05:30 level=ERROR source=poller.go:1063 msg="Unable to init exporter" Poller=CG1 error="missing parameter => port" name=prometheus1
time=2025-06-11T19:24:12.646+05:30 level=WARN source=poller.go:871 msg="exporter requested not available" Poller=CG1 exporterName=prometheus1 name=Rest object=SnapshotPolicy
time=2025-06-11T19:24:12.646+05:30 level=WARN source=poller.go:355 msg="no exporters initialized, continuing without exporters" Poller=CG1
time=2025-06-11T19:24:12.647+05:30 level=INFO source=poller.go:410 msg="Autosupport scheduled" Poller=CG1 asupSchedule=24h
time=2025-06-11T19:24:12.647+05:30 level=INFO source=poller.go:420 msg="poller start-up complete" Poller=CG1
time=2025-06-11T19:24:13.171+05:30 level=INFO source=poller.go:642 msg="updated status" Poller=CG1 collectors.up=1 collectors.total=1 exporters.up=0 exporters.total=0
time=2025-06-11T19:24:13.385+05:30 level=INFO source=collector.go:633 msg=Collected Poller=CG1 collector=Rest:SnapshotPolicy task=counter apiMs=733 bytesRx=0 metrics=0 numCalls=0 pollMs=738 zBegin=1749650052647
time=2025-06-11T19:24:13.633+05:30 level=WARN source=rest.go:597 msg="This instance is already processed. instKey is not unique" Poller=CG1 collector=Rest:SnapshotPolicy instKey=68c9ace3-c351-11ed-ba28-00a098af9054
time=2025-06-11T19:24:13.633+05:30 level=WARN source=rest.go:597 msg="This instance is already processed. instKey is not unique" Poller=CG1 collector=Rest:SnapshotPolicy instKey=68ca04b3-c351-11ed-ba28-00a098af9054
time=2025-06-11T19:24:13.633+05:30 level=WARN source=rest.go:597 msg="This instance is already processed. instKey is not unique" Poller=CG1 collector=Rest:SnapshotPolicy instKey=68ca4a42-c351-11ed-ba28-00a098af9054
time=2025-06-11T19:24:13.635+05:30 level=INFO source=collector.go:601 msg=Collected Poller=CG1 collector=Rest:SnapshotPolicy apiMs=248 bytesRx=11298 calcMs=0 exportMs=0 instances=13 instancesExported=0 metrics=97 metricsExported=0 numCalls=1 parseMs=1 pluginInstances=0 pluginMs=1 pollMs=250 renderedBytes=0 zBegin=1749650053385
time=2025-06-11T19:24:13.923+05:30 level=INFO source=poller.go:1448 msg=Metadata Poller=CG1 remote.name=Cluster1 remote.version=9.15.1 version="harvest version 25.06.11-1 (commit 5f853401) (build date 2025-06-11T14:41:44+0530) darwin/amd64" mem.liveHeapMB=0 mem.heapMB=0 mem.heapGoalMB=4 mem.rssMB=17 mem.maxRssMB=17 uptimeSeconds=3
time=2025-06-11T19:27:14.144+05:30 level=WARN source=rest.go:597 msg="This instance is already processed. instKey is not unique" Poller=CG1 collector=Rest:SnapshotPolicy instKey=68c9ace3-c351-11ed-ba28-00a098af9054
time=2025-06-11T19:27:14.144+05:30 level=WARN source=rest.go:597 msg="This instance is already processed. instKey is not unique" Poller=CG1 collector=Rest:SnapshotPolicy instKey=68ca04b3-c351-11ed-ba28-00a098af9054
time=2025-06-11T19:27:14.144+05:30 level=WARN source=rest.go:597 msg="This instance is already processed. instKey is not unique" Poller=CG1 collector=Rest:SnapshotPolicy instKey=68ca4a42-c351-11ed-ba28-00a098af9054
time=2025-06-11T19:27:14.144+05:30 level=INFO source=collector.go:601 msg=Collected Poller=CG1 collector=Rest:SnapshotPolicy apiMs=716 bytesRx=11298 calcMs=0 exportMs=0 instances=13 instancesExported=0 metrics=97 metricsExported=0 numCalls=1 parseMs=1 pluginInstances=0 pluginMs=0 pollMs=717 renderedBytes=0 zBegin=1749650233427
time=2025-06-11T19:30:14.261+05:30 level=WARN source=rest.go:597 msg="This instance is already processed. instKey is not unique" Poller=CG1 collector=Rest:SnapshotPolicy instKey=68c9ace3-c351-11ed-ba28-00a098af9054
time=2025-06-11T19:30:14.261+05:30 level=WARN source=rest.go:597 msg="This instance is already processed. instKey is not unique" Poller=CG1 collector=Rest:SnapshotPolicy instKey=68ca04b3-c351-11ed-ba28-00a098af9054
time=2025-06-11T19:30:14.261+05:30 level=WARN source=rest.go:597 msg="This instance is already processed. instKey is not unique" Poller=CG1 collector=Rest:SnapshotPolicy instKey=68ca4a42-c351-11ed-ba28-00a098af9054
time=2025-06-11T19:30:14.261+05:30 level=INFO source=collector.go:601 msg=Collected Poller=CG1 collector=Rest:SnapshotPolicy apiMs=834 bytesRx=11298 calcMs=0 exportMs=0 instances=13 instancesExported=0 metrics=97 metricsExported=0 numCalls=1 parseMs=0 pluginInstances=0 pluginMs=0 pollMs=835 renderedBytes=0 zBegin=1749650413426
```

After this PR changes, All 16 instances were exported.
```
harvest % ./bin/poller -p CG1 -c Rest -o SnapshotPolicy 
time=2025-06-11T19:31:17.490+05:30 level=INFO source=poller.go:235 msg=Init Poller=CG1 logLevel=INFO configPath=harvest.yml cwd=/Users/hardikl/Documents/Harvest/harvest version="harvest version 25.06.11-1 (commit 5f853401) (build date 2025-06-11T14:41:44+0530) darwin/amd64" fips=false options="&{Poller:CG1 Daemon:false Debug:false PromPort:0 Config:harvest.yml HomePath: LogPath:/var/log/harvest/ LogFormat:plain LogLevel:2 LogToFile:false Version:25.06.11 Hostname:hardikl-mac-1 Collectors:[Rest] Objects:[SnapshotPolicy] Profiling:0 Asup:false IsTest:false ConfPath:conf ConfPaths:[conf]}"
time=2025-06-11T19:31:17.491+05:30 level=INFO source=poller.go:274 msg="started in foreground" Poller=CG1 pid=95627
time=2025-06-11T19:31:19.253+05:30 level=INFO source=poller.go:1533 msg="Cluster info" Poller=CG1 remote="{Name:Cluster1 Model:cdot UUID:5b22a81c-bf7a-11ed-82e7-00a098f7d731 Version:9.15.1 Release:NetApp Release 9.15.1P1: Tue Jul 30 05:15:49 UTC 2024 Serial: IsSanOptimized:false IsDisaggregated:false ZAPIsExist:true HasREST:true IsClustered:true}"
time=2025-06-11T19:31:19.260+05:30 level=INFO source=helpers.go:109 msg="best-fit template" Poller=CG1 collector=Rest:SnapshotPolicy path=conf/rest/9.12.0/snapshotpolicy.yaml v=9.15.1 jitter=none
time=2025-06-11T19:31:19.261+05:30 level=ERROR source=prometheus.go:161 msg="missing Prometheus port" Poller=CG1 exporter=prometheus1
time=2025-06-11T19:31:19.261+05:30 level=ERROR source=poller.go:1063 msg="Unable to init exporter" Poller=CG1 error="missing parameter => port" name=prometheus1
time=2025-06-11T19:31:19.261+05:30 level=WARN source=poller.go:871 msg="exporter requested not available" Poller=CG1 exporterName=prometheus1 name=Rest object=SnapshotPolicy
time=2025-06-11T19:31:19.261+05:30 level=WARN source=poller.go:355 msg="no exporters initialized, continuing without exporters" Poller=CG1
time=2025-06-11T19:31:19.261+05:30 level=INFO source=poller.go:410 msg="Autosupport scheduled" Poller=CG1 asupSchedule=24h
time=2025-06-11T19:31:19.261+05:30 level=INFO source=poller.go:420 msg="poller start-up complete" Poller=CG1
time=2025-06-11T19:31:19.555+05:30 level=INFO source=poller.go:642 msg="updated status" Poller=CG1 collectors.up=1 collectors.total=1 exporters.up=0 exporters.total=0
time=2025-06-11T19:31:20.309+05:30 level=INFO source=poller.go:1448 msg=Metadata Poller=CG1 remote.name=Cluster1 remote.version=9.15.1 version="harvest version 25.06.11-1 (commit 5f853401) (build date 2025-06-11T14:41:44+0530) darwin/amd64" mem.liveHeapMB=0 mem.heapMB=1 mem.heapGoalMB=4 mem.rssMB=16 mem.maxRssMB=16 uptimeSeconds=2
time=2025-06-11T19:31:21.002+05:30 level=INFO source=collector.go:633 msg=Collected Poller=CG1 collector=Rest:SnapshotPolicy task=counter apiMs=1739 bytesRx=0 metrics=0 numCalls=0 pollMs=1740 zBegin=1749650479261
time=2025-06-11T19:31:21.252+05:30 level=INFO source=collector.go:601 msg=Collected Poller=CG1 collector=Rest:SnapshotPolicy apiMs=248 bytesRx=11298 calcMs=0 exportMs=0 instances=16 instancesExported=0 metrics=97 metricsExported=0 numCalls=1 parseMs=0 pluginInstances=0 pluginMs=1 pollMs=249 renderedBytes=0 zBegin=1749650481002
time=2025-06-11T19:34:21.719+05:30 level=INFO source=collector.go:601 msg=Collected Poller=CG1 collector=Rest:SnapshotPolicy apiMs=716 bytesRx=11298 calcMs=0 exportMs=0 instances=16 instancesExported=0 metrics=97 metricsExported=0 numCalls=1 parseMs=0 pluginInstances=0 pluginMs=0 pollMs=716 renderedBytes=0 zBegin=1749650661002
time=2025-06-11T19:37:21.727+05:30 level=INFO source=collector.go:601 msg=Collected Poller=CG1 collector=Rest:SnapshotPolicy apiMs=725 bytesRx=11298 calcMs=0 exportMs=0 instances=16 instancesExported=0 metrics=97 metricsExported=0 numCalls=1 parseMs=0 pluginInstances=0 pluginMs=0 pollMs=725 renderedBytes=0 zBegin=1749650841002
```