### PR TITLE
ci: disable nolintlint due to false positives

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,7 @@ linters:
     - nakedret
     - nilerr
     - nilnesserr
-    - nolintlint
+#    - nolintlint
     - nonamedreturns
     - nosprintfhostport
     - perfsprint


### PR DESCRIPTION
See https://github.com/golangci/golangci-lint/issues/3228