### PR TITLE
Add job filter to prometheus alert

### DIFF
--- a/container/prometheus/alert_rules.yml
+++ b/container/prometheus/alert_rules.yml
@@ -6,7 +6,7 @@ groups:
 
   # Alert for any instance that is unreachable for >5 minutes.
   - alert: InstanceDown
-    expr: up{} == 0
+    expr: up{job=~"harvest.*"} == 0
     for: 5m
     labels:
       severity: "critical"


### PR DESCRIPTION
`up` metric is ubiquitous prometheus metric, created from any prometheus scrape, so having alert `up==0` would fire on any scrape, even unrelated to Harvest. 

This PR adds  additional job filter that should ignore problems with unrelated scrapes.