### PR TITLE
fix: remove rate from PromQL for ONTAP dashboards.

### DIFF
--- a/grafana/dashboards/cmode/switch.json
+++ b/grafana/dashboards/cmode/switch.json
@@ -432,7 +432,7 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "sum by (switch, interface) (\n    rate(\n      ethernet_switch_port_transmit_packets{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[4m]\n    )\n  )\nand on (switch, interface)\n  topk(\n    $TopResources,\n    sum by (switch, interface) (\n      avg_over_time(\n        ethernet_switch_port_transmit_packets{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[3h]\n      )\n    )\n  )",
+              "expr": "sum by (switch, interface) (\n    ethernet_switch_port_transmit_packets{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}\n  )\nand on (switch, interface)\n  topk(\n    $TopResources,\n    sum by (switch, interface) (\n      avg_over_time(\n        ethernet_switch_port_transmit_packets{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[3h]\n      )\n    )\n  )",
               "interval": "",
               "legendFormat": "{{switch}} - {{interface}}",
               "refId": "A"
@@ -524,7 +524,7 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "sum by (switch, interface) (\n    rate(\n      ethernet_switch_port_receive_packets{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[4m]\n    )\n  )\nand on (switch, interface)\n  topk(\n    $TopResources,\n    sum by (switch, interface) (\n      avg_over_time(\n        ethernet_switch_port_receive_packets{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[3h]\n      )\n    )\n  )",
+              "expr": "sum by (switch, interface) (\n    ethernet_switch_port_receive_packets{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}\n  )\nand on (switch, interface)\n  topk(\n    $TopResources,\n    sum by (switch, interface) (\n      avg_over_time(\n        ethernet_switch_port_receive_packets{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[3h]\n      )\n    )\n  )",
               "interval": "",
               "legendFormat": "{{switch}} - {{interface}}",
               "refId": "A"
@@ -616,14 +616,14 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "sum by (switch, interface) (\n    rate(\n      ethernet_switch_port_receive_discards{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[4m]\n    )\n  )\nand on (switch, interface)\n  topk(\n    $TopResources,\n    sum by (switch, interface) (\n      avg_over_time(\n        ethernet_switch_port_receive_discards{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[3h]\n      )\n    )\n  )",
+              "expr": "sum by (switch, interface) (\n    ethernet_switch_port_receive_discards{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}\n  )\nand on (switch, interface)\n  topk(\n    $TopResources,\n    sum by (switch, interface) (\n      avg_over_time(\n        ethernet_switch_port_receive_discards{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[3h]\n      )\n    )\n  )",
               "interval": "",
               "legendFormat": "Receive - {{switch}} - {{interface}}",
               "refId": "A"
             },
             {
               "exemplar": false,
-              "expr": "sum by (switch, interface) (\n    rate(\n      ethernet_switch_port_transmit_discards{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[4m]\n    )\n  )\nand on (switch, interface)\n  topk(\n    $TopResources,\n    sum by (switch, interface) (\n      avg_over_time(\n        ethernet_switch_port_transmit_discards{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[3h]\n      )\n    )\n  )",
+              "expr": "sum by (switch, interface) (\n    ethernet_switch_port_transmit_discards{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}\n  )\nand on (switch, interface)\n  topk(\n    $TopResources,\n    sum by (switch, interface) (\n      avg_over_time(\n        ethernet_switch_port_transmit_discards{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[3h]\n      )\n    )\n  )",
               "interval": "",
               "legendFormat": "Transmit - {{switch}} - {{interface}}",
               "refId": "B"
@@ -715,14 +715,14 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "sum by (switch, interface) (\n    rate(\n      ethernet_switch_port_transmit_errors{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[4m]\n    )\n  )\nand on (switch, interface)\n  topk(\n    $TopResources,\n    sum by (switch, interface) (\n      avg_over_time(\n        ethernet_switch_port_transmit_errors{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[3h]\n      )\n    )\n  )",
+              "expr": "sum by (switch, interface) (\n    ethernet_switch_port_transmit_errors{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}\n  )\nand on (switch, interface)\n  topk(\n    $TopResources,\n    sum by (switch, interface) (\n      avg_over_time(\n        ethernet_switch_port_transmit_errors{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[3h]\n      )\n    )\n  )",
               "interval": "",
               "legendFormat": "Transmit - {{switch}} - {{interface}}",
               "refId": "A"
             },
             {
               "exemplar": false,
-              "expr": "sum by (switch, interface) (\n    rate(\n      ethernet_switch_port_receive_errors{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[4m]\n    )\n  )\nand on (switch, interface)\n  topk(\n    $TopResources,\n    sum by (switch, interface) (\n      avg_over_time(\n        ethernet_switch_port_receive_errors{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[3h]\n      )\n    )\n  )",
+              "expr": "sum by (switch, interface) (\n    ethernet_switch_port_receive_errors{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}\n  )\nand on (switch, interface)\n  topk(\n    $TopResources,\n    sum by (switch, interface) (\n      avg_over_time(\n        ethernet_switch_port_receive_errors{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",interface=~\"$Interface\",switch=~\"$Switch\"}[3h]\n      )\n    )\n  )",
               "interval": "",
               "legendFormat": "Receive - {{switch}} - {{interface}}",
               "refId": "B"

--- a/grafana/dashboards/cmode/vscan.json
+++ b/grafana/dashboards/cmode/vscan.json
@@ -457,7 +457,7 @@
         {
           "datasource": "${DS_PROMETHEUS}",
           "exemplar": false,
-          "expr": "sum by (cluster, svm) (\n    rate(\n      svm_vscan_scan_request_dispatched_rate{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",svm=~\"$SVM\"}[4m]\n    )\n  )\nand\n  topk(\n    $TopResources,\n    avg by (cluster, svm) (\n      avg_over_time(\n        svm_vscan_scan_request_dispatched_rate{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",svm=~\"$SVM\"}[3h]\n      )\n    )\n  )",
+          "expr": "sum by (cluster, svm) (\n    svm_vscan_scan_request_dispatched_rate{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",svm=~\"$SVM\"}\n  )\nand\n  topk(\n    $TopResources,\n    avg by (cluster, svm) (\n      avg_over_time(\n        svm_vscan_scan_request_dispatched_rate{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",svm=~\"$SVM\"}[3h]\n      )\n    )\n  )",
           "interval": "",
           "legendFormat": "{{svm}}",
           "refId": "A"
@@ -571,7 +571,7 @@
         {
           "datasource": "${DS_PROMETHEUS}",
           "exemplar": false,
-          "expr": "sum by (cluster, svm) (\n    rate(\n      svm_vscan_scan_noti_received_rate{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",svm=~\"$SVM\"}[4m]\n    )\n  )\nand\n  topk(\n    $TopResources,\n    avg by (cluster, svm) (\n      avg_over_time(\n        svm_vscan_scan_noti_received_rate{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",svm=~\"$SVM\"}[3h]\n      )\n    )\n  )",
+          "expr": "sum by (cluster, svm) (\n    svm_vscan_scan_noti_received_rate{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",svm=~\"$SVM\"}\n  )\nand\n  topk(\n    $TopResources,\n    avg by (cluster, svm) (\n      avg_over_time(\n        svm_vscan_scan_noti_received_rate{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",svm=~\"$SVM\"}[3h]\n      )\n    )\n  )",
           "interval": "",
           "legendFormat": "{{svm}}",
           "refId": "A"
@@ -785,7 +785,7 @@
             {
               "datasource": "${DS_PROMETHEUS}",
               "exemplar": false,
-              "expr": "sum by (cluster, scanner, svm) (\n    rate(\n      vscan_scan_request_dispatched_rate{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",scanner=~\"$Scanner\"}[4m]\n    )\n  )\nand\n  topk(\n    $TopResources,\n    avg by (cluster, scanner, svm) (\n      avg_over_time(\n        vscan_scan_request_dispatched_rate{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",scanner=~\"$Scanner\"}[3h]\n      )\n    )\n  )",
+              "expr": "sum by (cluster, scanner, svm) (\n    vscan_scan_request_dispatched_rate{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",scanner=~\"$Scanner\"}\n  )\nand\n  topk(\n    $TopResources,\n    avg by (cluster, scanner, svm) (\n      avg_over_time(\n        vscan_scan_request_dispatched_rate{cluster=~\"$Cluster\",datacenter=~\"$Datacenter\",scanner=~\"$Scanner\"}[3h]\n      )\n    )\n  )",
               "interval": "",
               "legendFormat": "{{scanner}}",
               "refId": "A"


### PR DESCRIPTION
rate should only be used for raw counters. The ONTAP counters are cooked so rate shouldn't be used