### PR TITLE
refactor: simplify parsing Cisco fan metrics

### DIFF
--- a/cmd/collectors/cisco/plugins/environment/environment_test.go
+++ b/cmd/collectors/cisco/plugins/environment/environment_test.go
@@ -1,12 +1,10 @@
 package environment
 
 import (
-	"cmp"
 	diff "github.com/google/go-cmp/cmp"
 	"github.com/netapp/harvest/v2/third_party/tidwall/gjson"
 	"log/slog"
 	"os"
-	"slices"
 	"testing"
 )
 
@@ -93,22 +91,10 @@ func TestFanSpeed(t *testing.T) {
 				t.Errorf("failed to read %s file: %v", tt.input, err)
 			}
 			got := NewFanModel(gjson.ParseBytes(data), slog.Default())
-			sortFans(got.Fans)
-			sortFans(tt.want.Fans)
-			diff1 := diff.Diff(tt.want, got)
+			diff1 := diff.Diff(got, tt.want)
 			if diff1 != "" {
 				t.Errorf("Mismatch (-got +want):\n%s", diff1)
 			}
 		})
 	}
-}
-
-// SortFans sorts the fans slice by Name and TrayFanNum
-func sortFans(fans []*FanData) {
-	slices.SortFunc(fans, func(a, b *FanData) int {
-		if a.Name == b.Name {
-			return cmp.Compare(a.TrayFanNum, b.TrayFanNum)
-		}
-		return cmp.Compare(a.Name, b.Name)
-	})
 }


### PR DESCRIPTION
Parse them in the same order they are returned by nx-api