### PR TITLE
fix: handled state field for LS type snapmirror

### DIFF
--- a/conf/rest/9.12.0/snapmirror.yaml
+++ b/conf/rest/9.12.0/snapmirror.yaml
@@ -21,6 +21,7 @@ counters:
   - ^source_path                             => source_location
   - ^source_volume                           => source_volume
   - ^source_vserver                          => source_vserver
+  - ^state                                   => relationship_state
   - ^status                                  => relationship_status
   - ^unhealthy_reason                        => unhealthy_reason
   - break_failed_count                       => break_failed_count
@@ -48,7 +49,6 @@ endpoints:
       - ^^destination.path                   => destination_location
       - ^^uuid                               => relationship_id
       - ^source.cluster.name                 => source_cluster
-      - ^state                               => relationship_state
       - ^unhealthy_reason.#.message          => last_transfer_error
 
 plugins:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/netapp/harvest/v2
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/goccy/go-yaml v1.19.2

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -1,6 +1,6 @@
 module github.com/Netapp/harvest-automation
 
-go 1.26.0
+go 1.26.1
 
 replace github.com/netapp/harvest/v2 => ../
 
@@ -17,6 +17,6 @@ require (
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	golang.org/x/net v0.50.0 // indirect
-	golang.org/x/sys v0.41.0 // indirect
+	golang.org/x/sys v0.42.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 )

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -20,6 +20,7 @@ golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
 golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=
 golang.org/x/text v0.34.0/go.mod h1:homfLqTYRFyVYemLBFl5GgL/DWEiH5wcsQ5gSh1yziA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
**Issue:** 
Harvest invokes private CLI `private/cli/snapmirror` first for most of the SM fields and later invoking public api `snapmirror/relationships` for remaining fields and append them in actual result. `state` is coming from public api for now. 

Now, Ontap private api gives all the relationship types whereas public api don't show records of `LS` type, that's why it's not able to append `state` field in `LS` type of relationships.

**Fix:**
Instead of fetching `state` field from public api, changed to fetch directly from private cli.


----------------------------
Before the fix,
<img width="1702" height="302" alt="image" src="https://github.com/user-attachments/assets/e5b9b2a5-1aa2-4861-bec8-2db8d74fffb4" />


After the fix,
<img width="1721" height="303" alt="image" src="https://github.com/user-attachments/assets/ffd60557-c014-4397-bbe9-55e8003f1d37" />
