### PR TITLE
refactor: lint issues

### DIFF
--- a/cmd/collectors/restperf/plugins/vscan/vscan_test.go
+++ b/cmd/collectors/restperf/plugins/vscan/vscan_test.go
@@ -28,6 +28,7 @@ func runTest(t *testing.T, createRestVscan func(params *node.Node) plugin.Plugin
 	data := readTestFile(testFile)
 	if data == nil {
 		t.Fatalf("failed to read test file %s", testFile)
+		return
 	}
 
 	dataMap := map[string]*matrix.Matrix{


### PR DESCRIPTION
cmd/collectors/restperf/plugins/vscan/vscan_test.go:29:5: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
        if data == nil {
           ^
cmd/collectors/restperf/plugins/vscan/vscan_test.go:34:8: SA5011: possible nil pointer dereference (staticcheck)
                data.Object: data,