### PR TITLE
fix: volume uuid should be instance_uuid

### DIFF
--- a/conf/rest/9.12.0/volume.yaml
+++ b/conf/rest/9.12.0/volume.yaml
@@ -10,6 +10,7 @@ counters:
   - ^clone_parent_name                            => clone_parent_volume
   - ^clone_parent_vserver                         => clone_parent_svm
   - ^clone_volume                                 => is_flexclone
+  - ^instance_uuid                                => uuid
   - ^is_encrypted                                 => isEncrypted
   - ^is_sis_volume                                => is_sis_volume
   - ^is_space_enforcement_logical                 => is_space_enforcement_logical
@@ -24,7 +25,6 @@ counters:
   - ^tiering_minimum_cooling_days                 => tiering_minimum_cooling_days
   - ^tiering_policy                               => tiering_policy
   - ^type                                         => type
-  - ^uuid                                         => uuid
   - ^volume_style_extended                        => style
   - ^vsroot                                       => svm_root
   - autosize_grow_threshold_percent               => autosize_grow_threshold_percent

--- a/conf/rest/9.14.0/volume.yaml
+++ b/conf/rest/9.14.0/volume.yaml
@@ -10,6 +10,7 @@ counters:
   - ^clone_parent_name                            => clone_parent_volume
   - ^clone_parent_vserver                         => clone_parent_svm
   - ^clone_volume                                 => is_flexclone
+  - ^instance_uuid                                => uuid
   - ^is_encrypted                                 => isEncrypted
   - ^is_sis_volume                                => is_sis_volume
   - ^is_space_enforcement_logical                 => is_space_enforcement_logical
@@ -24,7 +25,6 @@ counters:
   - ^tiering_minimum_cooling_days                 => tiering_minimum_cooling_days
   - ^tiering_policy                               => tiering_policy
   - ^type                                         => type
-  - ^uuid                                         => uuid
   - ^volume_style_extended                        => style
   - ^vsroot                                       => svm_root
   - autosize_grow_threshold_percent               => autosize_grow_threshold_percent


### PR DESCRIPTION
Thanks Greg for raising!

The uuid used in REST APIs is the instance-uuid from the CLI that doesn't change when you move a volume. The cli uuid field changes if you do a vol move.