### PR TITLE
feat: adding logger of latency_io_reqd if applied in custom.yaml

### DIFF
--- a/cmd/poller/poller.go
+++ b/cmd/poller/poller.go
@@ -837,6 +837,10 @@ func (p *Poller) readObjects(c conf.Collector) ([]objectCollector, error) {
 		return nil, err
 	}
 
+	if template.GetChildContentS("latency_io_reqd") != "" {
+		logger.Info("latency_io_reqd", slog.Any("value", template.GetChildContentS("latency_io_reqd")))
+	}
+
 	objects := make([]objectCollector, 0)
 	templateObject := template.GetChildContentS("object")
 


### PR DESCRIPTION
Verified locally with `Rest:custom.yaml` and `Zapi:custom.yaml`, when found in custom.yaml then It's logging accordingly 
```
time=2026-07-07T16:44:31.130+05:30 level=INFO source=poller.go:841 msg=latency_io_reqd Poller=u2 value=10
```
```
time=2026-07-07T16:43:38.800+05:30 level=INFO source=poller.go:841 msg=latency_io_reqd Poller=u2 value=100
```