### PR TITLE
fix: security zapi uuid should be child element

### DIFF
--- a/cmd/collectors/zapi/collector/parsers.go
+++ b/cmd/collectors/zapi/collector/parsers.go
@@ -25,6 +25,15 @@ func ParseShortestPath(m *matrix.Matrix, l map[string]string) []string {
 		keys = append(keys, strings.Split(key, "."))
 	}
 
+	// The last segment of every key is the leaf field name (e.g. "cluster-uuid"),
+	// not a container. Strip it so we only compute the common prefix of the
+	// container paths. Flat keys (length 1) have no container — leave them as-is
+	for i, key := range keys {
+		if len(key) > 1 {
+			keys[i] = key[:len(key)-1]
+		}
+	}
+
 	minLen := node.MinLen(keys)
 
 	for i := range minLen {

--- a/cmd/collectors/zapi/collector/parsers_test.go
+++ b/cmd/collectors/zapi/collector/parsers_test.go
@@ -1,0 +1,103 @@
+package zapi
+
+import (
+	"testing"
+
+	"github.com/netapp/harvest/v2/pkg/matrix"
+)
+
+func TestParseShortestPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		metrics  []string
+		labels   map[string]string
+		expected []string
+	}{
+		{
+			name:     "single flat key",
+			labels:   map[string]string{"cluster-uuid": "uuid"},
+			expected: []string{"cluster-uuid"},
+		},
+		{
+			name:     "single nested key",
+			labels:   map[string]string{"cluster-identity-info.cluster-uuid": "uuid"},
+			expected: []string{"cluster-identity-info"},
+		},
+		{
+			name: "two sibling nested keys",
+			labels: map[string]string{
+				"cluster-identity-info.cluster-uuid": "uuid",
+				"cluster-identity-info.cluster-name": "name",
+			},
+			expected: []string{"cluster-identity-info"},
+		},
+		{
+			name: "two flat keys with different names",
+			labels: map[string]string{
+				"cluster-uuid": "uuid",
+				"cluster-name": "name",
+			},
+			expected: nil,
+		},
+		{
+			name: "depth 3 two sibling keys",
+			labels: map[string]string{
+				"grandparent.parent.leaf-a": "a",
+				"grandparent.parent.leaf-b": "b",
+			},
+			expected: []string{"grandparent", "parent"},
+		},
+		{
+			name:     "depth 3 single key",
+			labels:   map[string]string{"grandparent.parent.leaf": "val"},
+			expected: []string{"grandparent", "parent"},
+		},
+		{
+			name:     "mixed depth keys with common container",
+			metrics:  []string{"container.metric-a"},
+			labels:   map[string]string{"container.label-b": "b"},
+			expected: []string{"container"},
+		},
+		{
+			name:     "mixed depth keys with no common container",
+			metrics:  []string{"info-a.metric"},
+			labels:   map[string]string{"info-b.label": "val"},
+			expected: nil,
+		},
+		{
+			name: "keys at different depths with common prefix",
+			labels: map[string]string{
+				"container.sub.deep-leaf": "a",
+				"container.shallow-leaf":  "b",
+			},
+			expected: []string{"container"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := matrix.New("test", "test", "test")
+			for _, key := range tt.metrics {
+				if _, err := m.NewMetricUint64(key); err != nil {
+					t.Fatalf("failed to create metric %q: %v", key, err)
+				}
+			}
+			got := ParseShortestPath(m, tt.labels)
+			if !slicesEqual(got, tt.expected) {
+				t.Errorf("got = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/conf/zapi/cdot/9.8.0/security.yaml
+++ b/conf/zapi/cdot/9.8.0/security.yaml
@@ -4,7 +4,8 @@ query:      cluster-identity-get
 object:     security
 
 counters:
-  - ^^cluster-uuid             =>  uuid
+  - cluster-identity-info:
+      - ^^cluster-uuid  =>  uuid
 
 collect_only_labels: true
 no_max_records: true

--- a/pkg/tree/node/node.go
+++ b/pkg/tree/node/node.go
@@ -440,6 +440,9 @@ func (n *Node) SearchContent(prefix []string, paths [][]string) ([]string, bool)
 }
 
 func (n *Node) SearchChildren(path []string) []*Node {
+	if len(path) == 0 {
+		return nil
+	}
 
 	var (
 		search  func(*Node, []string)


### PR DESCRIPTION
Below template fails with old code and fixed template returns no record.

```
name:       Security
query:      cluster-identity-get
object:     security

counters:
  - ^^cluster-uuid             =>  uuid
  - ^cluster-name              =>  cluster

collect_only_labels: true
no_max_records: true
only_cluster_instance: true

plugins:
  - Security:
      schedule:
        - data: 3m  # should be multiple of data poll duration

export_options:
  instance_keys:
    - uuid
  instance_labels:
    - fips_enabled
    - rsh_enabled
    - telnet_enabled
```




```
name:       Security
query:      cluster-identity-get
object:     security

counters:
  - cluster-identity-info:
      - ^^cluster-uuid  =>  uuid

collect_only_labels: true
no_max_records: true
plugins:
  - Security:
      schedule:
        - data: 3m  # should be multiple of data poll duration
export_options:
  instance_keys:
    - uuid
  instance_labels:
    - fips_enabled
    - rsh_enabled
    - telnet_enabled
```