### PR TITLE
ci: unit test should fail ZapiPerf templates when detect caret

### DIFF
--- a/cmd/tools/template/template_test.go
+++ b/cmd/tools/template/template_test.go
@@ -443,7 +443,7 @@ func TestZapiPerfMetricsHaveNoCaret(t *testing.T) {
 	visitTemplates(t, func(path string, model Model) {
 		for _, metric := range model.metrics {
 			if strings.HasPrefix(metric.line, "^") {
-				t.Errorf("counter %s should not have ^^ at path=[%s]", metric.line, shortPath(path))
+				t.Errorf("counter %s should not have ^ at path=[%s]", metric.line, shortPath(path))
 			}
 		}
 	}, []string{"zapiperf"}...)


### PR DESCRIPTION
Validated against this Spinhi template,
```
name:                     Spinhi
query:                    spinhi
object:                   spinhi

instance_key:             uuid

counters:
  - ^^instance_uuid
  - instance_name          => volume
  - node_name              => node
  - spinhi_fileops

plugins:
  - LabelAgent:
      # Ignore transient volumes, e.g. SnapProtect, SnapManager, SnapCenter, CommVault, Clone, and Metadata volumes
      exclude_regex:
        - volume `.+_CVclone`
        - volume `.+(0[1-9]|[12][0-9]|3[01])(0[1-9]|1[012])\d\d[0-9]{6}`
        - volume `cl_.+_(19|20)\d\d(0[1-9]|1[012])( 0[1-9]|[12][0-9]|3[01])[0-9]{6}`
        - volume `sdw_cl_.+`
        - volume `MDV_CRS_.+`
        - volume `MDV_aud_.+`

export_options:
  instance_keys:
    - node
    - volume
```