### PR TITLE
refactor: move codebase to go 1.26

### DIFF
--- a/cmd/collectors/cisco/rest/client.go
+++ b/cmd/collectors/cisco/rest/client.go
@@ -73,8 +73,7 @@ func (c *Client) callAPI(command string, callType apiType) (gjson.Result, error)
 	result, err := c.callWithAuthRetry(command, callType)
 
 	if err != nil {
-		var he errs.HarvestError
-		if errors.As(err, &he) {
+		if he, ok := errors.AsType[errs.HarvestError](err); ok {
 			// If this is an auth failure and the client is using a credential script,
 			// expire the current credentials, call the script again, update the client's password,
 			// and try again

--- a/cmd/collectors/discovery.go
+++ b/cmd/collectors/discovery.go
@@ -116,8 +116,7 @@ func checkZapi(pollerName string, cred *auth.Credentials) (conf.Remote, error) {
 
 		returnErr := true
 
-		var he errs.HarvestError
-		if errors.As(err, &he) {
+		if he, ok := errors.AsType[errs.HarvestError](err); ok {
 			switch {
 			case he.ErrNum == errs.ErrNumZAPISuspended, he.StatusCode >= 400 && he.StatusCode < 500:
 				// ZAPI is suspended, or we got a 4xx error, so we assume that ZAPI is not available

--- a/cmd/collectors/eseries/rest/client.go
+++ b/cmd/collectors/eseries/rest/client.go
@@ -292,8 +292,7 @@ func (c *Client) get(endpoint string, headers ...map[string]string) ([]gjson.Res
 	results, err = doInvoke()
 
 	if err != nil {
-		var re *errs.RestError
-		if errors.As(err, &re) {
+		if re, ok := errors.AsType[*errs.RestError](err); ok {
 			if errors.Is(re, errs.ErrAuthFailed) {
 				pollerAuth, err2 := c.auth.GetPollerAuth()
 				if err2 != nil {

--- a/cmd/collectors/power.go
+++ b/cmd/collectors/power.go
@@ -394,8 +394,7 @@ func (s *Sensor) Init(remote conf.Remote) error {
 	s.hasREST = true
 
 	if err := s.client.Init(5, remote); err != nil {
-		var re *errs.RestError
-		if errors.As(err, &re) && re.StatusCode == http.StatusNotFound {
+		if re, ok := errors.AsType[*errs.RestError](err); ok && re.StatusCode == http.StatusNotFound {
 			s.SLogger.Warn("Cluster does not support REST. Power plugin disabled")
 			s.hasREST = false
 			return nil

--- a/cmd/collectors/storagegrid/rest/client.go
+++ b/cmd/collectors/storagegrid/rest/client.go
@@ -206,8 +206,7 @@ func (c *Client) invoke() ([]byte, error) {
 	resp, err = c.fetch()
 	if err != nil {
 		// check that the auth token has not expired
-		var storageGridErr errs.StorageGridError
-		if errors.As(err, &storageGridErr) {
+		if storageGridErr, ok := errors.AsType[errs.StorageGridError](err); ok {
 			if storageGridErr.IsAuthErr() {
 				// If using authToken from credential script, expire cache before retry
 				// so fetchTokenWithAuthRetry gets fresh token instead of cached expired one
@@ -432,8 +431,7 @@ func (c *Client) fetchTokenWithAuthRetry() error {
 
 	err := fetchToken()
 	if err != nil {
-		var storageGridErr errs.StorageGridError
-		if errors.As(err, &storageGridErr) {
+		if storageGridErr, ok := errors.AsType[errs.StorageGridError](err); ok {
 			// If this is an auth failure and the client is using a credential script,
 			// expire the current credentials, call the script again, and try again
 			if storageGridErr.IsAuthErr() {

--- a/cmd/exporters/influxdb/influxdb.go
+++ b/cmd/exporters/influxdb/influxdb.go
@@ -89,12 +89,10 @@ func (e *InfluxDB) Init() error {
 		}
 		if port = e.Params.Port; port == nil {
 			e.Logger.Debug("using default port", slog.Int("default", defaultPort))
-			defPort := defaultPort
-			port = &defPort
+			port = new(defaultPort)
 		}
 		if version = e.Params.Version; version == nil {
-			v := defaultAPIVersion
-			version = &v
+			version = new(defaultAPIVersion)
 		}
 		e.Logger.Debug("using api version", slog.String("version", *version))
 
@@ -109,14 +107,12 @@ func (e *InfluxDB) Init() error {
 		e.Logger.Debug("using organization", slog.String("org", *org))
 
 		if precision = e.Params.Precision; precision == nil {
-			p := defaultAPIPrecision
-			precision = &p
+			precision = new(defaultAPIPrecision)
 		}
 		e.Logger.Debug("using api precision", slog.String("precision", *precision))
 
 		//goland:noinspection HttpUrlsUsage
-		urlToUSe := "http://" + *addr + ":" + strconv.Itoa(*port)
-		url = &urlToUSe
+		url = new("http://" + *addr + ":" + strconv.Itoa(*port))
 		e.url = fmt.Sprintf("%s/api/v%s/write?org=%s&bucket=%s&precision=%s",
 			*url, *version, url2.PathEscape(*org), url2.PathEscape(*bucket), *precision)
 	}

--- a/cmd/exporters/victoriametrics/victoriametrics.go
+++ b/cmd/exporters/victoriametrics/victoriametrics.go
@@ -98,18 +98,15 @@ func (v *VictoriaMetrics) Init() error {
 		}
 		if port = v.Params.Port; port == nil {
 			v.Logger.Debug("using default port", slog.Int("default", defaultPort))
-			defPort := defaultPort
-			port = &defPort
+			port = new(defaultPort)
 		}
 		if version = v.Params.Version; version == nil {
-			v := defaultAPIVersion
-			version = &v
+			version = new(defaultAPIVersion)
 		}
 		v.Logger.Debug("using api version", slog.String("version", *version))
 
 		//goland:noinspection HttpUrlsUsage
-		urlToUse := "http://" + *addr + ":" + strconv.Itoa(*port)
-		url = &urlToUse
+		url = new("http://" + *addr + ":" + strconv.Itoa(*port))
 		v.url = fmt.Sprintf("%s/api/v%s/import/prometheus", *url, *version)
 	}
 

--- a/cmd/poller/poller.go
+++ b/cmd/poller/poller.go
@@ -1743,8 +1743,7 @@ func (p *Poller) negotiateAPI(cols []conf.Collector) []conf.Collector {
 			if p.remote.IsASAr2() {
 				for _, col := range ontapCols {
 					if slices.Equal(*col.Templates, *conf.DefaultTemplates) {
-						newTemplates := append(*col.Templates, "asar2/default.yaml", "asar2/custom.yaml")
-						col.Templates = &newTemplates
+						col.Templates = new(append(*col.Templates, "asar2/default.yaml", "asar2/custom.yaml"))
 						validCollectors = append(validCollectors, col)
 					} else {
 						validCollectors = append(validCollectors, col)

--- a/cmd/tools/rest/client.go
+++ b/cmd/tools/rest/client.go
@@ -286,8 +286,7 @@ func (c *Client) invokeWithAuthRetry() ([]byte, error) {
 	body, err = doInvoke()
 
 	if err != nil {
-		var re *errs.RestError
-		if errors.As(err, &re) {
+		if re, ok := errors.AsType[*errs.RestError](err); ok {
 			// If this is an auth failure and the client is using a credential script,
 			// expire the current credentials, call the script again, update the client's password,
 			// and try again

--- a/cmd/tools/rest/rest.go
+++ b/cmd/tools/rest/rest.go
@@ -130,8 +130,7 @@ func fetchData(poller *conf.Poller, timeout time.Duration) (*Results, error) {
 	// Init is called to get the cluster version
 	err = client.Init(1, conf.Remote{})
 	if err != nil {
-		var re *errs.RestError
-		if errors.As(err, &re) {
+		if re, ok := errors.AsType[*errs.RestError](err); ok {
 			return nil, fmt.Errorf("poller=%s statusCode=%d", poller.Name, re.StatusCode)
 		}
 		return nil, fmt.Errorf("poller=%s %w", poller.Name, err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/netapp/harvest/v2
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/goccy/go-yaml v1.19.2

--- a/integration/certer/main.go
+++ b/integration/certer/main.go
@@ -191,8 +191,7 @@ func addCertificateAuthToHarvestUser() error {
 			Fetch(context.Background())
 
 		if err != nil {
-			var oe models.OntapError
-			if errors.As(err, &oe) {
+			if oe, ok := errors.AsType[models.OntapError](err); ok {
 				if oe.StatusCode == http.StatusConflict {
 					// duplicate entry - that's fine, ignore
 					continue

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -1,6 +1,6 @@
 module github.com/Netapp/harvest-automation
 
-go 1.24.0
+go 1.26.0
 
 replace github.com/netapp/harvest/v2 => ../
 

--- a/integration/test/copy_logs_test.go
+++ b/integration/test/copy_logs_test.go
@@ -70,8 +70,7 @@ func checkLogs(t *testing.T, container docker.Container, info containerInfo) {
 	//   1 means no lines matched
 	//  >1 means an error occurred
 	if err != nil {
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
+		if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 			// an exit code of 1 means there were no matches, that's OK
 			if ee.ExitCode() == 1 {
 				return

--- a/integration/test/promtool_metrics_test.go
+++ b/integration/test/promtool_metrics_test.go
@@ -44,8 +44,7 @@ func checkMetrics(t *testing.T, port int) {
 	command := exec.Command("bash", "-c", cli)
 	output, err := command.CombinedOutput()
 	if err != nil {
-		var ee *exec.ExitError
-		if !errors.As(err, &ee) {
+		if _, ok := errors.AsType[*exec.ExitError](err); !ok {
 			// An exit code can't be used since we need to ignore metrics that are not valid but can't change
 			t.Errorf("ERR checking metrics cli=%s err=%v output=%s", cli, err, string(output))
 			return

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -1,6 +1,6 @@
 module mcp-server
 
-go 1.25
+go 1.26
 
 replace github.com/netapp/harvest/v2 => ../
 

--- a/pkg/api/ontapi/zapi/client.go
+++ b/pkg/api/ontapi/zapi/client.go
@@ -436,8 +436,7 @@ func (c *Client) invokeWithAuthRetry(withTimers bool, headers ...map[string]stri
 	resp, t1, t2, err := c.invoke(withTimers, headers...)
 
 	if err != nil {
-		var he errs.HarvestError
-		if errors.As(err, &he) {
+		if he, ok := errors.AsType[errs.HarvestError](err); ok {
 			// If this is an auth failure and the client is using a credential script,
 			// expire the current credentials, call the script again, update the client's password,
 			// and try again

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -776,8 +776,7 @@ func ZapiPoller(n *node.Node) *Poller {
 		p.TLSMinVersion = tlsMinVersion
 	}
 	if logSet := n.GetChildS("log"); logSet != nil {
-		names := logSet.GetAllChildNamesS()
-		p.LogSet = &names
+		p.LogSet = new(logSet.GetAllChildNamesS())
 	}
 	if confPath := n.GetChildContentS("conf_path"); confPath != "" {
 		p.ConfPath = confPath

--- a/pkg/conf/conf_test.go
+++ b/pkg/conf/conf_test.go
@@ -96,17 +96,15 @@ func TestPollerUnion(t *testing.T) {
 	TestLoadHarvestConfig(testYml)
 	addr := "addr"
 	user := "user"
-	no := false
-	yes := true
 	defaults := Poller{
 		Addr:           addr,
 		Collectors:     []Collector{{Name: "0"}, {Name: "1"}, {Name: "2"}, {Name: "3"}},
 		Username:       user,
-		UseInsecureTLS: &yes,
+		UseInsecureTLS: new(true),
 		IsKfs:          true,
 	}
 	p := Poller{
-		UseInsecureTLS: &no,
+		UseInsecureTLS: new(false),
 		IsKfs:          false,
 	}
 	p.Union(&defaults)

--- a/pkg/errs/ontap.go
+++ b/pkg/errs/ontap.go
@@ -98,8 +98,7 @@ var (
 )
 
 func IsRestErr(err error, sentinel OntapRestCode) bool {
-	var restErr *RestError
-	if errors.As(err, &restErr) {
+	if restErr, ok := errors.AsType[*RestError](err); ok {
 		if restErr.Code == sentinel.Code {
 			return true
 		}


### PR DESCRIPTION
https://blog.jetbrains.com/go/2026/02/13/moving-your-codebase-to-go-1-26-with-goland-syntax-updates/