### PR TITLE
ci: fix ci issue

### DIFF
--- a/integration/test/promtool_metrics_test.go
+++ b/integration/test/promtool_metrics_test.go
@@ -14,6 +14,7 @@ var allowedList = []string{
 	"aggr_power",
 	"cluster_software_status",
 	"health_lif_alerts",
+	"health_support_alerts",
 	"security_certificate_labels",
 	"shelf_average_ambient_temperature",
 	"shelf_average_fan_speed",


### PR DESCRIPTION
    promtool_metrics_test.go:69: ERR health_support_alerts label names should be written in 'snake_case' not 'camelCase'
