### PR TITLE
fix: better error handling when trying to monitor an ONTAP cluster wi…

### DIFF
--- a/pkg/errs/storagegrid.go
+++ b/pkg/errs/storagegrid.go
@@ -27,7 +27,9 @@ func NewStorageGridErr(statusCode int, jsonText []byte) error {
 	var e StorageGridError
 	err := json.Unmarshal(jsonText, &e)
 	if err != nil {
-		return New(err, "failed to unmarshal storage grid err")
+		truncated := string(jsonText)
+		truncated = truncated[:min(100, len(jsonText))]
+		return New(err, "failed to unmarshal storage grid err because text was "+truncated)
 	}
 	if statusCode == 401 {
 		e.Code = 401


### PR DESCRIPTION
…th a SG collector

Thanks to @ikrnjajic for reporting.

Logging shows:

time=2025-11-25T09:36:10.788-05:00 level=WARN source=poller.go:1812 msg="gather remote info failed" Poller=sar connectionType=StorageGrid remote="{Name: Model: UUID: Version: Release: Serial: IsSanOptimized:false IsDisaggregated:false ZAPIsExist:false ZAPIsChecked:false HasREST:false IsClustered:false}" error="invalid character '<' looking for beginning of value => failed to unmarshal storage grid err because text was <!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n<html><head>\n<title>404 Not Found</title>\n</head>"

Fixes: #4035