### PR TITLE
refactor: share typed LoadParam for collector and plugin config

### DIFF
--- a/cmd/collectors/cmperf/cmperf.go
+++ b/cmd/collectors/cmperf/cmperf.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -243,7 +242,7 @@ func (c *CmPerf) InitQOS() error {
 func (c *CmPerf) InitMatrix() error {
 	mat := c.Matrix[c.Object]
 	// init perf properties
-	c.perfProp.latencyIoReqd = c.loadParamInt("latency_io_reqd", latencyIoReqd)
+	c.perfProp.latencyIoReqd = c.LoadParam("latency_io_reqd", latencyIoReqd)
 	c.perfProp.isCacheEmpty = true
 	// overwrite from abstract collector
 	mat.Object = c.Prop.Object
@@ -258,30 +257,6 @@ func (c *CmPerf) InitMatrix() error {
 	_, _ = c.Metadata.NewMetricUint64("skips")
 	_, _ = c.Metadata.NewMetricUint64("numPartials")
 	return nil
-}
-
-// load an int parameter or use defaultValue
-func (c *CmPerf) loadParamInt(name string, defaultValue int) int {
-
-	var (
-		x string
-		n int
-		e error
-	)
-
-	if x = c.Params.GetChildContentS(name); x != "" {
-		if n, e = strconv.Atoi(x); e == nil {
-			c.Logger.Debug("using",
-				slog.String("name", name),
-				slog.Int("value", n),
-			)
-			return n
-		}
-		c.Logger.Warn("invalid parameter (expected integer)", slog.String("name", name), slog.String("value", x))
-	}
-
-	c.Logger.Debug("using", slog.String("name", name), slog.Int("defaultValue", defaultValue))
-	return defaultValue
 }
 
 func (c *CmPerf) PollCounter() (map[string]*matrix.Matrix, error) {

--- a/cmd/collectors/commonutils.go
+++ b/cmd/collectors/commonutils.go
@@ -280,13 +280,10 @@ func IsValidUnit(unit string) bool {
 	return validUnits[unit]
 }
 
+// ReadPluginKey reports whether the boolean plugin parameter key is set.
 func ReadPluginKey(param *node.Node, key string) bool {
-	if val := param.GetChildContentS(key); val != "" {
-		if boolValue, err := strconv.ParseBool(val); err == nil {
-			return boolValue
-		}
-	}
-	return false
+	v, _ := param.GetParam(key, false)
+	return v
 }
 
 type VscanNames struct {

--- a/cmd/collectors/ems/ems.go
+++ b/cmd/collectors/ems/ems.go
@@ -158,12 +158,7 @@ func (e *Ems) InitCache() error {
 		e.Prop.Object = strings.ToLower(e.Object)
 	}
 
-	if b := e.Params.GetChildContentS("max_url_size"); b != "" {
-		if s, err := strconv.Atoi(b); err == nil {
-			e.maxURLSize = s
-		}
-	}
-	e.Logger.Debug("", slog.Int("max_url_size", e.maxURLSize))
+	e.maxURLSize = e.LoadParam("max_url_size", e.maxURLSize)
 
 	if s := e.Params.GetChildContentS("severity"); s != "" {
 		e.severityFilter = severityFilterPrefix + s

--- a/cmd/collectors/keyperf/keyperf.go
+++ b/cmd/collectors/keyperf/keyperf.go
@@ -112,7 +112,7 @@ func (kp *KeyPerf) Init(a *collector.AbstractCollector) error {
 func (kp *KeyPerf) InitMatrix() error {
 	mat := kp.Matrix[kp.Object]
 	// init perf properties
-	kp.perfProp.latencyIoReqd = kp.loadParamInt("latency_io_reqd", latencyIoReqd)
+	kp.perfProp.latencyIoReqd = kp.LoadParam("latency_io_reqd", latencyIoReqd)
 	kp.perfProp.isCacheEmpty = true
 	// overwrite from abstract collector
 	mat.Object = kp.Prop.Object
@@ -128,27 +128,6 @@ func (kp *KeyPerf) InitMatrix() error {
 	_, _ = kp.Metadata.NewMetricUint64("skips")
 	_, _ = kp.Metadata.NewMetricUint64("numPartials")
 	return nil
-}
-
-// load an int parameter or use defaultValue
-func (kp *KeyPerf) loadParamInt(name string, defaultValue int) int {
-
-	var (
-		x string
-		n int
-		e error
-	)
-
-	if x = kp.Params.GetChildContentS(name); x != "" {
-		if n, e = strconv.Atoi(x); e == nil {
-			kp.Logger.Debug("", slog.String("name", name), slog.Int("n", n))
-			return n
-		}
-		kp.Logger.Warn("invalid parameter", slog.String("parameter", name), slog.String("x", x))
-	}
-
-	kp.Logger.Debug("using values", slog.String("name", name), slog.Int("defaultValue", defaultValue))
-	return defaultValue
 }
 
 func (kp *KeyPerf) LoadPlugin(kind string, p *plugin.AbstractPlugin) plugin.Plugin {

--- a/cmd/collectors/restperf/plugins/fabricpool/fabricpool.go
+++ b/cmd/collectors/restperf/plugins/fabricpool/fabricpool.go
@@ -6,7 +6,6 @@ import (
 	"github.com/netapp/harvest/v2/pkg/collector"
 	"github.com/netapp/harvest/v2/pkg/conf"
 	"github.com/netapp/harvest/v2/pkg/matrix"
-	"strconv"
 	"strings"
 )
 
@@ -24,11 +23,7 @@ func (f *FabricPool) Init(conf.Remote) error {
 	if err != nil {
 		return err
 	}
-	if val := f.Params.GetChildContentS("include_constituents"); val != "" {
-		if boolValue, err := strconv.ParseBool(val); err == nil {
-			f.includeConstituents = boolValue
-		}
-	}
+	f.includeConstituents = f.LoadParam("include_constituents", f.includeConstituents)
 	return nil
 }
 

--- a/cmd/collectors/restperf/plugins/volumetopmetrics/volumetopmetrics.go
+++ b/cmd/collectors/restperf/plugins/volumetopmetrics/volumetopmetrics.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"log/slog"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -149,13 +148,7 @@ func (t *TopMetrics) Init(remote conf.Remote) error {
 
 	t.maxVolumeCount = defaultTopN
 
-	if maxVol := t.Params.GetChildContentS("max_volumes"); maxVol != "" {
-		if maxVolCount, err := strconv.Atoi(maxVol); err != nil {
-			t.maxVolumeCount = defaultTopN
-		} else {
-			t.maxVolumeCount = min(maxVolCount, maxTopN)
-		}
-	}
+	t.maxVolumeCount = min(t.LoadParam("max_volumes", defaultTopN), maxTopN)
 
 	// enable client, file and user metrics collection by default
 	t.clientMetricsEnabled = true

--- a/cmd/collectors/restperf/plugins/vscan/vscan.go
+++ b/cmd/collectors/restperf/plugins/vscan/vscan.go
@@ -4,36 +4,36 @@ import (
 	"github.com/netapp/harvest/v2/cmd/collectors"
 	"github.com/netapp/harvest/v2/cmd/poller/plugin"
 	"github.com/netapp/harvest/v2/pkg/collector"
+	"github.com/netapp/harvest/v2/pkg/conf"
 	"github.com/netapp/harvest/v2/pkg/matrix"
-	"github.com/netapp/harvest/v2/pkg/slogx"
 	"log/slog"
-	"strconv"
 )
 
 type Vscan struct {
 	*plugin.AbstractPlugin
+	isPerScanner bool
 }
 
 func New(p *plugin.AbstractPlugin) plugin.Plugin {
 	return &Vscan{AbstractPlugin: p}
 }
 
+func (v *Vscan) Init(conf.Remote) error {
+	if err := v.InitAbc(); err != nil {
+		return err
+	}
+
+	// parsed once at startup rather than on every poll
+	v.isPerScanner = v.LoadParam("metricsPerScanner", true)
+
+	return nil
+}
+
 func (v *Vscan) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, *collector.Metadata, error) {
 	data := dataMap[v.Object]
-	// defaults plugin options
-	isPerScanner := true
-
-	if s := v.Params.GetChildContentS("metricsPerScanner"); s != "" {
-		if parseBool, err := strconv.ParseBool(s); err == nil {
-			isPerScanner = parseBool
-		} else {
-			v.SLogger.Error("Failed to parse metricsPerScanner", slogx.Err(err))
-		}
-	}
-	v.SLogger.Debug("Vscan options", slog.Bool("isPerScanner", isPerScanner))
 
 	v.addSvmAndScannerLabels(data)
-	if !isPerScanner {
+	if !v.isPerScanner {
 		return nil, nil, nil
 	}
 

--- a/cmd/collectors/restperf/plugins/vscan/vscan_test.go
+++ b/cmd/collectors/restperf/plugins/vscan/vscan_test.go
@@ -3,12 +3,12 @@ package vscan
 import (
 	"encoding/json"
 	"github.com/netapp/harvest/v2/assert"
-	"log/slog"
 	"os"
 	"testing"
 
 	"github.com/netapp/harvest/v2/cmd/poller/options"
 	"github.com/netapp/harvest/v2/cmd/poller/plugin"
+	"github.com/netapp/harvest/v2/pkg/conf"
 	"github.com/netapp/harvest/v2/pkg/matrix"
 	"github.com/netapp/harvest/v2/pkg/tree/node"
 )
@@ -25,6 +25,9 @@ func runTest(t *testing.T, createRestVscan func(params *node.Node) plugin.Plugin
 	params := node.NewS("Vscan")
 	params.NewChildS("metricsPerScanner", metricsPerScanner)
 	v := createRestVscan(params)
+	// the framework always calls Init before Run; metricsPerScanner is parsed there
+	assert.Nil(t, v.Init(conf.Remote{}))
+
 	data := readTestFile(testFile)
 	if data == nil {
 		t.Fatalf("failed to read test file %s", testFile)
@@ -81,9 +84,7 @@ func TestRunForAllImplementations(t *testing.T) {
 
 func createRestVscan(params *node.Node) plugin.Plugin {
 	o := options.Options{IsTest: true}
-	v := &Vscan{AbstractPlugin: plugin.New("vscan", &o, params, nil, "vscan", nil)}
-	v.SLogger = slog.Default()
-	return v
+	return &Vscan{AbstractPlugin: plugin.New("vscan", &o, params, nil, "vscan", nil)}
 }
 
 func readTestFile(testFilePath string) *matrix.Matrix {
@@ -103,4 +104,27 @@ func readTestFile(testFilePath string) *matrix.Matrix {
 	}
 
 	return data
+}
+
+// metricsPerScanner defaults to true, so an absent or malformed value must not
+// silently disable per-scanner aggregation.
+func TestMetricsPerScannerDefault(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{name: "absent", value: ""},
+		{name: "malformed", value: "yes-please"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			params := node.NewS("Vscan")
+			if tc.value != "" {
+				params.NewChildS("metricsPerScanner", tc.value)
+			}
+
+			v := createRestVscan(params)
+			assert.Nil(t, v.Init(conf.Remote{}))
+			assert.True(t, v.(*Vscan).isPerScanner)
+		})
+	}
 }

--- a/cmd/collectors/restperf/restperf.go
+++ b/cmd/collectors/restperf/restperf.go
@@ -198,7 +198,7 @@ func (r *RestPerf) InitQOS() error {
 func (r *RestPerf) InitMatrix() error {
 	mat := r.Matrix[r.Object]
 	// init perf properties
-	r.perfProp.latencyIoReqd = r.loadParamInt("latency_io_reqd", latencyIoReqd)
+	r.perfProp.latencyIoReqd = r.LoadParam("latency_io_reqd", latencyIoReqd)
 	r.perfProp.isCacheEmpty = true
 	// overwrite from abstract collector
 	mat.Object = r.Prop.Object
@@ -239,30 +239,6 @@ func (r *RestPerf) loadWorkloadClassQuery(defaultValue string) string {
 		return s
 	}
 	r.Logger.Debug("", slog.String("name", name), slog.String("defaultValue", defaultValue))
-	return defaultValue
-}
-
-// load an int parameter or use defaultValue
-func (r *RestPerf) loadParamInt(name string, defaultValue int) int {
-
-	var (
-		x string
-		n int
-		e error
-	)
-
-	if x = r.Params.GetChildContentS(name); x != "" {
-		if n, e = strconv.Atoi(x); e == nil {
-			r.Logger.Debug("using",
-				slog.String("name", name),
-				slog.Int("value", n),
-			)
-			return n
-		}
-		r.Logger.Warn("invalid parameter (expected integer)", slog.String("name", name), slog.String("value", x))
-	}
-
-	r.Logger.Debug("using", slog.String("name", name), slog.Int("defaultValue", defaultValue))
 	return defaultValue
 }
 

--- a/cmd/collectors/statperf/statperf.go
+++ b/cmd/collectors/statperf/statperf.go
@@ -111,7 +111,7 @@ func (s *StatPerf) Init(a *collector.AbstractCollector) error {
 	}
 
 	s.filter = s.loadFilter()
-	s.batchSize = s.loadParamInt("batch_size", defaultBatchSize)
+	s.batchSize = s.LoadParam("batch_size", defaultBatchSize)
 
 	if err := s.InitMatrix(); err != nil {
 		return err
@@ -143,7 +143,7 @@ func (s *StatPerf) loadFilter() string {
 func (s *StatPerf) InitMatrix() error {
 	mat := s.Matrix[s.Object]
 	// init perf properties
-	s.perfProp.latencyIoReqd = s.loadParamInt("latency_io_reqd", latencyIoReqd)
+	s.perfProp.latencyIoReqd = s.LoadParam("latency_io_reqd", latencyIoReqd)
 	s.perfProp.isCacheEmpty = true
 	// overwrite from abstract collector
 	mat.Object = s.Prop.Object
@@ -159,30 +159,6 @@ func (s *StatPerf) InitMatrix() error {
 	_, _ = s.Metadata.NewMetricUint64("skips")
 	_, _ = s.Metadata.NewMetricUint64("numPartials")
 	return nil
-}
-
-// load an int parameter or use defaultValue
-func (s *StatPerf) loadParamInt(name string, defaultValue int) int {
-
-	var (
-		x string
-		n int
-		e error
-	)
-
-	if x = s.Params.GetChildContentS(name); x != "" {
-		if n, e = strconv.Atoi(x); e == nil {
-			s.Logger.Debug("using",
-				slog.String("name", name),
-				slog.Int("value", n),
-			)
-			return n
-		}
-		s.Logger.Warn("invalid parameter (expected integer)", slog.String("name", name), slog.String("value", x))
-	}
-
-	s.Logger.Debug("using", slog.String("name", name), slog.Int("defaultValue", defaultValue))
-	return defaultValue
 }
 
 func GetCounterInstanceBaseSet() string {

--- a/cmd/collectors/zapiperf/plugins/fabricpool/fabricpool.go
+++ b/cmd/collectors/zapiperf/plugins/fabricpool/fabricpool.go
@@ -6,7 +6,6 @@ import (
 	"github.com/netapp/harvest/v2/pkg/collector"
 	"github.com/netapp/harvest/v2/pkg/conf"
 	"github.com/netapp/harvest/v2/pkg/matrix"
-	"strconv"
 )
 
 type FabricPool struct {
@@ -23,11 +22,7 @@ func (f *FabricPool) Init(conf.Remote) error {
 	if err != nil {
 		return err
 	}
-	if val := f.Params.GetChildContentS("include_constituents"); val != "" {
-		if boolValue, err := strconv.ParseBool(val); err == nil {
-			f.includeConstituents = boolValue
-		}
-	}
+	f.includeConstituents = f.LoadParam("include_constituents", f.includeConstituents)
 	return nil
 }
 

--- a/cmd/collectors/zapiperf/plugins/vscan/vscan.go
+++ b/cmd/collectors/zapiperf/plugins/vscan/vscan.go
@@ -4,36 +4,36 @@ import (
 	"github.com/netapp/harvest/v2/cmd/collectors"
 	"github.com/netapp/harvest/v2/cmd/poller/plugin"
 	"github.com/netapp/harvest/v2/pkg/collector"
+	"github.com/netapp/harvest/v2/pkg/conf"
 	"github.com/netapp/harvest/v2/pkg/matrix"
-	"github.com/netapp/harvest/v2/pkg/slogx"
 	"log/slog"
-	"strconv"
 )
 
 type Vscan struct {
 	*plugin.AbstractPlugin
+	isPerScanner bool
 }
 
 func New(p *plugin.AbstractPlugin) plugin.Plugin {
 	return &Vscan{AbstractPlugin: p}
 }
 
+func (v *Vscan) Init(conf.Remote) error {
+	if err := v.InitAbc(); err != nil {
+		return err
+	}
+
+	// parsed once at startup rather than on every poll
+	v.isPerScanner = v.LoadParam("metricsPerScanner", true)
+
+	return nil
+}
+
 func (v *Vscan) Run(dataMap map[string]*matrix.Matrix) ([]*matrix.Matrix, *collector.Metadata, error) {
 	data := dataMap[v.Object]
-	// defaults plugin options
-	isPerScanner := true
-
-	if s := v.Params.GetChildContentS("metricsPerScanner"); s != "" {
-		if parseBool, err := strconv.ParseBool(s); err == nil {
-			isPerScanner = parseBool
-		} else {
-			v.SLogger.Error("Failed to parse metricsPerScanner", slogx.Err(err))
-		}
-	}
-	v.SLogger.Debug("Vscan options", slog.Bool("isPerScanner", isPerScanner))
 
 	v.addSvmAndScannerLabels(data)
-	if !isPerScanner {
+	if !v.isPerScanner {
 		return nil, nil, nil
 	}
 

--- a/cmd/collectors/zapiperf/zapiperf.go
+++ b/cmd/collectors/zapiperf/zapiperf.go
@@ -183,14 +183,11 @@ func (z *ZapiPerf) InitCache() error {
 	z.instanceLabels = make(map[string]string)
 	z.instanceKeys = z.loadParamArray("instance_key", instanceKey)
 	z.filter = z.loadFilter()
-	z.batchSize = z.loadParamInt("batch_size", batchSize)
-	z.latencyIoReqd = z.loadParamInt("latency_io_reqd", latencyIoReqd)
+	z.batchSize = z.LoadParam("batch_size", batchSize)
+	z.latencyIoReqd = z.LoadParam("latency_io_reqd", latencyIoReqd)
 	z.isCacheEmpty = true
-	z.object = z.loadParamStr("object", "")
-	allowPartialAggregation := z.loadParamStr("allow_partial_aggregation", "false")
-	if allowPartialAggregation == "true" {
-		z.allowPartialAggregation = true
-	}
+	z.object = z.LoadParam("object", "")
+	z.allowPartialAggregation = z.LoadParam("allow_partial_aggregation", false)
 	z.keyName, z.keyNameIndex = z.initKeyName()
 	// hack to override from AbstractCollector
 	// @TODO need cleaner solution
@@ -224,19 +221,6 @@ func (z *ZapiPerf) initKeyName() (string, int) {
 		}
 	}
 	return keyName, keyNameIndex
-}
-
-// load a string parameter or use defaultValue
-func (z *ZapiPerf) loadParamStr(name, defaultValue string) string {
-
-	var x string
-
-	if x = z.Params.GetChildContentS(name); x != "" {
-		z.Logger.Debug("using", slog.String(name, x))
-		return x
-	}
-	z.Logger.Debug("using", slog.String(name, defaultValue))
-	return defaultValue
 }
 
 func (z *ZapiPerf) loadFilter() string {
@@ -338,27 +322,6 @@ func (z *ZapiPerf) updateWorkloadQuery(query *node.Node) {
 			}
 		}
 	}
-}
-
-// load an int parameter or use defaultValue
-func (z *ZapiPerf) loadParamInt(name string, defaultValue int) int {
-
-	var (
-		x string
-		n int
-		e error
-	)
-
-	if x = z.Params.GetChildContentS(name); x != "" {
-		if n, e = strconv.Atoi(x); e == nil {
-			z.Logger.Debug("using", slog.String("name", name), slog.Int("value", n))
-			return n
-		}
-		z.Logger.Warn("invalid parameter (expected integer)", slog.String("name", name), slog.String("value", x))
-	}
-
-	z.Logger.Debug("using", slog.String("name", name), slog.Int("value", defaultValue))
-	return defaultValue
 }
 
 func (z *ZapiPerf) isPartialAggregation(instance *node.Node) bool {

--- a/cmd/exporters/utils.go
+++ b/cmd/exporters/utils.go
@@ -162,16 +162,12 @@ func Render(data *matrix.Matrix, addMetaTags bool, sortLabels bool, globalPrefix
 	includeAllLabels := false
 	requireInstanceKeys := true
 
-	if x := options.GetChildContentS("include_all_labels"); x != "" {
-		if includeAllLabels, err = strconv.ParseBool(x); err != nil {
-			logger.Error("parameter: include_all_labels", slogx.Err(err))
-		}
+	if includeAllLabels, err = options.GetParam("include_all_labels", includeAllLabels); err != nil {
+		logger.Error("parameter: include_all_labels", slogx.Err(err))
 	}
 
-	if x := options.GetChildContentS("require_instance_keys"); x != "" {
-		if requireInstanceKeys, err = strconv.ParseBool(x); err != nil {
-			logger.Error("parameter: require_instance_keys", slogx.Err(err))
-		}
+	if requireInstanceKeys, err = options.GetParam("require_instance_keys", requireInstanceKeys); err != nil {
+		logger.Error("parameter: require_instance_keys", slogx.Err(err))
 	}
 
 	if data.Object == "" {

--- a/cmd/poller/collector/collector.go
+++ b/cmd/poller/collector/collector.go
@@ -721,6 +721,15 @@ func (c *AbstractCollector) GetParams() *node.Node {
 	return c.Params
 }
 
+// LoadParam reads the collector parameter name and parses it as T, falling back
+// to def when the parameter is absent or malformed.
+//
+// A malformed value is logged at Warn and does not fail the poll -- the default
+// is used instead.
+func (c *AbstractCollector) LoadParam[T node.ParamType](name string, def T) T {
+	return node.LoadParam(c.Params, c.Logger, name, def)
+}
+
 // GetOptions returns the poller options passed to the collector
 func (c *AbstractCollector) GetOptions() *options.Options {
 	return c.Options

--- a/cmd/poller/collector/helpers.go
+++ b/cmd/poller/collector/helpers.go
@@ -28,7 +28,6 @@ import (
 	"regexp"
 	"slices"
 	"sort"
-	"strconv"
 	"strings"
 )
 
@@ -274,21 +273,17 @@ func RecordKeepLast(n *node.Node, logger *slog.Logger) int {
 		return DefaultRecordsToSave
 	}
 
-	kl := r.GetChildContentS("keep_last")
-	if kl != "" {
-		keep, err := strconv.Atoi(kl)
-		if err != nil {
-			logger.Error(
-				"invalid keep_last value. Using default.",
-				slog.Int("default", DefaultRecordsToSave),
-				slog.String("value", kl),
-			)
-			return DefaultRecordsToSave
-		}
-		return keep
+	keep, err := r.GetParam("keep_last", DefaultRecordsToSave)
+	if err != nil {
+		logger.Error(
+			"invalid keep_last value. Using default.",
+			slog.Int("default", DefaultRecordsToSave),
+			slog.String("value", r.GetChildContentS("keep_last")),
+		)
+		return DefaultRecordsToSave
 	}
 
-	return DefaultRecordsToSave
+	return keep
 }
 
 // ParseTemplateRef parses template references like "KeyPerf:volume.yaml"

--- a/cmd/poller/collector/loadparam_test.go
+++ b/cmd/poller/collector/loadparam_test.go
@@ -1,0 +1,64 @@
+package collector
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/netapp/harvest/v2/assert"
+	"github.com/netapp/harvest/v2/pkg/tree/node"
+)
+
+func newParamCollector(params map[string]string) *AbstractCollector {
+	n := node.New([]byte("root"))
+	for k, v := range params {
+		n.NewChildS(k, v)
+	}
+
+	return &AbstractCollector{Params: n, Logger: slog.Default()}
+}
+
+func TestLoadParam(t *testing.T) {
+	c := newParamCollector(map[string]string{
+		"client_timeout":  "30",
+		"batch_size":      "700",
+		"max_records":     "9000000000",
+		"latency_io_reqd": "1.5",
+		"instance_key":    "uuid",
+		"is_enabled":      "true",
+		"empty":           "",
+		"malformed":       "not-a-number",
+	})
+
+	// T is inferred from the default -- no explicit instantiation anywhere
+	assert.Equal(t, c.LoadParam("client_timeout", 5), 30)
+	assert.Equal(t, c.LoadParam("batch_size", 500), 700)
+	assert.Equal(t, c.LoadParam("max_records", int64(1)), int64(9000000000))
+	assert.Equal(t, c.LoadParam("latency_io_reqd", 0.0), 1.5)
+	assert.Equal(t, c.LoadParam("instance_key", "name"), "uuid")
+	assert.Equal(t, c.LoadParam("is_enabled", false), true)
+}
+
+func TestLoadParamFallsBackToDefault(t *testing.T) {
+	c := newParamCollector(map[string]string{
+		"empty":     "",
+		"malformed": "not-a-number",
+	})
+
+	// absent parameter
+	assert.Equal(t, c.LoadParam("nope", 500), 500)
+	assert.Equal(t, c.LoadParam("nope", "fallback"), "fallback")
+	assert.Equal(t, c.LoadParam("nope", false), false)
+
+	// present but empty
+	assert.Equal(t, c.LoadParam("empty", 500), 500)
+	assert.Equal(t, c.LoadParam("empty", int64(7)), int64(7))
+
+	// present but unparsable -- must not panic, must use the default
+	assert.Equal(t, c.LoadParam("malformed", 500), 500)
+	assert.Equal(t, c.LoadParam("malformed", int64(7)), int64(7))
+	assert.Equal(t, c.LoadParam("malformed", 2.5), 2.5)
+	assert.Equal(t, c.LoadParam("malformed", true), true)
+
+	// a string parameter is never malformed
+	assert.Equal(t, c.LoadParam("malformed", "fallback"), "not-a-number")
+}

--- a/cmd/poller/plugin/changelog/changelog_helper.go
+++ b/cmd/poller/plugin/changelog/changelog_helper.go
@@ -6,7 +6,6 @@ import (
 	"github.com/netapp/harvest/v2/pkg/tree/node"
 	"log/slog"
 	"slices"
-	"strconv"
 )
 
 // Entry represents a single ChangeLog entry
@@ -91,12 +90,10 @@ func getChangeLogConfig(parentParams *node.Node, overwriteConfig []byte, logger 
 		if exportOption := parentParams.GetChildS("export_options"); exportOption != nil {
 			if exportedKeys := exportOption.GetChildS("instance_keys"); exportedKeys != nil {
 				entry.PublishLabels = append(entry.PublishLabels, exportedKeys.GetAllChildContentS()...)
-			} else if x := exportOption.GetChildContentS("include_all_labels"); x != "" {
-				if includeAllLabels, err := strconv.ParseBool(x); err != nil {
-					logger.Error("parameter: include_all_labels", slogx.Err(err))
-				} else if includeAllLabels {
-					entry.includeAll = true
-				}
+			} else if includeAllLabels, err := exportOption.GetParam("include_all_labels", false); err != nil {
+				logger.Error("parameter: include_all_labels", slogx.Err(err))
+			} else if includeAllLabels {
+				entry.includeAll = true
 			}
 		}
 	}

--- a/cmd/poller/plugin/plugin.go
+++ b/cmd/poller/plugin/plugin.go
@@ -128,6 +128,15 @@ func New(parent string, o *options.Options, p *node.Node, pp *node.Node, object 
 	}
 }
 
+// LoadParam reads the plugin parameter name and parses it as T, falling back to
+// def when the parameter is absent or malformed.
+//
+// Call this from Init rather than Run, so a bad value is reported once at
+// startup instead of on every poll.
+func (p *AbstractPlugin) LoadParam[T node.ParamType](name string, def T) T {
+	return node.LoadParam(p.Params, p.SLogger, name, def)
+}
+
 // GetName returns the name of the plugin
 func (p *AbstractPlugin) GetName() string {
 	return p.Name

--- a/pkg/tree/node/node.go
+++ b/pkg/tree/node/node.go
@@ -8,11 +8,14 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/goccy/go-yaml/ast"
+	"github.com/netapp/harvest/v2/pkg/slogx"
 )
 
 type Node struct {
@@ -63,10 +66,6 @@ func (n *Node) GetNameS() string {
 	return string(n.name)
 }
 
-func (n *Node) SetName(name []byte) {
-	n.name = name
-}
-
 func (n *Node) SetNameS(name string) {
 	n.name = []byte(name)
 }
@@ -107,15 +106,6 @@ func (n *Node) GetChildren() []*Node {
 	return n.Children
 }
 
-func (n *Node) GetChild(name []byte) *Node {
-	for _, child := range n.Children {
-		if bytes.Equal(child.GetName(), name) {
-			return child
-		}
-	}
-	return nil
-}
-
 func (n *Node) GetChildS(name string) *Node {
 	for _, child := range n.Children {
 		if child.GetNameS() == name {
@@ -125,17 +115,13 @@ func (n *Node) GetChildS(name string) *Node {
 	return nil
 }
 
-func (n *Node) HasChild(name []byte) bool {
-	return n.GetChild(name) != nil
-}
-
 func (n *Node) HasChildS(name string) bool {
 	return n.GetChildS(name) != nil
 }
 
-func (n *Node) PopChild(name []byte) *Node {
+func (n *Node) PopChildS(name string) *Node {
 	for i, child := range n.Children {
-		if bytes.Equal(child.GetName(), name) {
+		if child.GetNameS() == name {
 			n.Children[i] = n.Children[len(n.Children)-1]
 			n.Children = n.Children[:len(n.Children)-1]
 			return child
@@ -144,25 +130,17 @@ func (n *Node) PopChild(name []byte) *Node {
 	return nil
 }
 
-func (n *Node) PopChildS(name string) *Node {
-	return n.PopChild([]byte(name))
-}
-
-func (n *Node) NewChild(name, content []byte) *Node {
+func (n *Node) NewChildS(name, content string) *Node {
 	var child *Node
 	if n.GetXMLNameS() != "" {
-		child = NewXML(name)
+		child = NewXMLS(name)
 	} else {
-		child = New(name)
+		child = NewS(name)
 	}
 	child.parent = n
-	child.Content = content
+	child.Content = []byte(content)
 	n.AddChild(child)
 	return child
-}
-
-func (n *Node) NewChildS(name, content string) *Node {
-	return n.NewChild([]byte(name), []byte(content))
 }
 
 func (n *Node) AddChild(child *Node) {
@@ -191,13 +169,6 @@ func (n *Node) GetContentIfHas() []byte {
 func (n *Node) GetContentIfHasS() string {
     return string(GetContentIfHas())
 }*/
-
-func (n *Node) GetChildContent(name []byte) []byte {
-	if child := n.GetChild(name); child != nil {
-		return child.GetContent()
-	}
-	return []byte("")
-}
 
 func (n *Node) GetChildContentS(name string) string {
 	if child := n.GetChildS(name); child != nil {
@@ -268,10 +239,10 @@ func (n *Node) Union(source *Node) {
 	}
 	for _, child := range source.Children {
 		switch {
-		case !n.HasChild(child.GetName()):
+		case !n.HasChildS(child.GetNameS()):
 			n.AddChild(child)
 		case child.GetChildren() != nil:
-			n.GetChild(child.GetName()).Union(child)
+			n.GetChildS(child.GetNameS()).Union(child)
 		default:
 			n.SetChildContentS(child.GetNameS(), child.GetContentS())
 		}
@@ -295,7 +266,7 @@ func (n *Node) searchAncestor(ancestor string) *Node {
 
 func (n *Node) PreprocessTemplate() {
 	for _, child := range n.Children {
-		mine := n.GetChild(child.GetName())
+		mine := n.GetChildS(child.GetNameS())
 		if mine != nil && len(child.GetName()) > 0 {
 			if mine.searchAncestor("LabelAgent") != nil {
 				if mine.GetContentS() != "" {
@@ -318,7 +289,7 @@ func (n *Node) Merge(subtemplate *Node, skipOverwrite []string) {
 		n.Content = subtemplate.Content
 	}
 	for _, child := range subtemplate.Children {
-		mine := n.GetChild(child.GetName())
+		mine := n.GetChildS(child.GetNameS())
 		switch {
 		case len(child.GetName()) == 0:
 			if mine != nil && mine.GetParent() != nil && mine.GetParent().GetChildByContent(child.GetContentS()) == nil {
@@ -525,4 +496,87 @@ func AllSame(elements [][]string, k int) bool {
 		}
 	}
 	return true
+}
+
+// ParamType is the set of types GetParam can parse a child's content into.
+type ParamType interface {
+	bool | int | int64 | float64 | string
+}
+
+// GetParam returns the content of the child named key, parsed as T. It is the
+// preferred way to read a typed template parameter. Collectors and plugins should
+// generally reach for their own LoadParam wrapper instead, which adds logging on top.
+//
+// When the child is missing or its content is empty, def is returned with a nil
+// error -- an absent parameter is not an error, it means "use the default".
+// When the content is present but cannot be parsed as T, def is returned along
+// with the parse error.
+//
+// GetParam deliberately cannot distinguish "absent" from "present and equal to
+// def". Call sites that must tell those apart (for example ones that set a
+// pointer field only when the key is present) should keep using GetChildContentS.
+func (n *Node) GetParam[T ParamType](key string, def T) (T, error) {
+	x := n.GetChildContentS(key)
+	if x == "" {
+		return def, nil
+	}
+
+	var (
+		parsed any
+		err    error
+	)
+
+	switch any(def).(type) {
+	case bool:
+		parsed, err = strconv.ParseBool(x)
+	case int:
+		parsed, err = strconv.Atoi(x)
+	case int64:
+		parsed, err = strconv.ParseInt(x, 10, 64)
+	case float64:
+		parsed, err = strconv.ParseFloat(x, 64)
+	case string:
+		parsed = x
+	}
+
+	if err != nil {
+		return def, err
+	}
+
+	// parsed always holds a T: the switch above is exhaustive over ParamType
+	// and every branch produces T's underlying type. The guard is belt-and-braces
+	// so a future addition to ParamType without a matching case cannot panic.
+	v, ok := parsed.(T)
+	if !ok {
+		return def, fmt.Errorf("cannot parse %q as %T", x, def)
+	}
+
+	return v, nil
+}
+
+// LoadParam reads the parameter name from n and parses it as T, falling back to
+// def when the parameter is absent or malformed. A malformed value is reported at
+// Warn on logger and does not fail the caller -- the default is used instead.
+func LoadParam[T ParamType](n *Node, logger *slog.Logger, name string, def T) T {
+	v, err := n.GetParam(name, def)
+	if err != nil {
+		logger.Warn(
+			"invalid parameter, using default",
+			slog.String("name", name),
+			slog.Any("default", def),
+			slogx.Err(err),
+		)
+
+		return def
+	}
+
+	logger.Debug(
+		"using",
+		slog.String("name", name),
+		slog.Any("value", v),
+		// so operators can tell a template override from a built-in default
+		slog.Bool("isDefault", n.GetChildContentS(name) == ""),
+	)
+
+	return v
 }

--- a/pkg/tree/node/node_test.go
+++ b/pkg/tree/node/node_test.go
@@ -156,3 +156,49 @@ func TestGetChildrenNoPanic(t *testing.T) {
 	assert.Equal(t, 1, len(s.GetChildS("child1").GetChildren()))
 	assert.Equal(t, 0, len(s.GetChildS("child2").GetChildren()))
 }
+
+func TestNodeGetParam(t *testing.T) {
+	n := New([]byte("root"))
+	n.NewChildS("aBool", "true")
+	n.NewChildS("anInt", "42")
+	n.NewChildS("anInt64", "9000000000")
+	n.NewChildS("aFloat", "1.5")
+	n.NewChildS("aString", "hello")
+	n.NewChildS("empty", "")
+	n.NewChildS("bad", "notanumber")
+
+	// present and parsable
+	assertGetParam(t, n, "aBool", false, true)
+	assertGetParam(t, n, "anInt", 7, 42)
+	assertGetParam(t, n, "anInt64", int64(7), int64(9000000000))
+	assertGetParam(t, n, "aFloat", 0.0, 1.5)
+	assertGetParam(t, n, "aString", "def", "hello")
+
+	// absent child and empty content both yield the default, with no error
+	assertGetParam(t, n, "missing", 500, 500)
+	assertGetParam(t, n, "empty", 500, 500)
+	assertGetParam(t, n, "missing", "def", "def")
+
+	// malformed content yields the default *and* an error
+	for _, tc := range []struct{ name string }{{"bad"}} {
+		if v, err := n.GetParam(tc.name, 500); err == nil || v != 500 {
+			t.Errorf("GetParam(%q, 500) = (%d, %v), want (500, non-nil error)", tc.name, v, err)
+		}
+		if v, err := n.GetParam(tc.name, false); err == nil || v {
+			t.Errorf("GetParam(%q, false) = (%v, %v), want (false, non-nil error)", tc.name, v, err)
+		}
+		if v, err := n.GetParam(tc.name, 0.0); err == nil || v != 0.0 {
+			t.Errorf("GetParam(%q, 0.0) = (%v, %v), want (0, non-nil error)", tc.name, v, err)
+		}
+	}
+
+	// a string default never fails to parse, even for content that isn't a number
+	assertGetParam(t, n, "bad", "def", "notanumber")
+}
+
+func assertGetParam[T ParamType](t *testing.T, n *Node, key string, def, want T) {
+	t.Helper()
+	got, err := n.GetParam(key, def)
+	assert.Nil(t, err)
+	assert.Equal(t, got, want)
+}


### PR DESCRIPTION
Replace duplicated loadParamInt/ParseBool helpers with node.GetParam and LoadParam so absent or malformed YAML values fall back to defaults with a single Warn path.