### PR TITLE
fix: duplicate metrics for flashpool

### DIFF
--- a/conf/restperf/9.12.0/wafl_hya_sizer.yaml
+++ b/conf/restperf/9.12.0/wafl_hya_sizer.yaml
@@ -4,9 +4,11 @@ object:                   flashpool
 
 counters:
   - ^^id
+  - ^aggregate.name         => aggr
   - ^node.name              => node
   - cache_stats
 
 export_options:
   instance_keys:
+    - aggr
     - node

--- a/conf/statperf/9.8.0/wafl_hya_sizer.yaml
+++ b/conf/statperf/9.8.0/wafl_hya_sizer.yaml
@@ -5,10 +5,11 @@ object:                   flashpool
 
 counters:
   - ^^instance_uuid
-  - ^instance_name        => flashpool
+  - ^instance_name        => aggr
   - ^node_name            => node
   - cache_stats
 
 export_options:
   instance_keys:
+    - aggr
     - node

--- a/conf/zapiperf/cdot/9.8.0/wafl_hya_sizer.yaml
+++ b/conf/zapiperf/cdot/9.8.0/wafl_hya_sizer.yaml
@@ -7,9 +7,10 @@ instance_key:             uuid
 
 counters:
   - cache_stats
-  - instance_name
+  - instance_name          => aggr
   - node_name              => node
 
 export_options:
   instance_keys:
+    - aggr
     - node


### PR DESCRIPTION
ts=2026-02-13T09:29:05.627Z caller=scrape.go:1820 level=warn component="scrape manager" scrape_pool=prometheus target=http://localhost:12993/metrics msg="Error on ingesting samples with different value but same timestamp" num_dropped=660
ts=2026-02-13T09:29:15.622Z caller=scrape.go:1820 level=warn component="scrape manager" scrape_pool=prometheus target=http://localhost:12993/metrics msg="Error on ingesting samples with different value but same timestamp" num_dropped=660
ts=2026-02-13T09:29:25.624Z caller=scrape.go:1820 level=warn component="scrape manager" scrape_pool=prometheus target=http://localhost:12993/metrics msg="Error on ingesting samples with different value but same timestamp" num_dropped=660
ts=2026-02-13T09:29:35.620Z caller=scrape.go:1820 level=warn component="scrape manager" scrape_pool=prometheus target=http://localhost:12993/metrics msg="Error on ingesting samples with different value but same timestamp" num_dropped=660
ts=2026-02-13T09:29:45.629Z caller=scrape.go:1820 level=warn component="scrape manager" scrape_pool=prometheus target=http://localhost:12993/metrics msg="Error on ingesting samples with different value but same timestamp" num_dropped=660
ts=2026-02-13T09:29:55.631Z caller=scrape.go:1820 level=warn component="scrape manager" scrape_pool=prometheus target=http://localhost:12993/metrics msg="Error on ingesting samples with different value but same timestamp" num_dropped=660
ts=2026-02-13T09:30:05.627Z caller=scrape.go:1820 level=warn component="scrape manager" scrape_pool=prometheus target=http://localhost:12993/metrics msg="Error on ingesting samples with different value but same timestamp" num_dropped=660
ts=2026-02-13T09:30:15.617Z caller=scrape.go:1820 level=warn component="scrape manager" scrape_pool=prometheus target=http://localhost:12993/metrics msg="Error on ingesting samples with different value but same timestamp" num_dropped=660
ts=2026-02-13T09:30:25.616Z caller=scrape.go:1820 level=warn component="scrape manager" scrape_pool=prometheus target=http://localhost:12993/metrics msg="Error on ingesting samples with different value but same timestamp" num_dropped=660
ts=2026-02-13T09:30:35.623Z caller=scrape.go:1820 level=warn component="scrape manager" scrape_pool=prometheus target=http://localhost:12993/metrics msg="Error on ingesting samples with different value but same timestamp" num_dropped=660
ts=2026-02-13T09:30:45.626Z caller=scrape.go:1820 level=warn component="scrape manager" scrape_pool=prometheus target=http://localhost:12993/metrics msg="Error on ingesting samples with different value but same timestamp" num_dropped=660
ts=2026-02-13T09:30:55.617Z caller=scrape.go:1820 level=warn component="scrape manager" scrape_pool=prometheus target=http://localhost:12993/metrics msg="Error on ingesting samples with different value but same timestamp" num_dropped=660





curl -s http://localhost:12993/metrics | sort | uniq -c | sort -rn | awk '$1 > 1'
zsh: command not found: #
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int019"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int018"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int017"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int016"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int015"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int014"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int013"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int012"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int011"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int010"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int009"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int008"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int007"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int006"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int005"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int004"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int003"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int002"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int001"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="type_conflict",submetric="int000"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int019"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int018"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int017"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int016"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int015"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int014"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int013"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int012"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int011"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int010"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int009"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int008"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int007"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int006"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int005"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int004"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int003"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int002"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int001"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="recycle_d_free",submetric="int000"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int019"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int018"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int017"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int016"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int015"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int014"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int013"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int012"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int011"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int010"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int009"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int008"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int007"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int006"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int005"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int004"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int003"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_op_replaced_rate",submetric="int002"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int019"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int018"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int017"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int016"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int015"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int014"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int013"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int012"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int011"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int010"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int009"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int008"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int007"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int006"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int005"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int004"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int003"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="read_hit_rate",submetric="int002"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int019"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int018"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int017"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int016"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int015"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int014"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int013"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int012"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int011"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int010"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int009"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int008"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int007"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int006"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int005"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int004"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int003"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int002"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int001"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit",submetric="int000"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int019"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int018"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int017"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int016"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int015"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int014"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int013"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int012"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int011"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int010"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int009"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int008"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int007"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int006"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int005"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int004"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int003"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int002"} 0
   2 flashpool_cache_stats{cluster="FsxId150428403216707808",datacenter="fsx",node="FsxId150428403216707808-vm2",metric="rd_hit_wc",submetric="int001"} 0
