### PR TITLE
fix: handle outage parsing in disk rest template

### DIFF
--- a/conf/rest/9.12.0/disk.yaml
+++ b/conf/rest/9.12.0/disk.yaml
@@ -12,7 +12,7 @@ counters:
   - ^name                       => disk
   - ^node.name                  => node
   - ^node.uuid
-  - ^outage.reason              => outage
+  - ^outage.reason.message      => outage
   - ^serial_number
   - ^shelf.uid                  => shelf
   - ^state
@@ -34,6 +34,8 @@ endpoints:
 plugins:
   - Disk
   - LabelAgent:
+      replace:
+        - outage outage `"` ``
       value_to_num:
         - new_status outage - - `0` #ok_value is empty value, '-' would be converted to blank while processing.
       join:


### PR DESCRIPTION
<img width="1275" height="451" alt="image" src="https://github.com/user-attachments/assets/b33ee2f0-e6c2-453b-9ce7-c7f71a469b31" />
