### PR TITLE
docs: Add docstring for PanicIfNotNil function

### DIFF
--- a/integration/test/errs/panic.go
+++ b/integration/test/errs/panic.go
@@ -1,5 +1,6 @@
 package errs
 
+// PanicIfNotNil panics if the provided error is not nil. It is intended for use in contexts where an error is considered fatal.
 func PanicIfNotNil(err error) {
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
### 问题背景

`PanicIfNotNil` 是一个公共函数，但缺少文档注释。在 Go 中，公共函数应有文档注释（docstring）来解释其用途和行为，以符合最佳实践和提高代码的可读性与可维护性。

### 修改内容

- **修改了什么**: 为 `integration/test/errs/panic.go` 中的 `PanicIfNotNil` 函数添加了一行文档注释。
- **为什么这样改**: 明确了函数的预期行为（当错误非 nil 时 panic）和使用场景（适用于被视为致命的上下文）。这有助于其他开发者快速理解其设计意图。
- **对代码质量的提升**: 提升了代码的文档化水平，使 API 更易于理解和正确使用，符合 Go 社区的编码规范。

### 验证方式

- **现有测试**: 此修改仅为添加文档注释，不改变任何功能逻辑。所有现有测试应不受影响，可以通过运行 `go test ./...` 来验证。
- **手动验证**: 检查修改后的文件，确保注释格式正确且内容准确。

### 其他信息

- **Breaking Changes**: 无。此修改不改变任何公共 API 或函数行为。
- **文档更新**: 本次修改即为文档更新本身。
- **已知限制**: 无。